### PR TITLE
chore: add type definitions for exporter-jaeger

### DIFF
--- a/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
@@ -30,32 +30,65 @@ export const Utils = requireJaegerClientModule('util');
 // tslint:disable-next-line:variable-name
 export const ThriftUtils = requireJaegerClientModule('thrift');
 
+export type TagValue = string|number|boolean;
+
 export type Tag = {
   key: string,
-  // tslint:disable-next-line:no-any
-  value: any
+  value: TagValue
 };
 
-export type Process = {
-  serviceName: string,
-  tags: Tag[]
+export type Log = {
+  timestamp: number,
+  fields: Tag[]
 };
 
 export type SenderCallback = (numSpans: number, err?: string) => void;
+
+export type ThriftProcess = {
+  serviceName: string,
+  tags: ThriftTag[]
+};
+
+export type ThriftTag = {
+  key: string,
+  vType: string,
+  vStr: string,
+  vDouble: number,
+  vBool: boolean
+};
+
+export type ThriftLog = {
+  timestamp: number,
+  fields: ThriftTag[]
+};
+
+export type ThriftSpan = {
+  traceIdLow: any,    // tslint:disable-line:no-any
+  traceIdHigh: any,   // tslint:disable-line:no-any
+  spanId: any,        // tslint:disable-line:no-any
+  parentSpanId: any,  // tslint:disable-line:no-any
+  operationName: string,
+  references: any[],  // tslint:disable-line:no-any
+  flags: number,
+  startTime: number,  // milliseconds
+  duration: number,   // milliseconds
+  tags: ThriftTag[],
+  logs: ThriftLog[],
+};
 
 /**
  * Translate opencensus Span to Jeager Thrift Span
  * @param span
  */
-export function spanToThrift(span: Span) {
-  const tags = [];
+export function spanToThrift(span: Span): ThriftSpan {
+  const tags: Tag[] = [];
   if (span.attributes) {
     Object.keys(span.attributes).forEach(key => {
       tags.push({'key': key, 'value': span.attributes[key]});
     });
   }
 
-  const logs = [];
+  const logs: Log[] = [];
   if (span.messageEvents) {
     span.messageEvents.forEach(msg => {
       logs.push({
@@ -70,7 +103,7 @@ export function spanToThrift(span: Span) {
 
   if (span.annotations) {
     span.annotations.forEach(ann => {
-      const tags = [];
+      const tags: Tag[] = [];
       Object.keys(ann.attributes).forEach(key => {
         tags.push({'key': key, 'value': ann.attributes[key]});
       });
@@ -91,8 +124,8 @@ export function spanToThrift(span: Span) {
 
   const high = traceId.slice(0, 16);
   const low = traceId.slice(16);
-  const spanTags = ThriftUtils.getThriftTags(tags);
-  const spanLogs = ThriftUtils.getThriftLogs(logs);
+  const spanTags: ThriftTag[] = ThriftUtils.getThriftTags(tags);
+  const spanLogs: ThriftLog[] = ThriftUtils.getThriftLogs(logs);
 
   return {
     traceIdLow: Utils.encodeInt64(low),
@@ -100,7 +133,7 @@ export function spanToThrift(span: Span) {
     spanId: Utils.encodeInt64(span.spanContext.spanId),
     parentSpanId: parentSpan,
     operationName: span.name,
-    references: [],
+    references: [] as any,  // tslint:disable-line:no-any
     flags: span.spanContext.options || 0x1,
     startTime:
         Utils.encodeInt64(span.startTime.getTime() * 1000),  // to microseconds

--- a/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
@@ -62,13 +62,25 @@ export type ThriftLog = {
   fields: ThriftTag[]
 };
 
+export enum ThriftReferenceType {
+  CHILD_OF = 'CHILD_OF',
+  FOLLOWS_FROM = 'FOLLOWS_FROM'
+}
+
+export type ThriftReference = {
+  traceIdLow: Buffer,
+  traceIdHigh: Buffer,
+  spanId: Buffer,
+  refType: ThriftReferenceType
+};
+
 export type ThriftSpan = {
-  traceIdLow: any,    // tslint:disable-line:no-any
-  traceIdHigh: any,   // tslint:disable-line:no-any
-  spanId: any,        // tslint:disable-line:no-any
-  parentSpanId: any,  // tslint:disable-line:no-any
+  traceIdLow: Buffer,
+  traceIdHigh: Buffer,
+  spanId: Buffer,
+  parentSpanId: string|Buffer,
   operationName: string,
-  references: any[],  // tslint:disable-line:no-any
+  references: ThriftReference[],
   flags: number,
   startTime: number,  // milliseconds
   duration: number,   // milliseconds
@@ -116,8 +128,9 @@ export function spanToThrift(span: Span): ThriftSpan {
   }
 
   const unsigned = true;
-  const parentSpan = span.parentSpanId ? Utils.encodeInt64(span.parentSpanId) :
-                                         ThriftUtils.emptyBuffer;
+  const parentSpan: string|Buffer = span.parentSpanId ?
+      Utils.encodeInt64(span.parentSpanId) :
+      ThriftUtils.emptyBuffer;
 
   const traceId =
       `00000000000000000000000000000000${span.spanContext.traceId}`.slice(-32);
@@ -133,7 +146,7 @@ export function spanToThrift(span: Span): ThriftSpan {
     spanId: Utils.encodeInt64(span.spanContext.spanId),
     parentSpanId: parentSpan,
     operationName: span.name,
-    references: [] as any,  // tslint:disable-line:no-any
+    references: [],
     flags: span.spanContext.options || 0x1,
     startTime:
         Utils.encodeInt64(span.startTime.getTime() * 1000),  // to microseconds

--- a/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
+++ b/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
@@ -27,7 +27,7 @@ import {spanToThrift, ThriftUtils, UDPSender} from '../src/jaeger-driver';
 
 const DEFAULT_BUFFER_TIMEOUT = 10;  // time in milliseconds
 
-import {Process} from '../src/jaeger-driver';
+import {ThriftProcess} from '../src/jaeger-driver';
 import {SenderCallback} from '../src/jaeger-driver';
 
 
@@ -179,9 +179,10 @@ function mockUDPSender(exporter: JaegerTraceExporter) {
 
 
 class MockedUDPSender extends UDPSender {
-  queue = [];
+  // tslint:disable-next-line:no-any
+  queue: any = [];
 
-  setProcess(process: Process): void {}
+  setProcess(process: ThriftProcess): void {}
 
   // tslint:disable-next-line:no-any
   append(span: any, callback?: SenderCallback): void {

--- a/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
+++ b/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
@@ -107,10 +107,9 @@ describe('Jaeger Exporter', () => {
           return;
         }
       });
-      assert.strictEqual(
-          true,
+      assert.ok(
           testVersionSeen && testExporterVersionSeen && testHostnameSeen &&
-              testProcessIpSeen);
+          testProcessIpSeen);
     });
   });
 
@@ -153,7 +152,7 @@ describe('Jaeger Exporter', () => {
           }
         });
 
-        assert.strictEqual(true, testBoolSeen && testStringSeen && testNumSeen);
+        assert.ok(testBoolSeen && testStringSeen && testNumSeen);
 
         assert.strictEqual(thriftSpan.logs.length, 1);
         thriftSpan.logs.forEach((log) => {
@@ -170,7 +169,7 @@ describe('Jaeger Exporter', () => {
               errorSeen = true;
               return;
             }
-            assert.strictEqual(true, descriptionSeen && errorSeen);
+            assert.ok(descriptionSeen && errorSeen);
           });
         });
       });

--- a/packages/opencensus-exporter-jaeger/tsconfig.json
+++ b/packages/opencensus-exporter-jaeger/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
@@ -14,5 +15,4 @@
     "src/**/*.ts",
     "test/**/*.ts"
   ]
-
 }


### PR DESCRIPTION
The typescript definition files weren't being generated for the exporter-jaeger package because the tsconfig didn't extend from the gts base config.