### PR TITLE
Enforce "noUnusedLocals" : Report errors on unused locals.

### DIFF
--- a/packages/opencensus-core/src/exporters/console-exporter.ts
+++ b/packages/opencensus-core/src/exporters/console-exporter.ts
@@ -15,7 +15,7 @@
  */
 
 import * as loggerTypes from '../common/types';
-import {Measure, Measurement, View} from '../stats/types';
+import {Measurement, View} from '../stats/types';
 import * as modelTypes from '../trace/model/types';
 
 import {ExporterBuffer} from './exporter-buffer';
@@ -34,6 +34,7 @@ export class NoopExporter implements types.Exporter {
 /** Format and sends span data to the console. */
 export class ConsoleExporter implements types.Exporter {
   /** Buffer object to store the spans. */
+  // @ts-ignore
   private logger: loggerTypes.Logger;
   private buffer: ExporterBuffer;
 

--- a/packages/opencensus-core/src/exporters/exporter-buffer.ts
+++ b/packages/opencensus-core/src/exporters/exporter-buffer.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as uuidv4 from 'uuid/v4';
 import * as logger from '../common/console-logger';
 import * as loggerTypes from '../common/types';
 import * as configTypes from '../trace/config/types';

--- a/packages/opencensus-core/src/stats/view.ts
+++ b/packages/opencensus-core/src/stats/view.ts
@@ -16,10 +16,9 @@
 
 import * as defaultLogger from '../common/console-logger';
 import * as loggerTypes from '../common/types';
-
 import {BucketBoundaries} from './bucket-boundaries';
 import {Recorder} from './recorder';
-import {AggregationData, AggregationMetadata, AggregationType, CountData, DistributionData, LastValueData, Measure, Measurement, MeasureType, SumData, Tags, View} from './types';
+import {AggregationData, AggregationType, Measure, Measurement, Tags, View} from './types';
 
 const RECORD_SEPARATOR = String.fromCharCode(30);
 const UNIT_SEPARATOR = String.fromCharCode(31);
@@ -64,6 +63,7 @@ export class BaseView implements View {
   /** true if the view was registered */
   registered = false;
   /** An object to log information to */
+  // @ts-ignore
   private logger: loggerTypes.Logger;
 
   /**

--- a/packages/opencensus-core/src/trace/instrumentation/base-plugin.ts
+++ b/packages/opencensus-core/src/trace/instrumentation/base-plugin.ts
@@ -15,11 +15,8 @@
  */
 import * as path from 'path';
 import * as semver from 'semver';
-
-import {logger} from '../../common/console-logger';
 import {Logger} from '../../common/types';
 import * as modelTypes from '../model/types';
-
 import * as types from './types';
 
 /**

--- a/packages/opencensus-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-core/src/trace/model/root-span.ts
@@ -15,10 +15,7 @@
  */
 
 import * as uuid from 'uuid';
-
 import * as logger from '../../common/console-logger';
-import {Clock} from '../../internal/clock';
-
 import {Span} from './span';
 import {SpanBase} from './span-base';
 import * as types from './types';

--- a/packages/opencensus-core/src/trace/model/span-base.ts
+++ b/packages/opencensus-core/src/trace/model/span-base.ts
@@ -16,7 +16,6 @@
 import {Logger} from '../../common/types';
 import {Clock} from '../../internal/clock';
 import {randomSpanId} from '../../internal/util';
-
 import * as types from './types';
 
 
@@ -30,6 +29,7 @@ export abstract class SpanBase implements types.Span {
   /** Indicates if this span was ended */
   private endedLocal = false;
   /** Indicates if this span was forced to end */
+  // @ts-ignore
   private truncated = false;
   /** The Span ID of this span */
   readonly id: string;

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -21,9 +21,7 @@ import * as configTypes from '../config/types';
 import {Propagation} from '../propagation/types';
 import {SamplerBuilder} from '../sampler/sampler';
 import * as samplerTypes from '../sampler/types';
-
 import {RootSpan} from './root-span';
-import {Span} from './span';
 import * as types from './types';
 
 
@@ -40,6 +38,7 @@ export class CoreTracer implements types.Tracer {
   /** A list of end span event listeners */
   private eventListenersLocal: types.SpanEventListener[] = [];
   /** A list of ended root spans */
+  // @ts-ignore
   private endedTraces: types.RootSpan[] = [];
   /** Bit to represent whether trace is sampled or not. */
   private readonly IS_SAMPLED = 0x1;

--- a/packages/opencensus-core/src/trace/sampler/sampler.ts
+++ b/packages/opencensus-core/src/trace/sampler/sampler.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {randomSpanId} from '../../internal/util';
 import {Sampler} from './types';
 
 // We use 52-bits as our max number because it remains a javascript "safe

--- a/packages/opencensus-core/src/trace/types.ts
+++ b/packages/opencensus-core/src/trace/types.ts
@@ -15,10 +15,8 @@
  */
 
 import * as exportersTypes from '../exporters/types';
-
 import * as configTypes from './config/types';
 import * as modelTypes from './model/types';
-import * as samplerTypes from './sampler/types';
 
 /** Main interface for tracing. */
 export interface Tracing {

--- a/packages/opencensus-core/test/test-console-exporter.ts
+++ b/packages/opencensus-core/test/test-console-exporter.ts
@@ -15,10 +15,7 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import {ConsoleExporter, NoopExporter} from '../src/exporters/console-exporter';
-import {ExporterBuffer} from '../src/exporters/exporter-buffer';
 import {RootSpan} from '../src/trace/model/root-span';
 import {CoreTracer} from '../src/trace/model/tracer';
 
@@ -57,7 +54,7 @@ describe('ConsoleLogExporter', () => {
     it('should end a span', () => {
       const intercept = require('intercept-stdout');
       let capturedText = '';
-      const unhookIntercept = intercept((txt: string) => {
+      intercept((txt: string) => {
         capturedText += txt;
       });
 
@@ -82,7 +79,7 @@ describe('ConsoleLogExporter', () => {
     it('should publish the rootspans in queue', () => {
       const intercept = require('intercept-stdout');
       let capturedText = '';
-      const unhookIntercept = intercept((txt: string) => {
+      intercept((txt: string) => {
         capturedText += txt;
       });
 

--- a/packages/opencensus-core/test/test-console-logger.ts
+++ b/packages/opencensus-core/test/test-console-logger.ts
@@ -15,11 +15,8 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import * as logger from '../src/common/console-logger';
 import {ConsoleLogger} from '../src/common/console-logger';
-import {Logger} from '../src/common/types';
 
 
 const LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
@@ -38,7 +35,7 @@ describe('ConsoleLogger', () => {
   /** Should create a new ConsoleLogger */
   describe('new ConsoleLogger()', () => {
     it('should log with default levels', () => {
-      const consoleLogger = logger.logger();
+      logger.logger();
       assert.equal(LEVELS.length, ConsoleLogger.LEVELS.length);
     });
 

--- a/packages/opencensus-core/test/test-exporter-buffer.ts
+++ b/packages/opencensus-core/test/test-exporter-buffer.ts
@@ -15,8 +15,6 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import * as logger from '../src/common/console-logger';
 import {NoopExporter} from '../src/exporters/console-exporter';
 import {ExporterBuffer} from '../src/exporters/exporter-buffer';

--- a/packages/opencensus-core/test/test-recorder.ts
+++ b/packages/opencensus-core/test/test-recorder.ts
@@ -15,8 +15,6 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import {Recorder} from '../src';
 import {AggregationType, CountData, DistributionData, LastValueData, Measure, Measurement, MeasureType, MeasureUnit, SumData, Tags} from '../src/stats/types';
 
@@ -176,8 +174,7 @@ describe('Recorder', () => {
                    const updatedAggregationData =
                        Recorder.addMeasurement(distributionData, measurement) as
                        DistributionData;
-
-                   assertDistributionData(distributionData, sentValues);
+                   assertDistributionData(updatedAggregationData, sentValues);
                  }
                });
           }

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -15,13 +15,11 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import {RootSpan} from '../src/trace/model/root-span';
 import {Span} from '../src/trace/model/span';
 import {CoreTracer} from '../src/trace/model/tracer';
 import * as types from '../src/trace/model/types';
-import {Annotation, Attributes, Link, MessageEvent, TraceOptions} from '../src/trace/model/types';
+import {Annotation, Attributes, Link, TraceOptions} from '../src/trace/model/types';
 
 const tracer = new CoreTracer();
 
@@ -165,7 +163,7 @@ describe('RootSpan', () => {
     it('should end all spans inside rootspan', () => {
       const root = new RootSpan(tracer);
       root.start();
-      const span = root.startChildSpan('spanName', 'spanType');
+      root.startChildSpan('spanName', 'spanType');
       root.end();
 
       for (const span of root.spans) {

--- a/packages/opencensus-core/test/test-sampler.ts
+++ b/packages/opencensus-core/test/test-sampler.ts
@@ -15,8 +15,6 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import {RootSpan} from '../src/trace/model/root-span';
 import {CoreTracer} from '../src/trace/model/tracer';
 import {SamplerBuilder} from '../src/trace/sampler/sampler';

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -15,13 +15,11 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import {RootSpan} from '../src/trace/model/root-span';
 import {Span} from '../src/trace/model/span';
 import {CoreTracer} from '../src/trace/model/tracer';
 import * as types from '../src/trace/model/types';
-import {Annotation, Attributes, Link, MessageEvent} from '../src/trace/model/types';
+import {Annotation, Attributes, Link} from '../src/trace/model/types';
 
 
 // TODO: we should evaluate a way to merge similar test cases between span and

--- a/packages/opencensus-core/test/test-stats.ts
+++ b/packages/opencensus-core/test/test-stats.ts
@@ -15,8 +15,6 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
-
 import {BaseView, Stats, StatsEventListener} from '../src';
 import {AggregationType, LastValueData, Measure, Measurement, MeasureType, MeasureUnit, View} from '../src/stats/types';
 
@@ -135,7 +133,6 @@ describe('Stats', () => {
   describe('record()', () => {
     let measure: Measure;
     const testExporter = new TestExporter();
-    let view;
     let aggregationData: LastValueData;
     before(() => {
       measure = stats.createMeasureInt64(measureName, measureUnit);
@@ -144,7 +141,7 @@ describe('Stats', () => {
     beforeEach(() => {
       testExporter.clean();
       stats.registerExporter(testExporter);
-      view = stats.createView(
+      stats.createView(
           viewName, measure, AggregationType.LAST_VALUE, tagKeys, description);
     });
 

--- a/packages/opencensus-core/test/test-tracer.ts
+++ b/packages/opencensus-core/test/test-tracer.ts
@@ -15,9 +15,7 @@
  */
 
 import * as assert from 'assert';
-import {EventEmitter} from 'events';
 import * as uuid from 'uuid';
-
 import {randomSpanId} from '../src/internal/util';
 import {TracerConfig} from '../src/trace/config/types';
 import {RootSpan} from '../src/trace/model/root-span';

--- a/packages/opencensus-core/test/test-view.ts
+++ b/packages/opencensus-core/test/test-view.ts
@@ -15,22 +15,15 @@
  */
 
 import * as assert from 'assert';
-import * as mocha from 'mocha';
 
 import {BaseView} from '../src';
-import {AggregationType, CountData, DistributionData, LastValueData, Measure, Measurement, MeasureType, MeasureUnit, SumData, Tags, View} from '../src/stats/types';
+import {AggregationType, DistributionData, Measure, Measurement, MeasureType, MeasureUnit, Tags, View} from '../src/stats/types';
 
 /** The order of how close values must be to be considerated almost equal */
 const EPSILON = 6;
 
 interface AggregationTestCase {
   aggregationType: AggregationType;
-  description: string;
-}
-
-interface MeasurementsTestCase {
-  values: number[];
-  bucketBoundaries: number[];
   description: string;
 }
 
@@ -117,7 +110,6 @@ describe('BaseView', () => {
   describe('recordMeasurement()', () => {
     const measurementValues = [1.1, 2.3, 3.2, 4.3, 5.2];
     const bucketBoundaries = [2, 4, 6];
-    const emptyAggregation = {};
     const tags: Tags = {testKey1: 'testValue', testKey2: 'testValue'};
 
     for (const aggregationTestCase of aggregationTestCases) {

--- a/packages/opencensus-core/tsconfig.json
+++ b/packages/opencensus-core/tsconfig.json
@@ -6,7 +6,8 @@
     "pretty": true,
     "module": "commonjs",
     "target": "es6",
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "noUnusedLocals": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Add ```--noUnusedLocals``` Compiler Options to disallows unused imports, variables, functions and
private class members.