### PR TITLE
fix: don't attempt to propagate a null span.

### DIFF
--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -256,6 +256,11 @@ export class HttpPlugin extends BasePlugin {
     return (span: Span): httpModule.ClientRequest => {
       plugin.logger.debug('makeRequestTrace');
 
+      if (!span) {
+        plugin.logger.debug('makeRequestTrace span is null');
+        return request;
+      }
+
       const setter: HeaderSetter = {
         setHeader(name: string, value: string) {
           request.setHeader(name, value);
@@ -265,11 +270,6 @@ export class HttpPlugin extends BasePlugin {
       const propagation = plugin.tracer.propagation;
       if (propagation) {
         propagation.inject(setter, span.spanContext);
-      }
-
-      if (!span) {
-        plugin.logger.debug('makeRequestTrace span is null');
-        return request;
       }
 
       request.on('response', (response: httpModule.ClientResponse) => {


### PR DESCRIPTION
Strictly this should not happen, we should always get a spanContext,
however, this is not currently the case.