### PR TITLE
fix: use default logger in jaeger exporter

### DIFF
--- a/packages/opencensus-exporter-jaeger/src/jaeger.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger.ts
@@ -61,7 +61,7 @@ export class JaegerTraceExporter implements Exporter {
 
   constructor(options: JaegerTraceExporterOptions) {
     const pjson = require('../../package.json');
-    this.logger = options.logger || logger.logger('debug');
+    this.logger = options.logger || logger.logger();
     this.bufferTimeout = options.bufferTimeout;
     this.bufferSize = options.bufferSize;
     this.sender = new UDPSender(options);


### PR DESCRIPTION
Jaeger exporter was using a "debug" logger as a default, whereas all other
exporters simply use the default logger.