### PR TITLE
Removes redundant range min/max from distributedValues

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -152,7 +152,6 @@ export class StackdriverStatsExporter implements StatsEventListener {
       count: distribution.count.toString(),
       mean: distribution.mean,
       sumOfSquaredDeviation: distribution.sumSquaredDeviations,
-      range: {min: distribution.min, max: distribution.max},
       bucketOptions: {
         explicitBuckets:
             {bounds: this.getBucketBoundaries(distribution.buckets)}

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -85,7 +85,6 @@ export interface Distribution {
   count: string;
   mean: number;
   sumOfSquaredDeviation: number;
-  range: {min: number; max: number;};
   bucketOptions: {explicitBuckets: {bounds: number[];}};
   bucketCounts: number[];
 }


### PR DESCRIPTION
Solves the error:
UnhandledPromiseRejectionWarning: Error: Field timeSeries[0].points[0].distributionValue.range is not allowed: Distribution range is not yet supported.