### PR TITLE
fix: propagate context, but don't sample

### DIFF
--- a/packages/opencensus-core/src/exporters/exporter-buffer.ts
+++ b/packages/opencensus-core/src/exporters/exporter-buffer.ts
@@ -73,6 +73,10 @@ export class ExporterBuffer {
    * @param root RootSpan to be added in the buffer.
    */
   addToBuffer(root: modelTypes.RootSpan) {
+    if (!(root.spanContext.options & 1)) {
+      return this;
+    }
+
     this.queue.push(root);
     this.logger.debug('ExporterBuffer: added new rootspan');
 

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -119,20 +119,14 @@ export class CoreTracer implements types.Tracer {
             propagatedSample =
                 ((options.spanContext.options & this.IS_SAMPLED) !== 0);
           }
-          if (!propagatedSample) {
-            options.spanContext = null;
-          }
         }
-        const aRoot = new RootSpan(this, options);
+        const newRoot = new RootSpan(this, options);
         const sampleDecision: boolean = propagatedSample ?
             propagatedSample :
-            this.sampler.shouldSample(aRoot.traceId);
+            this.sampler.shouldSample(newRoot.traceId);
 
-        if (sampleDecision) {
-          this.currentRootSpan = aRoot;
-          aRoot.start();
-          newRoot = aRoot;
-        }
+        this.currentRootSpan = newRoot;
+        newRoot.start();
       } else {
         this.logger.debug('Tracer is inactive, can\'t start new RootSpan');
       }


### PR DESCRIPTION
Currently the code generates, but then ignores, unsampled root spans, if no
existing span context exists. It also drop span context that come in from
propagators if they are not sampled. As a result, any span context that is
propagated through the application is also sent to the exporters, regardless
of the options on the span (because only sampled spans will ever been seen).

This behaviour is incorrect, at least by reference to the python and Go codebases.

The sampling decision should be propagated, even if that decision is not to sample.
Consequently, trace IDs are assigned and propagated (to propagate the sampling
decision).

The attached PR is not meant for merging, but was the easiest way of outlining the
flow.

This makes it easier to write instrumentation, since instrumentation will then never
recieve a null span.