### PR TITLE
feat: add propagation interface to core

### DIFF
--- a/packages/opencensus-core/src/index-types.ts
+++ b/packages/opencensus-core/src/index-types.ts
@@ -20,5 +20,6 @@ export * from './trace/model/types';
 export * from './trace/config/types';
 export * from './trace/sampler/types';
 export * from './trace/instrumentation/types';
+export * from './trace/propagation/types';
 export * from './exporters/types';
 export * from './common/types';

--- a/packages/opencensus-core/src/trace/config/types.ts
+++ b/packages/opencensus-core/src/trace/config/types.ts
@@ -17,6 +17,7 @@
 import {Logger} from '../../common/types';
 import {Exporter} from '../../exporters/types';
 import {PluginNames} from '../instrumentation/types';
+import {Propagation} from '../propagation/types';
 
 /** Interface configuration for a buffer. */
 export interface BufferConfig {
@@ -36,6 +37,8 @@ export interface TracerConfig {
   ignoreUrls?: Array<string|RegExp>;
   /** A logger object  */
   logger?: Logger;
+  /** A propagation instance */
+  propagation?: Propagation;
 }
 
 /** Available configuration options. */

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -18,6 +18,7 @@ import * as logger from '../../common/console-logger';
 import * as loggerTypes from '../../common/types';
 import * as cls from '../../internal/cls';
 import * as configTypes from '../config/types';
+import {Propagation} from '../propagation/types';
 import {Sampler} from '../sampler/sampler';
 import * as samplerTypes from '../sampler/types';
 
@@ -62,6 +63,11 @@ export class Tracer implements types.Tracer {
   /** Sets the current root span. */
   set currentRootSpan(root: types.RootSpan) {
     this.contextManager.set('rootspan', root);
+  }
+
+  /** A propagation instance */
+  get propagation(): Propagation {
+    return this.config ? this.config.propagation : null;
   }
 
   /**

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -16,6 +16,7 @@
 
 import * as loggerTypes from '../../common/types';
 import * as configTypes from '../config/types';
+import {Propagation} from '../propagation/types';
 import * as samplerTypes from '../sampler/types';
 
 
@@ -221,6 +222,9 @@ export interface Tracer extends OnEndSpanEventListener {
 
   /** A configuration for starting the tracer */
   logger: loggerTypes.Logger;
+
+  /** A propagation instance */
+  readonly propagation: Propagation;
 
   /** Get the eventListeners from tracer instance */
   readonly eventListeners: OnEndSpanEventListener[];

--- a/packages/opencensus-core/src/trace/propagation/types.ts
+++ b/packages/opencensus-core/src/trace/propagation/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpanContext} from '../model/types';
+
+/**
+ * An transport and environment neutral API for getting request headers.
+ */
+export interface HeaderGetter {
+  getHeader(name: string): string|string[]|undefined;
+}
+
+/**
+ * A transport and environment neutral API for setting headers.
+ */
+export interface HeaderSetter { setHeader(name: string, value: string): void; }
+
+/**
+ *  Propagation interface
+ */
+export interface Propagation {
+  extract(getter: HeaderGetter): SpanContext|null;
+  inject(setter: HeaderSetter, spanContext: SpanContext): void;
+  generate(): SpanContext;
+}


### PR DESCRIPTION
This PR adds the Propagation interface proposed by @ofrobots to Core. Also, a propagation property was also added to Config and Tracer.