### PR TITLE
fix: unref ExporterBuffer flush timer

### DIFF
--- a/packages/opencensus-core/src/exporters/exporter-buffer.ts
+++ b/packages/opencensus-core/src/exporters/exporter-buffer.ts
@@ -100,7 +100,7 @@ export class ExporterBuffer {
     this.logger.debug('ExporterBuffer: set timeout');
     this.bufferTimeoutInProgress = true;
 
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (this.queue.length === 0) {
         return;
       }
@@ -113,6 +113,8 @@ export class ExporterBuffer {
         this.flush();
       }
     }, this.bufferTimeout);
+    // Don't let this timer be the only thing keeping the process alive
+    timer.unref();
   }
 
   /** Send the trace queue to all exporters */

--- a/packages/opencensus-core/test/test-exporter-buffer.ts
+++ b/packages/opencensus-core/test/test-exporter-buffer.ts
@@ -105,13 +105,14 @@ describe('ExporterBuffer', () => {
    * Should flush by timeout
    */
   describe('addToBuffer force flush by timeout ', () => {
-    it('should flush by timeout', () => {
+    it('should flush by timeout', (done) => {
       const buffer = new ExporterBuffer(exporter, defaultBufferConfig);
       buffer.addToBuffer(new RootSpan(tracer));
       assert.strictEqual(buffer.getQueue().length, 1);
       setTimeout(() => {
         assert.strictEqual(buffer.getQueue().length, 0);
+        done();
       }, DEFAULT_BUFFER_TIMEOUT + 100);
-    });
+    }).timeout(5000);
   });
 });


### PR DESCRIPTION
The core unit tests take an unexpectedly long time before exiting... this change fixes that by `unref`'ing the `Timer` object used when doing periodic trace buffer flushing.