### PR TITLE
fix: set currentRootSpan before start and set parentSpanId at span constructor

### DIFF
--- a/packages/opencensus-core/src/trace/model/span-base.ts
+++ b/packages/opencensus-core/src/trace/model/span-base.ts
@@ -116,10 +116,10 @@ export abstract class SpanBase implements types.Span {
   /** Gives the TraceContext of the span. */
   get spanContext(): types.SpanContext {
     return {
-      traceId: this.traceId.toString(),
-      spanId: this.id.toString(),
-      options: 1  // always traced
-    } as types.SpanContext;
+      traceId: this.traceId,
+      spanId: this.id,
+      options: 0x1  // always traced
+    };
   }
 
   /**

--- a/packages/opencensus-core/src/trace/model/span-base.ts
+++ b/packages/opencensus-core/src/trace/model/span-base.ts
@@ -118,7 +118,7 @@ export abstract class SpanBase implements types.Span {
     return {
       traceId: this.traceId.toString(),
       spanId: this.id.toString(),
-      parentSpanId: this.parentSpanId
+      options: 1  // always traced
     } as types.SpanContext;
   }
 

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -40,15 +40,6 @@ export class Span extends SpanBase implements types.Span {
     return this.root.traceId;
   }
 
-  /** Gets trace context of span. */
-  get spanContext(): types.SpanContext {
-    return {
-      traceId: this.traceId.toString(),
-      spanId: this.id.toString(),
-      options: 1  // always traced
-    };
-  }
-
   /** Starts the span instance. */
   start() {
     super.start();
@@ -56,7 +47,6 @@ export class Span extends SpanBase implements types.Span {
         'starting span  %o',
         {traceId: this.traceId, spanId: this.id, name: this.name});
   }
-
 
 
   /** Ends the span. */

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -32,6 +32,7 @@ export class Span extends SpanBase implements types.Span {
     super();
     this.root = root;
     this.logger = this.root.logger || logger.logger();
+    this.parentSpanId = root.id;
   }
 
   /** Gets trace id of span. */

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -126,8 +126,8 @@ export class Tracer implements types.Tracer {
             this.sampler.shouldSample(aRoot.traceId);
 
         if (sampleDecision) {
-          aRoot.start();
           this.currentRootSpan = aRoot;
+          aRoot.start();
           newRoot = aRoot;
         }
       } else {


### PR DESCRIPTION
Fix three minor issues. 