### PR TITLE
Fix export issue

### DIFF
--- a/packages/opencensus-core/src/index.ts
+++ b/packages/opencensus-core/src/index.ts
@@ -51,5 +51,5 @@ export * from './stats/recorder';
 export * from './stats/types';
 
 // logger
-import * as logger from './common/console-logger';
-export {logger};
+import { logger } from './common/console-logger';
+export { logger };


### PR DESCRIPTION
When re-exporting like this, I get this error message when I try to
invoke core.logger:

Cannot invoke an expression whose type lacks a call signature. Type 'typeof import("/file/path/censored/node_modules/@opencensus/core/build/src/common/console-logger")' has no compatible call signatures.

My theory is that using a default import for this breaks type signatures.