### PR TITLE
chore: bump require-in-the-middle to ^3.0.0

### DIFF
--- a/packages/opencensus-nodejs/package.json
+++ b/packages/opencensus-nodejs/package.json
@@ -56,6 +56,6 @@
     "@opencensus/instrumentation-all": "^0.0.2",
     "@opencensus/core": "^0.0.2",
     "extend": "^3.0.1",
-    "require-in-the-middle": "^2.2.1"
+    "require-in-the-middle": "^3.0.0"
   }
 }


### PR DESCRIPTION
This new version allows for multiple versions of require-in-the-middle to be present in the same dependency-tree without interfering.