### PR TITLE
instrumentation-http: Parse URL instead of relying on pathname

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1977,7 +1977,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -212,7 +212,7 @@ export class HttpPlugin extends BasePlugin {
             return original.apply(this, arguments);
           }
 
-          pathname = url.parse(options.href).pathname;
+          pathname = url.parse(options.path).pathname;
         }
 
         const request = original.apply(this, arguments);

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -198,7 +198,7 @@ export class HttpPlugin extends BasePlugin {
         }
 
         // Makes sure the url is an url object
-        let pathname;
+        let pathname = "";
         if (typeof (options) === 'string') {
           options = url.parse(options);
           arguments[0] = options;
@@ -212,7 +212,10 @@ export class HttpPlugin extends BasePlugin {
             return original.apply(this, arguments);
           }
 
-          pathname = url.parse(options.path).pathname;
+          try {
+            pathname = options.pathname || url.parse(options.path).pathname;
+          } catch(e) {
+          }
         }
 
         const request = original.apply(this, arguments);

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -198,7 +198,7 @@ export class HttpPlugin extends BasePlugin {
         }
 
         // Makes sure the url is an url object
-        let pathname = "";
+        let pathname = '';
         if (typeof (options) === 'string') {
           options = url.parse(options);
           arguments[0] = options;
@@ -214,7 +214,7 @@ export class HttpPlugin extends BasePlugin {
 
           try {
             pathname = options.pathname || url.parse(options.path).pathname;
-          } catch(e) {
+          } catch (e) {
           }
         }
 

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -198,9 +198,11 @@ export class HttpPlugin extends BasePlugin {
         }
 
         // Makes sure the url is an url object
+        let pathname;
         if (typeof (options) === 'string') {
           options = url.parse(options);
           arguments[0] = options;
+          pathname = options.pathname;
         } else {
           // Do not trace ourselves
           if (options.headers &&
@@ -209,6 +211,8 @@ export class HttpPlugin extends BasePlugin {
                 'header with "x-opencensus-outgoing-request" - do not trace');
             return original.apply(this, arguments);
           }
+
+          pathname = url.parse(options.href).pathname;
         }
 
         const request = original.apply(this, arguments);
@@ -218,7 +222,7 @@ export class HttpPlugin extends BasePlugin {
         plugin.logger.debug('%s plugin outgoingRequest', plugin.moduleName);
         const traceOptions = {
           name:
-              `${request.method ? request.method : 'GET'} ${options.pathname}`,
+              `${request.method ? request.method : 'GET'} ${pathname}`,
           kind: 'CLIENT',
         };
 

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -221,8 +221,7 @@ export class HttpPlugin extends BasePlugin {
 
         plugin.logger.debug('%s plugin outgoingRequest', plugin.moduleName);
         const traceOptions = {
-          name:
-              `${request.method ? request.method : 'GET'} ${pathname}`,
+          name: `${request.method ? request.method : 'GET'} ${pathname}`,
           kind: 'CLIENT',
         };
 


### PR DESCRIPTION
instrumentation-http rely on `options.pathname` for outgoing request to name the span. However, several libraries are passing options directly to http.request which [save it as is](https://github.com/nodejs/node/blob/0d8021e5a4cf0a6aa3a700a361f6d42c2894f2ba/lib/_http_client.js#L90).

Affected libraries include:

- [node-fetch](https://github.com/bitinn/node-fetch) 1.x.x (can be solved by upgrading to 2.x.x)
- [request](https://github.com/request/request)

To reproduce, simply setup a tracer and fire an outgoing request with request. The trace will have the name of `GET undefined`.

This PR ensure that we parse every option for pathname instead of relying that it exists.