### PR TITLE
refactor: address b3 propagation TODOs

### DIFF
--- a/packages/opencensus-propagation-b3/src/b3-format.ts
+++ b/packages/opencensus-propagation-b3/src/b3-format.ts
@@ -39,9 +39,6 @@ export class B3Format implements types.Propagation {
    * @param getter
    */
   extract(getter: types.HeaderGetter): types.SpanContext {
-    // TODO: Review this logic, maybe make it more robust.
-    // Question: are this logic valid if any of the getHeader operations returns
-    // a string[].
     if (getter) {
       const opt = getter.getHeader(X_B3_SAMPLED);
       const spanContext = {

--- a/packages/opencensus-propagation-b3/src/b3-format.ts
+++ b/packages/opencensus-propagation-b3/src/b3-format.ts
@@ -40,7 +40,10 @@ export class B3Format implements types.Propagation {
    */
   extract(getter: types.HeaderGetter): types.SpanContext {
     if (getter) {
-      const opt = getter.getHeader(X_B3_SAMPLED);
+      let opt = getter.getHeader(X_B3_SAMPLED);
+      if (opt instanceof Array) {
+        opt = opt[0];
+      }
       const spanContext = {
         traceId: getter.getHeader(X_B3_TRACE_ID),
         spanId: getter.getHeader(X_B3_SPAN_ID),


### PR DESCRIPTION
The TODO left was: 

> TODO: Review this logic, maybe make it more robust. Question: are this logic valid if any of the `getHeader` operations returns a `string[]`.

I checked and `string[]` has the same behavior in this logic. `getHeader()` returns a `string | string[]`, the verification `isNaN(Number())` works for both.