### PR TITLE
fix: remove const enums

### DIFF
--- a/packages/opencensus-core/package.json
+++ b/packages/opencensus-core/package.json
@@ -41,6 +41,7 @@
     "@types/continuation-local-storage": "^3.2.1",
     "@types/mocha": "^2.2.48",
     "@types/node": "^9.4.7",
+    "@types/once": "^1.4.0",
     "@types/semver": "^5.5.0",
     "@types/shimmer": "^1.0.1",
     "@types/uuid": "^3.4.3",

--- a/packages/opencensus-core/scripts/compile.ts
+++ b/packages/opencensus-core/scripts/compile.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as path from 'path';
 import { forkP } from './utils';
 import * as ts from 'typescript';

--- a/packages/opencensus-core/scripts/utils.ts
+++ b/packages/opencensus-core/scripts/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChildProcess, ForkOptions, fork } from 'child_process';
+import * as once from 'once';
+
+function promisifyChildProcess(childProcess: ChildProcess): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const exit = (err?: Error) => once(() => err ? reject(err) : resolve())();
+      childProcess.on('error', exit);
+      childProcess.on('close', (code) => {
+        if (code === 0) {
+          exit();
+        } else {
+          exit(new Error(`Process ${childProcess.pid} exited with code ${code}.`));
+        }
+      });
+    });
+  }
+
+export function forkP(moduleName: string, args?: string[], options?: ForkOptions): Promise<void> {
+    const stringifiedCommand = `\`${moduleName}${args ? (' ' + args.join(' ')) : ''}\``;
+    console.log(`> Running: ${stringifiedCommand}`);
+    return promisifyChildProcess(fork(moduleName, args, Object.assign({
+      stdio: 'inherit'
+    }, options)));
+  }

--- a/packages/opencensus-core/src/stats/types.ts
+++ b/packages/opencensus-core/src/stats/types.ts
@@ -44,7 +44,7 @@ export interface Measure {
  * Describes the unit used for the Measure. Should follows the format described
  * by http://unitsofmeasure.org/ucum.html.
  */
-export const enum MeasureUnit {
+export enum MeasureUnit {
   UNIT = '1',    // for general counts
   BYTE = 'by',   // bytes
   KBYTE = 'kb',  // Kbytes
@@ -54,7 +54,7 @@ export const enum MeasureUnit {
 }
 
 /** Describes the types of a Measure. It can be Int64 or a Double type. */
-export const enum MeasureType {
+export enum MeasureType {
   INT64 = 'INT64',
   DOUBLE = 'DOUBLE'
 }
@@ -119,7 +119,7 @@ export interface View {
  * Informs the type of the aggregation. It can be: count, sum, lastValue or
  * distribution.
  */
-export const enum AggregationType {
+export enum AggregationType {
   COUNT = 0,
   SUM = 1,
   LAST_VALUE = 2,


### PR DESCRIPTION
This PR addresses the following:

- [Nodejs Quickstart](https://opencensus.io/quickstart/nodejs/metrics/#1) giving a _Cant read property MS of MeasureUnit_ error
- OpenCensus Core compile script giving a _The node cant find 'utils' module_ error.
- Warning for not recompiling the library with `strictNullChecks` enabled