### PR TITLE
fix: detect HTTP client request errors.

### DIFF
--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -313,6 +313,14 @@ export class HttpPlugin extends BasePlugin {
         });
       });
 
+      request.on('error', error => {
+        span.addAttribute(HttpPlugin.ATTRIBUTE_HTTP_ERROR_NAME, error.name);
+        span.addAttribute(
+            HttpPlugin.ATTRIBUTE_HTTP_ERROR_MESSAGE, error.message);
+        span.status = TraceStatusCodes.UNKNOWN;
+        span.end();
+      });
+
       plugin.logger.debug('makeRequestTrace retun request');
       return request;
     };


### PR DESCRIPTION
The error event is fired on the request if the request itself is malformed
(or on DNS resoltion/network errors). I've left the reponse error in, I'm assuming
that timeouts or abrupt server disconnection after a response has been recieved
can still trigger an error.