### PR TITLE
Adds metric name prefix override for [exporter-stackdriver]

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -42,6 +42,11 @@ export interface StackdriverExporterOptions extends ExporterConfig {
    * projectId project id defined to stackdriver
    */
   projectId: string;
+  /**
+   * Prefix for metric overrides the OpenCensus prefix
+   * of a stackdriver metric. Optional
+   */
+  metricPrefix?: string;
 }
 
 export interface TracesWithCredentials {


### PR DESCRIPTION
- The metric type, including its DNS name prefix. The type is not URL-encoded. 
All user-defined metric types have the DNS name custom.googleapis.com or 
external.googleapis.com. Metric types should use a natural hierarchical grouping. 
For example: ""custom.googleapis.com/invoice/paid/amount"" 
""external.googleapis.com/prometheus/up"" 
""appengine.googleapis.com/http/server/response_latencies"""



