### PR TITLE
Performance: Use one 24 byte random buffer instead of calling randomBytes() twice

### DIFF
--- a/packages/opencensus-propagation-tracecontext/src/tracecontext-format.ts
+++ b/packages/opencensus-propagation-tracecontext/src/tracecontext-format.ts
@@ -132,9 +132,10 @@ export class TraceContextFormat implements Propagation {
    * Context parts are based on section 2.2.2 of TraceContext spec.
    */
   generate(): SpanContext {
+    const buff = crypto.randomBytes(24).toString('hex');
     return {
-      traceId: crypto.randomBytes(16).toString('hex'),
-      spanId: crypto.randomBytes(8).toString('hex'),
+      traceId: buff.slice(0, 32),
+      spanId: buff.slice(32, 48),
       options: DEFAULT_OPTIONS,
       traceState: undefined
     };


### PR DESCRIPTION
Calling randomBytes() only once to create a 24 byte buffer and converting it to hex and slicing the string then provides the same randomness while shaving off ~40% execution time.

**Testcode**
```js
const crypto = require('crypto');

function headerCallTwice() {
  return {
    traceId: crypto.randomBytes(16).toString('hex'),
    spanId: crypto.randomBytes(8).toString('hex'),
    traceState: undefined
  };
}

function headerSliceBuffer() {
  const buff = crypto.randomBytes(24);
  return {
    traceId: buff.slice(0, 16).toString('hex'),
    spanId: buff.slice(16, 24).toString('hex'),
    traceState: undefined
  };
}

function headerSliceString() {
  const buff = crypto.randomBytes(24).toString('hex');
  return {
    traceId: buff.slice(0, 32),
    spanId: buff.slice(32, 48),
    traceState: undefined
  };
}

function timeFunc(f, n) {
  const hrstart = process.hrtime();
  for(let i = 0; i < n; i++) {
    f()
  }
  const hrend = process.hrtime(hrstart);
  console.info(f.name + ' Execution time (hr): %ds %dms', hrend[0], hrend[1] / 1000000)
  console.log('-----------------------');
}


timeFunc(headerCallTwice, 1000000);
timeFunc(headerSliceBuffer, 1000000);
timeFunc(headerSliceString, 1000000);
```
**Result (Node.js v8.11.1):**
```
headerCallTwice Execution time (hr): 5s 907.900675ms
-----------------------
headerSliceBuffer Execution time (hr): 4s 96.412333ms
-----------------------
headerSliceString Execution time (hr): 3s 654.048213ms
```