### PR TITLE
fix: sampler now samples correctly

### DIFF
--- a/packages/opencensus-core/src/trace/sampler/sampler.ts
+++ b/packages/opencensus-core/src/trace/sampler/sampler.ts
@@ -17,10 +17,11 @@
 import {randomSpanId} from '../../internal/util';
 import {Sampler} from './types';
 
-
-const MIN_NUMBER = Number.MIN_VALUE;
-const MAX_NUMBER = Number.MAX_VALUE;
-
+// We use 52-bits as our max number because it remains a javascript "safe
+// integer" for arithmetic and parsing while using the full hex range for
+// comparison to the lower order bytes on a traceId.
+const MAX_NUMBER = 0xfffffffffffff;
+const LOWER_BYTE_COUNT = 13;
 
 /**  Sampler that samples every trace. */
 export class AlwaysSampler implements Sampler {
@@ -61,7 +62,8 @@ export class ProbabilitySampler implements Sampler {
    * False if the traceId is not in probability.
    */
   shouldSample(traceId: string): boolean {
-    const LOWER_BYTES = traceId ? traceId.substring(16) : '0';
+    const LOWER_BYTES =
+        traceId ? ('0000000000000' + traceId).slice(-LOWER_BYTE_COUNT) : '0';
     // tslint:disable-next-line:ban Needed to parse hexadecimal.
     const LOWER_LONG = parseInt(LOWER_BYTES, 16);
 


### PR DESCRIPTION
Sampler was not adhering to the configured propability when not ALWAYS or
NEVER. Issue was that the Sampler was using Number.MAX_VALUE, which uses
1024-bits. There were two issues with this approach:

1. The MAX_VALUE is NOT considered a "safe integer" and thus there are side
   effects during manipulation.
2. The `shouldSample` method was only comparing the idUpperBound (based on
   1024-bits of data) to the lower 16 characters (64-bits) of a trace, which
   was resulting in the configured probabilty not being respected.

We now us a 52-bit number, which falls within the "safe integer" range (53-bits)
and is able to be fully represented by a 13-diget hex value. This allows the
value to:

1. Be safely algorithmically manipulated without side effects.
2. Be easily compared to the lower 52-bits (13 characters) of a traceId.

The tests have been updated to perform validation of traceIds that should and
should not be sampled given a probability.

fixes #99 