### PR TITLE
Use setInterval to upload metrics to Stackdriver periodically

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AggregationType, Bucket, DistributionData, logger, Logger, Measurement, MeasureType, StatsEventListener, View} from '@opencensus/core';
+import {AggregationType, Bucket, DistributionData, logger, Logger, Measurement, MeasureType, StatsEventListener, Tags, View} from '@opencensus/core';
 import {auth, JWT} from 'google-auth-library';
 import {google} from 'googleapis';
 import * as path from 'path';
@@ -24,11 +24,17 @@ import {Distribution, LabelDescriptor, MetricDescriptor, MetricKind, Point, Stac
 google.options({headers: {'x-opencensus-outgoing-request': 0x1}});
 const monitoring = google.monitoring('v3');
 
+const RECORD_SEPARATOR = String.fromCharCode(30);
+const UNIT_SEPARATOR = String.fromCharCode(31);
+
 /** Format and sends Stats to Stackdriver */
 export class StackdriverStatsExporter implements StatsEventListener {
   private delay: number;
   private projectId: string;
   private metricPrefix: string;
+  private viewToUpload:
+      {[key: string]: {view: View; tags: {[key: string]: Tags;}}};
+  private timer: NodeJS.Timer;
   static readonly CUSTOM_OPENCENSUS_DOMAIN: string =
       'custom.googleapis.com/opencensus';
   static readonly DELAY: number = 60000;
@@ -41,6 +47,17 @@ export class StackdriverStatsExporter implements StatsEventListener {
     this.metricPrefix = options.metricPrefix ||
         StackdriverStatsExporter.CUSTOM_OPENCENSUS_DOMAIN;
     this.logger = options.logger || logger.logger();
+    this.viewToUpload = {};
+
+    this.timer = setInterval(async () => {
+      try {
+        await this.uploadViews();
+      } catch (err) {
+        if (typeof options.onMetricUploadError === 'function') {
+          options.onMetricUploadError(err);
+        }
+      }
+    }, this.delay);
   }
 
   /**
@@ -70,13 +87,28 @@ export class StackdriverStatsExporter implements StatsEventListener {
    * @param measurement The measurement recorded
    */
   async onRecord(views: View[], measurement: Measurement) {
-    await new Promise(resolve => {
-      setTimeout(resolve, this.delay);
-    });
+    for (const view of views) {
+      if (!this.viewToUpload[view.name]) {
+        this.viewToUpload[view.name] = {view, tags: {}};
+      }
+      const tagsKey = this.encodeTags(measurement.tags);
+      this.viewToUpload[view.name].tags[tagsKey] = measurement.tags;
+    }
+  }
 
-    const timeSeries = views.map(view => {
-      return this.createTimeSeriesData(view, measurement);
-    });
+  async uploadViews() {
+    const timeSeries = [] as TimeSeries[];
+    for (const name of Object.keys(this.viewToUpload)) {
+      const v = this.viewToUpload[name];
+      for (const tagsKey of Object.keys(v.tags)) {
+        timeSeries.push(this.createTimeSeriesData(v.view, v.tags[tagsKey]));
+      }
+    }
+    this.viewToUpload = {};
+
+    if (timeSeries.length === 0) {
+      return Promise.resolve();
+    }
 
     return this.authorize().then(authClient => {
       const request = {
@@ -92,6 +124,15 @@ export class StackdriverStatsExporter implements StatsEventListener {
         });
       });
     });
+  }
+
+  private encodeTags(tags: Tags): string {
+    return Object.keys(tags)
+        .sort()
+        .map(tagKey => {
+          return tagKey + UNIT_SEPARATOR + tags[tagKey];
+        })
+        .join(RECORD_SEPARATOR);
   }
 
   /**
@@ -122,9 +163,8 @@ export class StackdriverStatsExporter implements StatsEventListener {
    * @param view The view to get TimeSeries information from
    * @param measurement The measurement to get TimeSeries information from
    */
-  private createTimeSeriesData(view: View, measurement: Measurement):
-      TimeSeries {
-    const aggregationData = view.getSnapshot(measurement.tags);
+  private createTimeSeriesData(view: View, tags: Tags): TimeSeries {
+    const aggregationData = view.getSnapshot(tags);
 
     const resourceLabels:
         {[key: string]: string} = {project_id: this.projectId};
@@ -137,16 +177,16 @@ export class StackdriverStatsExporter implements StatsEventListener {
         endTime;
 
     let value;
-    if (view.measure.type === MeasureType.INT64) {
-      value = {int64Value: measurement.value.toString()};
-    } else if (aggregationData.type === AggregationType.DISTRIBUTION) {
+    if (aggregationData.type === AggregationType.DISTRIBUTION) {
       value = {distributionValue: this.createDistribution(aggregationData)};
+    } else if (view.measure.type === MeasureType.INT64) {
+      value = {int64Value: aggregationData.value.toString()};
     } else {
-      value = {doubleValue: measurement.value};
+      value = {doubleValue: aggregationData.value};
     }
 
     return {
-      metric: {type: this.getMetricType(view.name), labels: measurement.tags},
+      metric: {type: this.getMetricType(view.name), labels: tags},
       resource: {type: 'global', labels: resourceLabels},
       metricKind: this.createMetricKind(view.aggregation),
       valueType: this.createValueType(view),

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -96,6 +96,14 @@ export class StackdriverStatsExporter implements StatsEventListener {
     }
   }
 
+  /**
+   * Clear the interval timer to stop uploading metrics. It should be called
+   * whenever the exporter is not needed anymore.
+   */
+  close() {
+    clearInterval(this.timer);
+  }
+
   private uploadViews() {
     const timeSeries: TimeSeries[] = [];
     for (const name of Object.keys(this.viewToUpload)) {
@@ -124,10 +132,6 @@ export class StackdriverStatsExporter implements StatsEventListener {
         });
       });
     });
-  }
-
-  close() {
-    clearInterval(this.timer);
   }
 
   private encodeTags(tags: Tags): string {

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -169,10 +169,10 @@ export class StackdriverStatsExporter implements StatsEventListener {
     const resourceLabels:
         {[key: string]: string} = {project_id: this.projectId};
 
-    // For non Sum Aggregations, the end time should be the same as the start
+    // For LAST_VALUE Aggregations, the end time should be the same as the start
     // time.
     const endTime = (new Date(aggregationData.timestamp)).toISOString();
-    const startTime = view.aggregation === AggregationType.SUM ?
+    const startTime = view.aggregation !== AggregationType.LAST_VALUE ?
         (new Date(view.startTime)).toISOString() :
         endTime;
 
@@ -281,7 +281,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
    * from.
    */
   private createMetricKind(aggregationType: AggregationType): MetricKind {
-    if (aggregationType === AggregationType.SUM) {
+    if (aggregationType !== AggregationType.LAST_VALUE) {
       return MetricKind.CUMULATIVE;
     }
     return MetricKind.GAUGE;

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -41,8 +41,8 @@ export class StackdriverStatsExporter implements StatsEventListener {
   logger: Logger;
 
   constructor(options: StackdriverExporterOptions) {
-    this.delay =
-        options.delay != null ? options.delay : StackdriverStatsExporter.DELAY;
+    this.delay = options.delay !== undefined ? options.delay :
+                                               StackdriverStatsExporter.DELAY;
     this.projectId = options.projectId;
     this.metricPrefix = options.metricPrefix ||
         StackdriverStatsExporter.CUSTOM_OPENCENSUS_DOMAIN;
@@ -124,6 +124,10 @@ export class StackdriverStatsExporter implements StatsEventListener {
         });
       });
     });
+  }
+
+  close() {
+    clearInterval(this.timer);
   }
 
   private encodeTags(tags: Tags): string {

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -29,7 +29,7 @@ const UNIT_SEPARATOR = String.fromCharCode(31);
 
 /** Format and sends Stats to Stackdriver */
 export class StackdriverStatsExporter implements StatsEventListener {
-  private delay: number;
+  private period: number;
   private projectId: string;
   private metricPrefix: string;
   private viewToUpload:
@@ -37,12 +37,13 @@ export class StackdriverStatsExporter implements StatsEventListener {
   private timer: NodeJS.Timer;
   static readonly CUSTOM_OPENCENSUS_DOMAIN: string =
       'custom.googleapis.com/opencensus';
-  static readonly DELAY: number = 60000;
+  static readonly PERIOD: number = 60000;
   logger: Logger;
 
   constructor(options: StackdriverExporterOptions) {
-    this.delay = options.delay !== undefined ? options.delay :
-                                               StackdriverStatsExporter.DELAY;
+    this.period = options.period !== undefined ?
+        options.period :
+        StackdriverStatsExporter.PERIOD;
     this.projectId = options.projectId;
     this.metricPrefix = options.metricPrefix ||
         StackdriverStatsExporter.CUSTOM_OPENCENSUS_DOMAIN;
@@ -57,7 +58,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
           options.onMetricUploadError(err);
         }
       }
-    }, this.delay);
+    }, this.period);
   }
 
   /**

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -86,7 +86,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
    * @param views The views associated with the measure
    * @param measurement The measurement recorded
    */
-  async onRecord(views: View[], measurement: Measurement) {
+  onRecord(views: View[], measurement: Measurement) {
     for (const view of views) {
       if (!this.viewToUpload[view.name]) {
         this.viewToUpload[view.name] = {view, tags: {}};
@@ -96,8 +96,8 @@ export class StackdriverStatsExporter implements StatsEventListener {
     }
   }
 
-  async uploadViews() {
-    const timeSeries = [] as TimeSeries[];
+  private uploadViews() {
+    const timeSeries: TimeSeries[] = [];
     for (const name of Object.keys(this.viewToUpload)) {
       const v = this.viewToUpload[name];
       for (const tagsKey of Object.keys(v.tags)) {

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -36,8 +36,11 @@ export type TranslatedSpan = {
  * Options for stackdriver configuration
  */
 export interface StackdriverExporterOptions extends ExporterConfig {
-  /** Delay in milliseconds */
-  delay?: number;
+  /**
+   * Period in milliseconds sets the interval between uploading aggregated
+   * metrics to stackdriver. Optional, default to 1 minute.
+   */
+  period?: number;
   /**
    * projectId project id defined to stackdriver
    */

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -47,6 +47,8 @@ export interface StackdriverExporterOptions extends ExporterConfig {
    * of a stackdriver metric. Optional
    */
   metricPrefix?: string;
+
+  onMetricUploadError?: (err: Error) => void;
 }
 
 export interface TracesWithCredentials {

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -48,6 +48,10 @@ export interface StackdriverExporterOptions extends ExporterConfig {
    */
   metricPrefix?: string;
 
+  /**
+   * Is called whenever the exporter fails to upload metrics to stackdriver.
+   * Optional
+   */
   onMetricUploadError?: (err: Error) => void;
 }
 

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -226,15 +226,13 @@ describe('Stackdriver Stats Exporter', function() {
               Measurement = {measure: view.measure, value: 1, tags};
           view.recordMeasurement(measurement);
 
-          await exporter.onRecord([view], measurement)
-              .then(() => {
-                return new Promise((resolve) => setTimeout(resolve, 10));
-              })
-              .then(() => {
-                return assertTimeSeries(
-                    exporterTestLogger.debugBuffer[1][0], view, measurement,
-                    PROJECT_ID);
-              });
+          exporter.onRecord([view], measurement);
+
+          await new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
+            return assertTimeSeries(
+                exporterTestLogger.debugBuffer[1][0], view, measurement,
+                PROJECT_ID);
+          });
         });
       });
     });
@@ -270,15 +268,13 @@ describe('Stackdriver Stats Exporter', function() {
 
         viewTimeSeries.recordMeasurement(measurement);
 
-        await exporter.onRecord([viewTimeSeries], measurement)
-            .then(() => {
-              return new Promise((resolve) => setTimeout(resolve, 10));
-            })
-            .then(() => {
-              return assertTimeSeries(
-                  exporterTestLogger.debugBuffer[0][0], viewTimeSeries,
-                  measurement, PROJECT_ID);
-            });
+        exporter.onRecord([viewTimeSeries], measurement);
+
+        await new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
+          return assertTimeSeries(
+              exporterTestLogger.debugBuffer[0][0], viewTimeSeries, measurement,
+              PROJECT_ID);
+        });
       });
     });
 
@@ -362,15 +358,13 @@ describe('Stackdriver Stats Exporter', function() {
           nocks.timeSeries(PROJECT_ID, null, null, false);
         }
         viewTimeSeries.recordMeasurement(measurement);
-        await prefixExporter.onRecord([viewTimeSeries], measurement)
-            .then(() => {
-              return new Promise((resolve) => setTimeout(resolve, 10));
-            })
-            .then(() => {
-              return assertTimeSeries(
-                  exporterTestLogger.debugBuffer[0][0], viewTimeSeries,
-                  measurement, PROJECT_ID, prefixExporterOptions.metricPrefix);
-            });
+        prefixExporter.onRecord([viewTimeSeries], measurement);
+
+        await new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
+          return assertTimeSeries(
+              exporterTestLogger.debugBuffer[0][0], viewTimeSeries, measurement,
+              PROJECT_ID, prefixExporterOptions.metricPrefix);
+        });
       });
     });
 

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -176,7 +176,7 @@ describe('Stackdriver Stats Exporter', function() {
     }
 
     exporterOptions = {
-      delay: 0,
+      period: 0,
       projectId: PROJECT_ID,
       logger: exporterTestLogger
     };
@@ -313,7 +313,7 @@ describe('Stackdriver Stats Exporter', function() {
                .reply(403, 'Permission denied');
 
            const failExporter = new StackdriverStatsExporter({
-             delay: 0,
+             period: 0,
              projectId: WRONG_PROJECT_ID,
              onMetricUploadError: (err) => {
                assert.ok(err.message.indexOf('Permission denied') >= 0);
@@ -395,7 +395,7 @@ describe('Stackdriver Stats Exporter', function() {
                .reply(443, 'Simulated Network Error');
 
            const failExporter = new StackdriverStatsExporter({
-             delay: 0,
+             period: 0,
              projectId: PROJECT_ID,
              onMetricUploadError: (err) => {
                assert.ok(err.message.indexOf('Simulated Network Error') >= 0);

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -99,7 +99,7 @@ function assertTimeSeries(
   const resourceLabels: {[key: string]: string} = {project_id: projectId};
 
   let metricKind: MetricKind;
-  if (view.aggregation === AggregationType.SUM) {
+  if (view.aggregation !== AggregationType.LAST_VALUE) {
     metricKind = MetricKind.CUMULATIVE;
   } else {
     metricKind = MetricKind.GAUGE;


### PR DESCRIPTION
Hi, 

I made some changes to let stackdriver monitoring exporter upload metrics periodically, which are related to issue #152. Including:

1. Use `setInterval()` to schedule metrics uploading.
2. Add the `close()` method which can clear the setInterval timer.
3. Change the behavior of `.onRecord()` and related test cases, because metrics will not be uploaded when `.onRecord()` is called.
4. Make sure `.catch()` blocks in some test cases are executed by finishing them with mocha `done()`
5. Map all non `AggregationType.LAST_VALUE` to stackdriver `MetricKind.CUMULATIVE`.


