### PR TITLE
feat: add onStartSpan method to OnEndSpanEventListener interface and rename it to SpanEventListener

### DIFF
--- a/packages/opencensus-core/src/exporters/console-exporter.ts
+++ b/packages/opencensus-core/src/exporters/console-exporter.ts
@@ -23,6 +23,7 @@ import * as types from './types';
 /** Do not send span data */
 export class NoopExporter implements types.Exporter {
   logger: loggerTypes.Logger;
+  onStartSpan(root: modelTypes.RootSpan) {}
   onEndSpan(root: modelTypes.RootSpan) {}
   publish(rootSpans: modelTypes.RootSpan[]) {}
 }
@@ -42,6 +43,8 @@ export class ConsoleExporter implements types.Exporter {
     this.buffer = new ExporterBuffer(this, config);
     this.logger = config.logger;
   }
+
+  onStartSpan(root: modelTypes.RootSpan) {}
 
   /**
    * Event called when a span is ended.

--- a/packages/opencensus-core/src/exporters/types.ts
+++ b/packages/opencensus-core/src/exporters/types.ts
@@ -20,7 +20,7 @@ import * as configTypes from '../trace/config/types';
 import * as modelTypes from '../trace/model/types';
 
 /** Defines an exporter interface. */
-export interface Exporter extends modelTypes.OnEndSpanEventListener {
+export interface Exporter extends modelTypes.SpanEventListener {
   /**
    * Sends a list of root spans to the service.
    * @param rootSpans A list of root spans to publish.

--- a/packages/opencensus-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-core/src/trace/model/root-span.ts
@@ -70,6 +70,8 @@ export class RootSpan extends SpanBase implements types.RootSpan {
     this.logger.debug(
         'starting %s  %o', this.className,
         {traceId: this.traceId, id: this.id, parentSpanId: this.parentSpanId});
+
+    this.tracer.onStartSpan(this);
   }
 
   // TODO: review end() behavior if it should throw an error when it is called

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -82,8 +82,9 @@ export interface SpanContext {
 }
 
 /** Defines an end span event listener */
-export interface OnEndSpanEventListener {
+export interface SpanEventListener {
   /** Happens when a span is ended */
+  onStartSpan(span: RootSpan): void;
   onEndSpan(span: RootSpan): void;
 }
 
@@ -213,7 +214,7 @@ export interface RootSpan extends Span {
 
 
 /** Interface for Tracer */
-export interface Tracer extends OnEndSpanEventListener {
+export interface Tracer extends SpanEventListener {
   /** Get and set the currentRootSpan to tracer instance */
   currentRootSpan: RootSpan;
 
@@ -227,7 +228,7 @@ export interface Tracer extends OnEndSpanEventListener {
   readonly propagation: Propagation;
 
   /** Get the eventListeners from tracer instance */
-  readonly eventListeners: OnEndSpanEventListener[];
+  readonly eventListeners: SpanEventListener[];
 
   /** Get the active status from tracer instance */
   readonly active: boolean;
@@ -254,7 +255,7 @@ export interface Tracer extends OnEndSpanEventListener {
    * Register a OnEndSpanEventListener on the tracer instance
    * @param listener An OnEndSpanEventListener instance
    */
-  registerEndSpanListener(listener: OnEndSpanEventListener): void;
+  registerSpanEventListener(listener: SpanEventListener): void;
 
   /** Clear the currentRootSpan from tracer instance */
   clearCurrentTrace(): void;

--- a/packages/opencensus-core/test/test-console-exporter.ts
+++ b/packages/opencensus-core/test/test-console-exporter.ts
@@ -74,7 +74,7 @@ describe('ConsoleLogExporter', () => {
   describe('onEndSpan()', () => {
     it('should end a span', () => {
       const exporter = new ConsoleExporter(defaultBufferConfig);
-      tracer.registerEndSpanListener(exporter);
+      tracer.registerSpanEventListener(exporter);
       // const rootSpan = new RootSpan(tracer);
       const rootSpans = createRootSpans();
       for (const rootSpan of rootSpans) {

--- a/packages/opencensus-core/test/test-tracer.ts
+++ b/packages/opencensus-core/test/test-tracer.ts
@@ -24,11 +24,12 @@ import {RootSpan} from '../src/trace/model/root-span';
 import {Span} from '../src/trace/model/span';
 import {Tracer} from '../src/trace/model/tracer';
 import * as types from '../src/trace/model/types';
-import {OnEndSpanEventListener} from '../src/trace/model/types';
+import {SpanEventListener} from '../src/trace/model/types';
 
-class OnEndSpanClass implements OnEndSpanEventListener {
+class OnEndSpanClass implements SpanEventListener {
   /** Counter for test use */
   testCount = 0;
+  onStartSpan(span: RootSpan): void {}
   /** Happens when a span is ended */
   onEndSpan(span: RootSpan): void {
     this.testCount++;
@@ -80,12 +81,12 @@ describe('Tracer', () => {
   });
 
   /** Should return an OnEndSpanEventListener list */
-  describe('registerEndSpanListener() / get eventListeners()', () => {
+  describe('registerSpanEventListener() / get eventListeners()', () => {
     let tracer, onEndSpan;
     before(() => {
       tracer = new Tracer();
       onEndSpan = new OnEndSpanClass();
-      tracer.registerEndSpanListener(onEndSpan);
+      tracer.registerSpanEventListener(onEndSpan);
     });
 
     it('should register a new OnEndSpanEventListener on listners list', () => {
@@ -271,7 +272,7 @@ describe('Tracer', () => {
     it('should run eventListeners when the rootSpan ends', () => {
       const tracer = new Tracer();
       const eventListener = new OnEndSpanClass();
-      tracer.registerEndSpanListener(eventListener);
+      tracer.registerSpanEventListener(eventListener);
       tracer.start(defaultConfig);
 
       tracer.startRootSpan(options, (rootSpan) => {

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver.ts
@@ -60,6 +60,9 @@ export class StackdriverTraceExporter implements types.Exporter {
     this.exporterBuffer.addToBuffer(root);
   }
 
+  /** Not used for this exporter */
+  onStartSpan(root: types.RootSpan) {}
+
   /**
    * Publishes a list of root spans to Stackdriver.
    * @param rootSpans

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver.ts
@@ -75,7 +75,7 @@ describe('Stackdriver Exporter', function() {
     exporter = new StackdriverTraceExporter(exporterOptions);
     tracer = new classes.Tracer();
     tracer.start({samplingRate: 1});
-    tracer.registerEndSpanListener(exporter);
+    tracer.registerSpanEventListener(exporter);
     if (!dryrun) {
       process.env.GOOGLE_APPLICATION_CREDENTIALS =
           GOOGLE_APPLICATION_CREDENTIALS;
@@ -143,7 +143,7 @@ describe('Stackdriver Exporter', function() {
       const failExporter = new StackdriverTraceExporter(failExporterOptions);
       const failTracer = new classes.Tracer();
       failTracer.start({samplingRate: 1});
-      failTracer.registerEndSpanListener(failExporter);
+      failTracer.registerSpanEventListener(failExporter);
       return failTracer.startRootSpan(
           {name: 'sdNoExportTestRootSpan'}, async (rootSpan) => {
             const span = failTracer.startChildSpan('sdNoExportTestChildSpan');

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -56,9 +56,10 @@ const httpRequest = {
 
 const VERSION = process.versions.node;
 
-class RootSpanVerifier implements types.OnEndSpanEventListener {
+class RootSpanVerifier implements types.SpanEventListener {
   endedRootSpans: types.RootSpan[] = [];
 
+  onStartSpan(span: types.RootSpan): void {}
   onEndSpan(root: types.RootSpan) {
     this.endedRootSpans.push(root);
   }
@@ -99,7 +100,7 @@ describe('HttpPlugin', () => {
 
   before(() => {
     plugin.applyPatch(http, tracer, VERSION);
-    tracer.registerEndSpanListener(rootSpanVerifier);
+    tracer.registerSpanEventListener(rootSpanVerifier);
     server = http.createServer((request, response) => {
       response.end('Test Server Response');
     });

--- a/packages/opencensus-instrumentation-https/test/test-https.ts
+++ b/packages/opencensus-instrumentation-https/test/test-https.ts
@@ -60,9 +60,10 @@ const httpRequest = {
 
 const VERSION = process.versions.node;
 
-class RootSpanVerifier implements types.OnEndSpanEventListener {
+class RootSpanVerifier implements types.SpanEventListener {
   endedRootSpans: types.RootSpan[] = [];
 
+  onStartSpan(span: types.RootSpan): void {}
   onEndSpan(root: types.RootSpan) {
     this.endedRootSpans.push(root);
   }
@@ -107,7 +108,7 @@ describe('HttpsPlugin', () => {
 
   before(() => {
     plugin.applyPatch(https, tracer, VERSION);
-    tracer.registerEndSpanListener(rootSpanVerifier);
+    tracer.registerSpanEventListener(rootSpanVerifier);
     server = https.createServer(httpsOptions, (request, response) => {
       response.end('Test Server Response');
     });

--- a/packages/opencensus-nodejs/src/trace/tracing.ts
+++ b/packages/opencensus-nodejs/src/trace/tracing.ts
@@ -116,7 +116,7 @@ export class Tracing implements types.Tracing {
         this.unRegisterExporter(this.configLocal.exporter);
       }
       this.configLocal.exporter = exporter;
-      this.tracer.registerEndSpanListener(exporter);
+      this.tracer.registerSpanEventListener(exporter);
     } else {
       // TODO: if unRegisterExporter go public, this logic may not be
       // necessary - register a null to unRegister


### PR DESCRIPTION
To address Zpages exporter features was necessary to add a new method 'onStartSpan' to OnEndSpanEventListener interface. Then this interface was renamed to SpanEventListener.