### PR TITLE
chore: start testing on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,68 @@
+---
+release_tags: &release_tags
+  tags:
+    only: /^v\d+(\.\d+){2}(-.*)?$/
+
+# "Include" for unit tests definition.
+unit_tests: &unit_tests
+  steps:
+    - checkout
+    - run:
+        name: Install modules and dependencies.
+        command: npm install
+    - run:
+        name: Run unit tests.
+        command: npm run test
+
+version: 2.0
+workflows:
+  version: 2
+  tests:
+    jobs:
+      - node6:
+          filters: *release_tags
+      - node8:
+          filters: *release_tags
+      - node9:
+          filters: *release_tags
+      - publish_npm:
+          requires:
+            - node6
+            - node8
+            - node9
+          filters:
+            branches:
+              ignore: /.*/
+            <<: *release_tags
+
+jobs:
+  node6:
+    docker:
+      - image: node:6
+        user: node
+    <<: *unit_tests
+  node8:
+    docker:
+      - image: node:8
+        user: node
+    <<: *unit_tests
+  node9:
+    docker:
+      - image: node:9
+        user: node
+    <<: *unit_tests
+  publish_npm:
+    docker:
+      - image: node:8
+        user: node
+    steps:
+      - checkout
+      - run:
+          name: Set NPM authentication.
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run:
+          name: Install modules and dependencies.
+          command: npm install
+      - run:
+          name: Publish the module to npm.
+          command: npm publish

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "types": "build/src/index.d.ts",
   "repository": "census-instrumentation/opencensus-node",
   "scripts": {
-    "postinstall": "npm run bootstrap;npm run build;",
-    "build": "node_modules/.bin/lerna run build",
-    "test": "node_modules/.bin/lerna run test",
-    "bootstrap": "node_modules/.bin/lerna bootstrap",
-    "bump": "node_modules/.bin/lerna publish"
+    "postinstall": "npm run bootstrap",
+    "compile": "lerna run compile",
+    "test": "lerna run test",
+    "bootstrap": "lerna bootstrap",
+    "bump": "lerna publish"
   },
   "keywords": [
     "opencensus",

--- a/packages/opencensus-core/package.json
+++ b/packages/opencensus-core/package.json
@@ -6,7 +6,6 @@
   "types": "build/src/index.d.ts",
   "repository": "census-instrumentation/opencensus-node",
   "scripts": {
-    "build": "node_modules/.bin/tsc --declaration",
     "test": "nyc -x '**/test/**' --reporter=html --reporter=text mocha 'build/test/**/*.js'",
     "clean": "rimraf build/*",
     "check": "gts check",


### PR DESCRIPTION
This PR starts running CI with CircleCI. We currently don't test Node 10 because of known issues related to ts-node (that should be fixed tomorrow, hopefully).

I've also removed the `build` command and changed references to it to `compile`. @fabiogomessilva does this seem alright to you?