### PR TITLE
refactor: add third party files to opencensus-exporter-jaeger

### DIFF
--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/LICENSE
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/METADATA
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/METADATA
@@ -1,0 +1,24 @@
+name: "Jaeger Bindings for Javascript OpenTracing API"
+description:
+    "The following files are used from the linked project: "
+    " "
+    "bufrw.js"
+    "jaeger-idl"
+    "jaeger-idl/thrift/jaeger.thrift"
+    "jaeger-thrift.js"
+    "LICENSE"
+    "reporter.js"
+    "thrift.js"
+    "thriftrw-idl/agent.thrift"
+    "udp_sender.js"
+    "util.js"
+
+third_party {
+  url {
+    type: GIT
+    value: "https://github.com/jaegertracing/jaeger-client-node"
+  }
+  version: "3.10.0"
+  last_upgrade_date { year: 2018 month: 6 day: 5 }
+  license_type: PERMISSIVE
+}

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/bufrw.js
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/bufrw.js
@@ -1,0 +1,17 @@
+// @flow
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+declare type LengthResult = {
+  err: ?string,
+  length: number,
+};

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/jaeger-idl/thrift/jaeger.thrift
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/jaeger-idl/thrift/jaeger.thrift
@@ -1,0 +1,87 @@
+# Copyright (c) 2016 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+namespace java com.uber.jaeger.thriftjava
+
+# TagType denotes the type of a Tag's value.
+enum TagType { STRING, DOUBLE, BOOL, LONG, BINARY }
+
+# Tag is a basic strongly typed key/value pair. It has been flattened to reduce the use of pointers in golang
+struct Tag {
+  1: required string  key
+  2: required TagType vType
+  3: optional string  vStr
+  4: optional double  vDouble
+  5: optional bool    vBool
+  6: optional i64     vLong
+  7: optional binary  vBinary
+}
+
+# Log is a timed even with an arbitrary set of tags.
+struct Log {
+  1: required i64       timestamp
+  2: required list<Tag> fields
+}
+
+enum SpanRefType { CHILD_OF, FOLLOWS_FROM }
+
+# SpanRef describes causal relationship of the current span to another span (e.g. 'child-of')
+struct SpanRef {
+  1: required SpanRefType refType
+  2: required i64         traceIdLow
+  3: required i64         traceIdHigh
+  4: required i64         spanId
+}
+
+# Span represents a named unit of work performed by a service.
+struct Span {
+  1:  required i64           traceIdLow   # the least significant 64 bits of a traceID
+  2:  required i64           traceIdHigh  # the most significant 64 bits of a traceID; 0 when only 64bit IDs are used
+  3:  required i64           spanId       # unique span id (only unique within a given trace)
+  4:  required i64           parentSpanId # since nearly all spans will have parents spans, CHILD_OF refs do not have to be explicit
+  5:  required string        operationName
+  6:  optional list<SpanRef> references   # causal references to other spans
+  7:  required i32           flags        # a bit field used to propagate sampling decisions. 1 signifies a SAMPLED span, 2 signifies a DEBUG span.
+  8:  required i64           startTime
+  9:  required i64           duration
+  10: optional list<Tag>     tags
+  11: optional list<Log>     logs
+}
+
+# Process describes the traced process/service that emits spans.
+struct Process {
+  1: required string    serviceName
+  2: optional list<Tag> tags
+}
+
+# Batch is a collection of spans reported out of process.
+struct Batch {
+  1: required Process    process
+  2: required list<Span> spans
+}
+
+# BatchSubmitResponse is the response on submitting a batch. 
+struct BatchSubmitResponse {
+    1: required bool ok   # The Collector's client is expected to only log (or emit a counter) when not ok equals false
+}
+
+service Collector  {
+    list<BatchSubmitResponse> submitBatches(1: list<Batch> batches)
+}

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/jaeger-thrift.js
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/jaeger-thrift.js
@@ -1,0 +1,42 @@
+// @flow
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+declare type Tag = {
+  key: string,
+  value: any,
+};
+
+declare type LogData = {
+  timestamp: number,
+  fields: Array<Tag>,
+};
+
+declare type Process = {
+  serviceName: string,
+  tags: Array<Tag>,
+  // N.B. uuid uniquely identifies this instance of the client. This variable is not defined
+  // in the jaeger thrift process; it is only used inside this code base to facilitate passing
+  // the uuid around to different objects. The uuid will be propagated via process tags, not
+  // as a first class citizen of thrift process.
+  uuid?: string,
+};
+
+declare type Batch = {
+  process: Process,
+  spans: Array<any>,
+};
+
+declare type Reference = {
+  type(): string,
+  referencedContext(): SpanContext,
+};

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/reporter.js
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/reporter.js
@@ -1,0 +1,29 @@
+// @flow
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import Span from '../span.js';
+
+declare interface Reporter {
+  report(span: Span): void;
+  close(callback?: () => void): void;
+  setProcess(serviceName: string, tags: Array<Tag>): void;
+}
+
+declare class Sender {
+  append(span: Span, callback?: SenderCallback): void;
+  flush(callback?: SenderCallback): void;
+  close(): void;
+  setProcess(process: Process): void;
+}
+
+declare type SenderCallback = (numSpans: number, err?: string) => void;

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/thrift.js
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/thrift.js
@@ -1,0 +1,135 @@
+// @flow
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import fs from 'fs';
+import opentracing from 'opentracing';
+import path from 'path';
+import { Thrift } from 'thriftrw';
+import Utils from './util.js';
+
+export default class ThriftUtils {
+  static _thrift = new Thrift({
+    source: fs.readFileSync(path.join(__dirname, './jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+    allowOptionalArguments: true,
+  });
+  static emptyBuffer: Buffer = new Buffer([0, 0, 0, 0, 0, 0, 0, 0]);
+
+  static getThriftTags(initialTags: Array<Tag>): Array<any> {
+    let thriftTags = [];
+    for (let i = 0; i < initialTags.length; i++) {
+      let tag = initialTags[i];
+
+      let key: string = tag.key;
+
+      let vLong: Buffer = ThriftUtils.emptyBuffer;
+      let vBinary: Buffer = ThriftUtils.emptyBuffer;
+      let vBool: boolean = false;
+      let vDouble: number = 0;
+      let vStr: string = '';
+
+      let vType: string = '';
+      let valueType = typeof tag.value;
+      if (valueType === 'number') {
+        vType = ThriftUtils._thrift.TagType.DOUBLE;
+        vDouble = tag.value;
+      } else if (valueType === 'boolean') {
+        vType = ThriftUtils._thrift.TagType.BOOL;
+        vBool = tag.value;
+      } else if (tag.value instanceof Buffer) {
+        vType = ThriftUtils._thrift.TagType.BINARY;
+        vBinary = tag.value;
+      } else if (valueType === 'object') {
+        vType = ThriftUtils._thrift.TagType.STRING;
+        vStr = JSON.stringify(tag.value);
+      } else {
+        vType = ThriftUtils._thrift.TagType.STRING;
+        if (valueType === 'string') {
+          vStr = tag.value;
+        } else {
+          vStr = String(tag.value);
+        }
+      }
+
+      thriftTags.push({
+        key: key,
+        vType: vType,
+        vStr: vStr,
+        vDouble: vDouble,
+        vBool: vBool,
+        vLong: vLong,
+        vBinary: vBinary,
+      });
+    }
+
+    return thriftTags;
+  }
+
+  static getThriftLogs(logs: Array<LogData>): Array<any> {
+    let thriftLogs = [];
+    for (let i = 0; i < logs.length; i++) {
+      let log = logs[i];
+      thriftLogs.push({
+        timestamp: Utils.encodeInt64(log.timestamp * 1000), // to microseconds
+        fields: ThriftUtils.getThriftTags(log.fields),
+      });
+    }
+
+    return thriftLogs;
+  }
+
+  static spanRefsToThriftRefs(refs: Array<Reference>): Array<any> {
+    let thriftRefs = [];
+    for (let i = 0; i < refs.length; i++) {
+      let refEnum;
+      let ref = refs[i];
+      let context = refs[i].referencedContext();
+
+      if (ref.type() === opentracing.REFERENCE_CHILD_OF) {
+        refEnum = ThriftUtils._thrift.SpanRefType.CHILD_OF;
+      } else if (ref.type() === opentracing.REFERENCE_FOLLOWS_FROM) {
+        refEnum = ThriftUtils._thrift.SpanRefType.FOLLOWS_FROM;
+      } else {
+        continue;
+      }
+
+      thriftRefs.push({
+        refType: refEnum,
+        traceIdLow: context.traceId,
+        traceIdHigh: ThriftUtils.emptyBuffer,
+        spanId: context.spanId,
+      });
+    }
+
+    return thriftRefs;
+  }
+
+  static spanToThrift(span: Span): any {
+    let tags = ThriftUtils.getThriftTags(span._tags);
+    let logs = ThriftUtils.getThriftLogs(span._logs);
+    let unsigned = true;
+
+    return {
+      traceIdLow: span._spanContext.traceId,
+      traceIdHigh: ThriftUtils.emptyBuffer, // TODO(oibe) implement 128 bit ids
+      spanId: span._spanContext.spanId,
+      parentSpanId: span._spanContext.parentId || ThriftUtils.emptyBuffer,
+      operationName: span._operationName,
+      references: ThriftUtils.spanRefsToThriftRefs(span._references),
+      flags: span._spanContext.flags,
+      startTime: Utils.encodeInt64(span._startTime * 1000), // to microseconds
+      duration: Utils.encodeInt64(span._duration * 1000), // to microseconds
+      tags: tags,
+      logs: logs,
+    };
+  }
+}

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/thriftrw-idl/agent.thrift
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/thriftrw-idl/agent.thrift
@@ -1,0 +1,29 @@
+# Copyright (c) 2017 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+# For thriftrw to work, include paths must be prefixed with ./ or ../
+# This agent.thrift file is a copy of jaeger-idl/thrift/agent.thrift with
+# a few alterations:
+#
+# 1) zipkin.thrift was completely removed given that jaeger-idl/thrift/zipkincore.thrift
+#    doesn't conform to thriftrw specifications.
+# 2) changed the path to jaeger.thrift
+#
+# Unfortunately, this file needs to be kept up to date manually.
+
+include "../jaeger-idl/thrift/jaeger.thrift"
+
+namespace java com.uber.jaeger.agent.thrift
+
+service Agent {
+    oneway void emitBatch(1: jaeger.Batch batch)
+}

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/udp_sender.js
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/udp_sender.js
@@ -1,0 +1,199 @@
+// @flow
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import dgram from 'dgram';
+import fs from 'fs';
+import path from 'path';
+import { Thrift } from 'thriftrw';
+import NullLogger from '../logger.js';
+
+const HOST = 'localhost';
+const PORT = 6832;
+const UDP_PACKET_MAX_LENGTH = 65000;
+
+export default class UDPSender {
+  _host: string;
+  _port: number;
+  _maxPacketSize: number;
+  _process: Process;
+  _emitSpanBatchOverhead: number;
+  _logger: Logger;
+  _client: dgram$Socket;
+  _agentThrift: Thrift;
+  _jaegerThrift: Thrift;
+  _batch: Batch;
+  _thriftProcessMessage: any;
+  _maxSpanBytes: number; // maxPacketSize - (batch + tags overhead)
+  _totalSpanBytes: number; // size of currently batched spans as Thrift bytes
+
+  constructor(options: any = {}) {
+    this._host = options.host || HOST;
+    this._port = options.port || PORT;
+    this._maxPacketSize = options.maxPacketSize || UDP_PACKET_MAX_LENGTH;
+    this._logger = options.logger || new NullLogger();
+    this._client = dgram.createSocket('udp4');
+    this._client.on('error', err => {
+      this._logger.error(`error sending spans over UDP: ${err}`);
+    });
+    this._agentThrift = new Thrift({
+      entryPoint: path.join(__dirname, '../thriftrw-idl/agent.thrift'),
+      allowOptionalArguments: true,
+      allowFilesystemAccess: true,
+    });
+    this._jaegerThrift = new Thrift({
+      source: fs.readFileSync(path.join(__dirname, '../jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      allowOptionalArguments: true,
+    });
+    this._totalSpanBytes = 0;
+  }
+
+  _calcBatchSize(batch: Batch) {
+    return this._agentThrift.Agent.emitBatch.argumentsMessageRW.byteLength(
+      this._convertBatchToThriftMessage(this._batch)
+    ).length;
+  }
+
+  _calcSpanSize(span: any): LengthResult {
+    return this._jaegerThrift.Span.rw.byteLength(new this._jaegerThrift.Span(span));
+  }
+
+  setProcess(process: Process): void {
+    // This function is only called once during reporter construction, and thus will
+    // give us the length of the batch before any spans have been added to the span
+    // list in batch.
+    this._process = process;
+    this._batch = {
+      process: this._process,
+      spans: [],
+    };
+
+    const tagMessages = [];
+    for (let j = 0; j < this._batch.process.tags.length; j++) {
+      const tag = this._batch.process.tags[j];
+      tagMessages.push(new this._jaegerThrift.Tag(tag));
+    }
+
+    this._thriftProcessMessage = new this._jaegerThrift.Process({
+      serviceName: this._batch.process.serviceName,
+      tags: tagMessages,
+    });
+    this._emitSpanBatchOverhead = this._calcBatchSize(this._batch);
+    this._maxSpanBytes = this._maxPacketSize - this._emitSpanBatchOverhead;
+  }
+
+  _invokeCallback(callback?: SenderCallback, numSpans: number, error?: string) {
+    if (callback) {
+      callback(numSpans, error);
+    }
+  }
+
+  append(span: any, callback?: SenderCallback): void {
+    const { err, length } = this._calcSpanSize(span);
+    if (err) {
+      this._invokeCallback(callback, 1, `error converting span to Thrift: ${err}`);
+      return;
+    }
+    const spanSize = length;
+    if (spanSize > this._maxSpanBytes) {
+      this._invokeCallback(
+        callback,
+        1,
+        `span size ${spanSize} is larger than maxSpanSize ${this._maxSpanBytes}`
+      );
+      return;
+    }
+
+    if (this._totalSpanBytes + spanSize <= this._maxSpanBytes) {
+      this._batch.spans.push(span);
+      this._totalSpanBytes += spanSize;
+      if (this._totalSpanBytes < this._maxSpanBytes) {
+        // still have space in the buffer, don't flush it yet
+        this._invokeCallback(callback, 0);
+        return;
+      }
+      // buffer size === this._maxSpanBytes
+      this.flush(callback);
+      return;
+    }
+
+    this.flush((numSpans: number, err?: string) => {
+      // TODO theoretically we can have buffer overflow here too, if many spans were appended during flush()
+      this._batch.spans.push(span);
+      this._totalSpanBytes += spanSize;
+      this._invokeCallback(callback, numSpans, err);
+    });
+  }
+
+  flush(callback?: SenderCallback): void {
+    const numSpans = this._batch.spans.length;
+    if (!numSpans) {
+      this._invokeCallback(callback, 0);
+      return;
+    }
+
+    const bufferLen = this._totalSpanBytes + this._emitSpanBatchOverhead;
+    const thriftBuffer = new Buffer(bufferLen);
+    const writeResult = this._agentThrift.Agent.emitBatch.argumentsMessageRW.writeInto(
+      this._convertBatchToThriftMessage(this._batch),
+      thriftBuffer,
+      0
+    );
+    this._reset();
+
+    if (writeResult.err) {
+      this._invokeCallback(callback, numSpans, `error writing Thrift object: ${writeResult.err}`);
+      return;
+    }
+
+    // Having the error callback here does not prevent uncaught exception from being thrown,
+    // that's why in the constructor we also add a general on('error') handler.
+    this._client.send(thriftBuffer, 0, thriftBuffer.length, this._port, this._host, (err, sent) => {
+      if (err) {
+        const error: string =
+          err &&
+          `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`;
+        this._invokeCallback(callback, numSpans, error);
+      } else {
+        this._invokeCallback(callback, numSpans);
+      }
+    });
+  }
+
+  _convertBatchToThriftMessage() {
+    const spanMessages = [];
+    for (let i = 0; i < this._batch.spans.length; i++) {
+      const span = this._batch.spans[i];
+      spanMessages.push(new this._jaegerThrift.Span(span));
+    }
+
+    return new this._agentThrift.Agent.emitBatch.ArgumentsMessage({
+      version: 1,
+      id: 0,
+      body: {
+        batch: new this._jaegerThrift.Batch({
+          process: this._thriftProcessMessage,
+          spans: spanMessages,
+        }),
+      },
+    });
+  }
+
+  _reset() {
+    this._batch.spans = [];
+    this._totalSpanBytes = 0;
+  }
+
+  close(): void {
+    this._client.close();
+  }
+}

--- a/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/util.js
+++ b/packages/opencensus-exporter-jaeger/third_party/jaeger-driver/util.js
@@ -1,0 +1,163 @@
+// @flow
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import xorshift from 'xorshift';
+import Int64 from 'node-int64';
+import os from 'os';
+import http from 'http';
+
+export default class Utils {
+  /**
+   * Determines whether a string contains a given prefix.
+   *
+   * @param {string} text - the string for to search for a prefix
+   * @param {string} prefix - the prefix to search for in the text given.
+   * @return {boolean} - boolean representing whether or not the
+   * string contains the prefix.
+   **/
+  static startsWith(text: string, prefix: string): boolean {
+    return text.indexOf(prefix) === 0;
+  }
+
+  /**
+   * Determines whether a string contains a given prefix.
+   *
+   * @return {Buffer}  - returns a buffer representing a random 64 bit
+   * number.
+   **/
+  static getRandom64(): Buffer {
+    let randint = xorshift.randomint();
+    let buf = new Buffer(8);
+    buf.writeUInt32BE(randint[0], 0);
+    buf.writeUInt32BE(randint[1], 4);
+    return buf;
+  }
+
+  /**
+   * @param {string|number} numberValue - a string or number to be encoded
+   * as a 64 bit byte array.
+   * @return {Buffer} - returns a buffer representing the encoded string, or number.
+   **/
+  static encodeInt64(numberValue: any): any {
+    return new Int64(numberValue).toBuffer();
+  }
+
+  /**
+   * @param {string} ip - a string representation of an ip address.
+   * @return {number} - a 32-bit number where each byte represents an
+   * octect of an ip address.
+   **/
+  static ipToInt(ip: string): ?number {
+    let ipl = 0;
+    let parts = ip.split('.');
+    if (parts.length != 4) {
+      return null;
+    }
+
+    for (let i = 0; i < parts.length; i++) {
+      ipl <<= 8;
+      ipl += parseInt(parts[i], 10);
+    }
+
+    let signedLimit = 0x7fffffff;
+    if (ipl > signedLimit) {
+      return (1 << 32) - ipl;
+    }
+    return ipl;
+  }
+
+  /**
+   * @param {string} input - the input for which leading zeros should be removed.
+   * @return {string} - returns the input string without leading zeros.
+   **/
+  static removeLeadingZeros(input: string): string {
+    let counter = 0;
+    let length = input.length - 1;
+    for (let i = 0; i < length; i++) {
+      if (input.charAt(i) === '0') {
+        counter++;
+      } else {
+        break;
+      }
+    }
+
+    return input.substring(counter);
+  }
+
+  static myIp(): string {
+    let myIp = '0.0.0.0';
+    let ifaces = os.networkInterfaces();
+    let keys = Object.keys(ifaces);
+    loop1: for (let i = 0; i < keys.length; i++) {
+      let iface = ifaces[keys[i]];
+      for (let j = 0; j < iface.length; j++) {
+        if (iface[j].family === 'IPv4' && !iface[j].internal) {
+          myIp = iface[j].address;
+          break loop1;
+        }
+      }
+    }
+    return myIp;
+  }
+
+  static clone(obj: any): any {
+    let newObj = {};
+    for (let key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        newObj[key] = obj[key];
+      }
+    }
+
+    return newObj;
+  }
+
+  static convertObjectToTags(dict: any): Array<Tag> {
+    let tags: Array<Tag> = [];
+    for (let key in dict) {
+      let value = dict[key];
+      if (dict.hasOwnProperty(key)) {
+        tags.push({ key: key, value: value });
+      }
+    }
+
+    return tags;
+  }
+
+  static httpGet(host: string, port: number, path: string, success: Function, error: Function) {
+    http
+      .get(
+        {
+          host: host,
+          port: port,
+          path: path,
+        },
+        res => {
+          // explicitly treat incoming data as utf8 (avoids issues with multi-byte chars)
+          res.setEncoding('utf8');
+
+          // incrementally capture the incoming response body
+          let body = '';
+          res.on('data', chunk => {
+            body += chunk;
+          });
+
+          res.on('end', () => {
+            success(body);
+          });
+        }
+      )
+      .on('error', err => {
+        error(err);
+      });
+  }
+}


### PR DESCRIPTION
This PR adds third-party files used by opencensus-exporter-jaeger according to OSPR requirements 