### PR TITLE
chore: use TS synthetic default imports

### DIFF
--- a/packages/opencensus-propagation-stackdriver/src/v1.ts
+++ b/packages/opencensus-propagation-stackdriver/src/v1.ts
@@ -20,8 +20,8 @@
  * Full details at https://cloud.google.com/trace/docs/support.
  */
 
-import * as crypto from 'crypto';
-import * as uuid from 'uuid';
+import crypto from 'crypto';
+import uuid from 'uuid';
 
 import {HeaderGetter, HeaderSetter, SpanContext} from './index';
 


### PR DESCRIPTION
This avoids deprecation warnings from Node.js core due to `import *`
of `crypto` in Node 10.

Example from a repo where I am using this module:

```
$ node --trace-deprecation build/system-test/foo.js
(node:19445) [DEP0091] DeprecationWarning: crypto.DEFAULT_ENCODING is deprecated.
    at __importStar (/Users/ofrobots/src/veneer/nodejs-logging-bunyan/node_modules/@opencensus/propagation-stackdriver/build/src/v1.js:20:96)
    at Object.<anonymous> (/Users/ofrobots/src/veneer/nodejs-logging-bunyan/node_modules/@opencensus/propagation-stackdriver/build/src/v1.js:30:16)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
    at Function.Module._load (internal/modules/cjs/loader.js:543:3)
    at Module.require (internal/modules/cjs/loader.js:650:17)
    at require (internal/modules/cjs/helpers.js:20:18)
```