### PR TITLE
test: test-plugin-loader.ts - add a call to intercept-stdout unhook

### DIFF
--- a/packages/opencensus-nodejs/test/test-plugin-loader.ts
+++ b/packages/opencensus-nodejs/test/test-plugin-loader.ts
@@ -131,7 +131,7 @@ describe('Plugin Loader', () => {
         const http = require(TEST_MODULES[2]);
         intercept((txt: string) => {
           assert.ok(txt.indexOf('error') >= 0);
-        });
+        })();
         assert.strictEqual(pluginLoader.plugins.length, 0);
       });
     });


### PR DESCRIPTION
'intercept-stdout' used by 'test-plugin-loader.ts' was interfering in the visualization of tests results because a call to unhook was missing.