### PR TITLE
refactor: privatize some non-user-facing Methods

### DIFF
--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -68,7 +68,8 @@ class RootSpanVerifier implements types.SpanEventListener {
 function assertSpanAttributes(
     span: types.Span, httpStatusCode: number, httpMethod: string,
     hostName: string, path: string, userAgent: string) {
-  assert.strictEqual(span.status, plugin.traceStatus(httpStatusCode));
+  assert.strictEqual(
+      span.status, HttpPlugin.convertTraceStatus(httpStatusCode));
   assert.strictEqual(span.attributes[HttpPlugin.ATTRIBUTE_HTTP_HOST], hostName);
   assert.strictEqual(
       span.attributes[HttpPlugin.ATTRIBUTE_HTTP_METHOD], httpMethod);

--- a/packages/opencensus-instrumentation-http2/package-lock.json
+++ b/packages/opencensus-instrumentation-http2/package-lock.json
@@ -3872,9 +3872,9 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "typescript": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "unique-string": {
       "version": "1.0.0",

--- a/packages/opencensus-instrumentation-http2/test/test-http2.ts
+++ b/packages/opencensus-instrumentation-http2/test/test-http2.ts
@@ -40,7 +40,8 @@ class RootSpanVerifier implements types.SpanEventListener {
 function assertSpanAttributes(
     span: types.Span, httpStatusCode: number, httpMethod: string,
     hostName: string, path: string, userAgent: string) {
-  assert.strictEqual(span.status, plugin.traceStatus(httpStatusCode));
+  assert.strictEqual(
+      span.status, Http2Plugin.convertTraceStatus(httpStatusCode));
   assert.strictEqual(
       span.attributes[Http2Plugin.ATTRIBUTE_HTTP_HOST], hostName);
   assert.strictEqual(

--- a/packages/opencensus-instrumentation-https/package.json
+++ b/packages/opencensus-instrumentation-https/package.json
@@ -6,7 +6,7 @@
   "types": "build/src/index.d.ts",
   "repository": "census-instrumentation/opencensus-node",
   "scripts": {
-    "test": "nyc -x '**/test/**' --reporter=html --reporter=text mocha 'build/test/**/*.js'",
+    "test": "nyc -x '**/test/**' --reporter=html --reporter=text mocha -r source-map-support/register 'build/test/**/*.js'",
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
@@ -50,7 +50,8 @@
     "ncp": "^2.0.0",
     "nock": "^9.2.6",
     "nyc": "^11.7.1",
-    "rimraf": "^2.6.2",  
+    "rimraf": "^2.6.2",
+    "source-map-support": "^0.5.6",
     "ts-node": "^4.0.0",
     "typescript": "~2.7.2"
   },

--- a/packages/opencensus-instrumentation-https/src/https.ts
+++ b/packages/opencensus-instrumentation-https/src/https.ts
@@ -46,7 +46,7 @@ export class HttpsPlugin extends HttpPlugin {
       shimmer.wrap(
           moduleExports && moduleExports.Server &&
               moduleExports.Server.prototype,
-          'emit', this.patchIncomingRequest());
+          'emit', this.getPatchIncomingRequestFunction());
     } else {
       this.logger.error(
           'Could not apply patch to %s.emit. Interface is not as expected.',
@@ -55,7 +55,7 @@ export class HttpsPlugin extends HttpPlugin {
 
     // TODO: review the need to patch 'request'
 
-    shimmer.wrap(moduleExports, 'get', this.patchOutgoingRequest());
+    shimmer.wrap(moduleExports, 'get', this.getPatchOutgoingRequestFunction());
 
     return moduleExports;
   }

--- a/packages/opencensus-instrumentation-https/test/test-https.ts
+++ b/packages/opencensus-instrumentation-https/test/test-https.ts
@@ -77,7 +77,8 @@ const httpsOptions = {
 function assertSpanAttributes(
     span: types.Span, httpStatusCode: number, httpMethod: string,
     hostName: string, path: string, userAgent: string) {
-  assert.strictEqual(span.status, plugin.traceStatus(httpStatusCode));
+  assert.strictEqual(
+      span.status, HttpsPlugin.convertTraceStatus(httpStatusCode));
   assert.strictEqual(
       span.attributes[HttpsPlugin.ATTRIBUTE_HTTP_HOST], hostName);
   assert.strictEqual(


### PR DESCRIPTION
This PR makes various type fixes. It also makes `traceStatus` a static function (as it should be).