### PR TITLE
feat: add a default zipkin url

### DIFF
--- a/packages/opencensus-exporter-zipkin/README.md
+++ b/packages/opencensus-exporter-zipkin/README.md
@@ -22,7 +22,9 @@ wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=z
 java -jar zipkin.jar
 ```
 
-Instance the exporter on your application and pass the options. For javascript:
+Instance the exporter on your application and pass the options, it must contain a service name and, optionaly, an URL. If no URL is passed, `http://localhost:9411/api/v2/spans` is used as default.
+
+For javascript:
 
 ```javascript
 var tracing = require('@opencensus/nodejs');

--- a/packages/opencensus-exporter-zipkin/src/zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/src/zipkin.ts
@@ -21,7 +21,7 @@ import * as http from 'http';
 import * as url from 'url';
 
 export interface ZipkinExporterOptions extends ExporterConfig {
-  url: string;
+  url?: string;
   serviceName: string;
 }
 
@@ -40,13 +40,15 @@ interface TranslatedSpan {
 
 /** Zipkin Exporter manager class */
 export class ZipkinTraceExporter implements Exporter {
+  static readonly DEFAULT_URL = 'http://localhost:9411/api/v2/spans';
   private zipkinUrl: url.UrlWithStringQuery;
   private serviceName: string;
   buffer: ExporterBuffer;
   logger: Logger;
 
   constructor(options: ZipkinExporterOptions) {
-    this.zipkinUrl = url.parse(options.url);
+    this.zipkinUrl = options.url && url.parse(options.url) ||
+        url.parse(ZipkinTraceExporter.DEFAULT_URL);
     this.serviceName = options.serviceName;
     this.buffer = new ExporterBuffer(this, options);
     this.logger = options.logger || logger.logger();


### PR DESCRIPTION
This is just a feature that may be handy for users. The Zipkin URL asks for a specific format. This change adds a default URL making it optional.