### PR TITLE
chore: swap out node 9 testing on ci with node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,13 @@ workflows:
           filters: *release_tags
       - node8:
           filters: *release_tags
-      - node9:
+      - node10:
           filters: *release_tags
       - publish_npm:
           requires:
             - node6
             - node8
-            - node9
+            - node10
           filters:
             branches:
               ignore: /.*/
@@ -56,9 +56,9 @@ jobs:
         environment: *test_env
       - *mongo_service
     <<: *unit_tests
-  node9:
+  node10:
     docker:
-      - image: node:9
+      - image: node:10
         user: node
         environment: *test_env
       - *mongo_service


### PR DESCRIPTION
Since Node 9 is going [EOL this month](https://github.com/nodejs/Release#release-schedule), and Node 10 has been out for a while, this PR swaps out Node 9 CI testing with Node 10.

Fixes #44