### PR TITLE
Add Double and INT64 Gauges APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Add Resource API.
 - Add Metrics API.
 - Remove support for `min`/`max` in the stats Distribution to make it compatible with Metrics.
+- Add Gauges (`DoubleGauge`, `LongGauge`) APIs.
 
 ## 0.0.7 - 2018-11-12
  **Contains API breaking changes for stats/metrics implementations**

--- a/packages/opencensus-core/package-lock.json
+++ b/packages/opencensus-core/package-lock.json
@@ -1,11 +1,14 @@
 {
-  "requires": true,
+  "name": "@opencensus/core",
+  "version": "0.0.7",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha1-oz4N+dzptCTRyY/E/evYV43O7H4=",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -13,42 +16,50 @@
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
     },
     "@types/node": {
       "version": "9.4.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
-      "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw=="
+      "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
+      "dev": true
     },
     "@types/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@types/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw=="
+      "integrity": "sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
     },
     "@types/shimmer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.1.tgz",
-      "integrity": "sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ=="
+      "integrity": "sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ==",
+      "dev": true
     },
     "@types/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
+      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
+      "dev": true
     },
     "@types/strip-json-comments": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true
     },
     "@types/uuid": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -57,6 +68,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
       "requires": {
         "string-width": "^2.0.0"
       },
@@ -64,17 +76,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -84,6 +99,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -93,17 +109,20 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -112,6 +131,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -119,12 +139,14 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "async-listener": {
       "version": "0.6.9",
@@ -139,6 +161,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -148,12 +171,14 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -165,19 +190,22 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
       "requires": {
         "ansi-align": "^2.0.0",
         "camelcase": "^4.0.0",
@@ -191,22 +219,26 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -216,6 +248,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -226,6 +259,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -234,17 +268,20 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
       "requires": {
         "camelcase": "^4.1.0",
         "map-obj": "^2.0.0",
@@ -254,19 +291,22 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         }
       }
     },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
     },
     "chalk": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
       "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -276,12 +316,14 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -291,12 +333,14 @@
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
     },
     "clang-format": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.2.tgz",
       "integrity": "sha512-6X9u1JBMak/9VbC0IZajEDvp19/PbjCanbRO3Z2xsluypQtbPPAGDvGGovLOWoUpXIvJH9vJExmzlqWvwItZxA==",
+      "dev": true,
       "requires": {
         "async": "^1.5.2",
         "glob": "^7.0.0",
@@ -306,19 +350,22 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
         }
       }
     },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -326,12 +373,14 @@
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -339,22 +388,26 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "configstore": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "dev": true,
       "requires": {
         "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
@@ -368,6 +421,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
           }
@@ -387,6 +441,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
@@ -395,6 +450,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
       "requires": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -404,12 +460,14 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
       }
@@ -418,6 +476,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -425,12 +484,14 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
@@ -439,24 +500,28 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
         }
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "emitter-listener": {
       "version": "1.1.1",
@@ -470,6 +535,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -477,22 +543,26 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
       "requires": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -507,6 +577,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true,
       "requires": {
         "chardet": "^0.4.0",
         "iconv-lite": "^0.4.17",
@@ -517,6 +588,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -525,6 +597,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
       }
@@ -532,17 +605,20 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -556,6 +632,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
       "requires": {
         "ini": "^1.3.4"
       }
@@ -563,17 +640,20 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
     },
     "gts": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.4.tgz",
       "integrity": "sha512-bDxE/NvHu+v0uW0qbUMYClrGCi81Ug4Wa7BsV/yUtdEh67C3K56BiqAk8yBOttLH1k4XYks+7QSJy7XOf3vaQw==",
+      "dev": true,
       "requires": {
         "chalk": "^2.3.0",
         "clang-format": "1.2.2",
@@ -590,6 +670,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -597,17 +678,20 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -615,32 +699,38 @@
     "hosted-git-info": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "indent-string": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -649,17 +739,20 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
@@ -680,17 +773,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -700,6 +796,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -710,6 +807,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/intercept-stdout/-/intercept-stdout-0.1.2.tgz",
       "integrity": "sha1-Emq/H65sUJpCipjGGmMVWQQq6f0=",
+      "dev": true,
       "requires": {
         "lodash.toarray": "^3.0.0"
       }
@@ -717,12 +815,14 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
       }
@@ -731,6 +831,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
@@ -739,17 +840,20 @@
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
       "requires": {
         "path-is-inside": "^1.0.1"
       }
@@ -757,42 +861,50 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -801,12 +913,14 @@
     "json-parse-better-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
     },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
       "requires": {
         "package-json": "^4.0.0"
       }
@@ -815,6 +929,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -826,6 +941,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -837,6 +953,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -845,37 +962,44 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "dev": true
     },
     "lodash._basevalues": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
       "requires": {
         "lodash._getnative": "^3.0.0",
         "lodash.isarguments": "^3.0.0",
@@ -886,6 +1010,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-3.0.2.tgz",
       "integrity": "sha1-KyBPD6T1HChcbwDIHRzqWiMEEXk=",
+      "dev": true,
       "requires": {
         "lodash._arraycopy": "^3.0.0",
         "lodash._basevalues": "^3.0.0",
@@ -901,6 +1026,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
@@ -909,12 +1035,14 @@
     "lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -924,6 +1052,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "dev": true,
       "requires": {
         "pify": "^3.0.0"
       }
@@ -931,17 +1060,20 @@
     "make-error": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+      "dev": true
     },
     "map-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
     },
     "meow": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
       "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+      "dev": true,
       "requires": {
         "camelcase-keys": "^4.0.0",
         "decamelize-keys": "^1.0.0",
@@ -957,19 +1089,22 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -977,12 +1112,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
       "requires": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0"
@@ -992,6 +1129,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -1000,6 +1138,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
       "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
+      "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
         "commander": "2.11.0",
@@ -1016,22 +1155,26 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
     "ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -1043,6 +1186,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -1051,6 +1195,7 @@
       "version": "11.6.0",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
       "integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
+      "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "arrify": "^1.0.1",
@@ -1084,6 +1229,7 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1092,65 +1238,79 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "atob": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chalk": "^1.1.3",
             "esutils": "^2.0.2",
@@ -1160,6 +1320,7 @@
         "babel-generator": {
           "version": "6.26.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-messages": "^6.23.0",
             "babel-runtime": "^6.26.0",
@@ -1174,6 +1335,7 @@
         "babel-messages": {
           "version": "6.23.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "^6.22.0"
           }
@@ -1181,6 +1343,7 @@
         "babel-runtime": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "core-js": "^2.4.0",
             "regenerator-runtime": "^0.11.0"
@@ -1189,6 +1352,7 @@
         "babel-template": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
             "babel-traverse": "^6.26.0",
@@ -1200,6 +1364,7 @@
         "babel-traverse": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
             "babel-messages": "^6.23.0",
@@ -1215,6 +1380,7 @@
         "babel-types": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
             "esutils": "^2.0.2",
@@ -1224,15 +1390,18 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "base": {
           "version": "0.11.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
             "class-utils": "^0.3.5",
@@ -1246,19 +1415,22 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1267,6 +1439,7 @@
         "braces": {
           "version": "1.8.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
@@ -1275,11 +1448,13 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
             "component-emitter": "^1.2.1",
@@ -1294,13 +1469,15 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "caching-transform": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
             "mkdirp": "^0.5.1",
@@ -1310,11 +1487,13 @@
         "camelcase": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "^0.1.3",
@@ -1324,6 +1503,7 @@
         "chalk": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -1335,6 +1515,7 @@
         "class-utils": {
           "version": "0.3.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
             "define-property": "^0.2.5",
@@ -1345,6 +1526,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -1352,6 +1534,7 @@
             "is-accessor-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -1359,6 +1542,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -1368,6 +1552,7 @@
             "is-data-descriptor": {
               "version": "0.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -1375,6 +1560,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -1384,6 +1570,7 @@
             "is-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -1392,17 +1579,20 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "^0.1.1",
@@ -1413,17 +1603,20 @@
             "wordwrap": {
               "version": "0.0.2",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
             "object-visit": "^1.0.0"
@@ -1431,31 +1624,38 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "core-js": {
           "version": "2.5.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
@@ -1464,25 +1664,30 @@
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
           }
@@ -1490,6 +1695,7 @@
         "define-property": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -1497,13 +1703,15 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "repeating": "^2.0.0"
           }
@@ -1511,21 +1719,25 @@
         "error-ex": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "execa": {
           "version": "0.7.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -1539,6 +1751,7 @@
             "cross-spawn": {
               "version": "5.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -1550,6 +1763,7 @@
         "expand-brackets": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-posix-bracket": "^0.1.0"
           }
@@ -1557,6 +1771,7 @@
         "expand-range": {
           "version": "1.8.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fill-range": "^2.1.0"
           }
@@ -1564,6 +1779,7 @@
         "extend-shallow": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -1572,6 +1788,7 @@
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
               }
@@ -1581,17 +1798,20 @@
         "extglob": {
           "version": "0.3.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^2.1.0",
             "isobject": "^2.0.0",
@@ -1603,6 +1823,7 @@
         "find-cache-dir": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "commondir": "^1.0.1",
             "mkdirp": "^0.5.1",
@@ -1612,17 +1833,20 @@
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "for-own": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "for-in": "^1.0.1"
           }
@@ -1630,6 +1854,7 @@
         "foreground-child": {
           "version": "1.5.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "^4",
             "signal-exit": "^3.0.0"
@@ -1638,29 +1863,35 @@
         "fragment-cache": {
           "version": "0.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -1673,6 +1904,7 @@
         "glob-base": {
           "version": "0.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob-parent": "^2.0.0",
             "is-glob": "^2.0.0"
@@ -1681,21 +1913,25 @@
         "glob-parent": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-glob": "^2.0.0"
           }
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "async": "^1.4.0",
             "optimist": "^0.6.1",
@@ -1706,6 +1942,7 @@
             "source-map": {
               "version": "0.4.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -1715,17 +1952,20 @@
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "get-value": "^2.0.6",
             "has-values": "^1.0.0",
@@ -1734,13 +1974,15 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "has-values": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "kind-of": "^4.0.0"
@@ -1749,6 +1991,7 @@
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -1756,6 +1999,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -1765,6 +2009,7 @@
             "kind-of": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -1773,15 +2018,18 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -1789,43 +2037,51 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "invariant": {
           "version": "2.2.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
           }
@@ -1833,19 +2089,22 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-descriptor": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1854,43 +2113,51 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-dotfile": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -1898,6 +2165,7 @@
         "is-number": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -1905,71 +2173,85 @@
         "is-odd": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isobject": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isarray": "1.0.0"
           }
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "append-transform": "^0.4.0"
           }
@@ -1977,6 +2259,7 @@
         "istanbul-lib-instrument": {
           "version": "1.10.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-generator": "^6.18.0",
             "babel-template": "^6.16.0",
@@ -1990,6 +2273,7 @@
         "istanbul-lib-report": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.2",
             "mkdirp": "^0.5.1",
@@ -2000,6 +2284,7 @@
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
               }
@@ -2009,6 +2294,7 @@
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debug": "^3.1.0",
             "istanbul-lib-coverage": "^1.1.2",
@@ -2020,6 +2306,7 @@
             "debug": {
               "version": "3.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -2029,21 +2316,25 @@
         "istanbul-reports": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2051,11 +2342,13 @@
         "lazy-cache": {
           "version": "1.0.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
           }
@@ -2063,6 +2356,7 @@
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^2.2.0",
@@ -2074,6 +2368,7 @@
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -2081,21 +2376,25 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "js-tokens": "^3.0.0"
           }
@@ -2103,6 +2402,7 @@
         "lru-cache": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -2110,11 +2410,13 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
           }
@@ -2122,17 +2424,20 @@
         "md5-hex": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mem": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
           }
@@ -2140,19 +2445,22 @@
         "merge-source-map": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "source-map": "^0.6.1"
           },
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "micromatch": {
           "version": "2.3.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-diff": "^2.0.0",
             "array-unique": "^0.2.1",
@@ -2171,22 +2479,26 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"
@@ -2195,6 +2507,7 @@
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
               }
@@ -2204,17 +2517,20 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -2232,21 +2548,25 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "is-builtin-module": "^1.0.0",
@@ -2257,6 +2577,7 @@
         "normalize-path": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -2264,21 +2585,25 @@
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
             "define-property": "^0.2.5",
@@ -2288,6 +2613,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -2295,6 +2621,7 @@
             "is-accessor-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               }
@@ -2302,6 +2629,7 @@
             "is-data-descriptor": {
               "version": "0.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               }
@@ -2309,6 +2637,7 @@
             "is-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -2317,7 +2646,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "5.1.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             }
@@ -2326,19 +2656,22 @@
         "object-visit": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "object.omit": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "for-own": "^0.1.4",
             "is-extendable": "^0.1.1"
@@ -2347,19 +2680,22 @@
         "object.pick": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2367,6 +2703,7 @@
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "~0.0.1",
             "wordwrap": "~0.0.2"
@@ -2374,11 +2711,13 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
@@ -2387,11 +2726,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-try": "^1.0.0"
           }
@@ -2399,17 +2740,20 @@
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "parse-glob": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob-base": "^0.3.0",
             "is-dotfile": "^1.0.0",
@@ -2420,36 +2764,43 @@
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-type": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
@@ -2458,15 +2809,18 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
           }
@@ -2474,6 +2828,7 @@
         "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "find-up": "^1.0.0"
           },
@@ -2481,6 +2836,7 @@
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -2490,19 +2846,23 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "preserve": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "randomatic": {
           "version": "1.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "kind-of": "^4.0.0"
@@ -2511,6 +2871,7 @@
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -2518,6 +2879,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -2527,6 +2889,7 @@
             "kind-of": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -2536,6 +2899,7 @@
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
             "normalize-package-data": "^2.3.2",
@@ -2545,6 +2909,7 @@
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "find-up": "^1.0.0",
             "read-pkg": "^1.0.0"
@@ -2553,6 +2918,7 @@
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -2562,11 +2928,13 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "regex-cache": {
           "version": "0.4.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-equal-shallow": "^0.1.3"
           }
@@ -2574,6 +2942,7 @@
         "regex-not": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
             "safe-regex": "^1.1.0"
@@ -2581,46 +2950,56 @@
         },
         "remove-trailing-separator": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "repeating": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "^0.1.1"
@@ -2629,6 +3008,7 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -2636,21 +3016,25 @@
         "safe-regex": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ret": "~0.1.10"
           }
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "set-value": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -2661,6 +3045,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -2670,25 +3055,30 @@
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "base": "^0.11.1",
             "debug": "^2.2.0",
@@ -2703,6 +3093,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -2710,6 +3101,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -2717,6 +3109,7 @@
             "is-accessor-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -2724,6 +3117,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -2733,6 +3127,7 @@
             "is-data-descriptor": {
               "version": "0.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -2740,6 +3135,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -2749,6 +3145,7 @@
             "is-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -2757,13 +3154,15 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "snapdragon-node": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "^1.0.0",
             "isobject": "^3.0.0",
@@ -2773,30 +3172,35 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
           }
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "atob": "^2.0.0",
             "decode-uri-component": "^0.2.0",
@@ -2807,11 +3211,13 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
             "mkdirp": "^0.5.0",
@@ -2824,6 +3230,7 @@
         "spdx-correct": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -2831,11 +3238,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -2843,11 +3252,13 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "split-string": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
           }
@@ -2855,6 +3266,7 @@
         "static-extend": {
           "version": "0.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "^0.2.5",
             "object-copy": "^0.1.0"
@@ -2863,6 +3275,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -2870,6 +3283,7 @@
             "is-accessor-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -2877,6 +3291,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -2886,6 +3301,7 @@
             "is-data-descriptor": {
               "version": "0.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -2893,6 +3309,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -2902,6 +3319,7 @@
             "is-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -2910,13 +3328,15 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -2924,11 +3344,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -2938,6 +3360,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2945,21 +3368,25 @@
         "strip-bom": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arrify": "^1.0.1",
             "micromatch": "^3.1.8",
@@ -2970,15 +3397,18 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "braces": {
               "version": "2.3.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -2997,6 +3427,7 @@
                 "define-property": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-descriptor": "^1.0.0"
                   }
@@ -3004,6 +3435,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -3013,6 +3445,7 @@
             "expand-brackets": {
               "version": "2.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "debug": "^2.3.3",
                 "define-property": "^0.2.5",
@@ -3026,6 +3459,7 @@
                 "define-property": {
                   "version": "0.2.5",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-descriptor": "^0.1.0"
                   }
@@ -3033,6 +3467,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -3040,6 +3475,7 @@
                 "is-descriptor": {
                   "version": "0.1.6",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-accessor-descriptor": "^0.1.6",
                     "is-data-descriptor": "^0.1.4",
@@ -3048,13 +3484,15 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "extglob": {
               "version": "2.0.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "array-unique": "^0.3.2",
                 "define-property": "^1.0.0",
@@ -3069,6 +3507,7 @@
                 "define-property": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-descriptor": "^1.0.0"
                   }
@@ -3076,6 +3515,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -3085,6 +3525,7 @@
             "fill-range": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -3095,6 +3536,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -3104,6 +3546,7 @@
             "is-accessor-descriptor": {
               "version": "0.1.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -3111,6 +3554,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -3120,6 +3564,7 @@
             "is-data-descriptor": {
               "version": "0.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -3127,6 +3572,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -3136,6 +3582,7 @@
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -3143,6 +3590,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -3151,15 +3599,18 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "micromatch": {
               "version": "3.1.9",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -3180,11 +3631,13 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -3192,6 +3645,7 @@
         "to-regex": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "^2.0.2",
             "extend-shallow": "^3.0.2",
@@ -3202,6 +3656,7 @@
         "to-regex-range": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
@@ -3210,6 +3665,7 @@
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               }
@@ -3218,11 +3674,13 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "source-map": "~0.5.1",
@@ -3233,6 +3691,7 @@
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
+              "dev": true,
               "optional": true,
               "requires": {
                 "camelcase": "^1.0.2",
@@ -3246,11 +3705,13 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
             "get-value": "^2.0.6",
@@ -3261,6 +3722,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -3268,6 +3730,7 @@
             "set-value": {
               "version": "0.4.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -3280,6 +3743,7 @@
         "unset-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has-value": "^0.3.1",
             "isobject": "^3.0.0"
@@ -3288,6 +3752,7 @@
             "has-value": {
               "version": "0.3.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "get-value": "^2.0.3",
                 "has-values": "^0.1.4",
@@ -3297,6 +3762,7 @@
                 "isobject": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
                   }
@@ -3305,34 +3771,40 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "use": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -3341,26 +3813,31 @@
         "which": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "window-size": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
@@ -3369,6 +3846,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3376,6 +3854,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3386,11 +3865,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -3399,15 +3880,18 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yargs": {
           "version": "11.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
@@ -3425,15 +3909,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "cliui": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "string-width": "^2.1.1",
                 "strip-ansi": "^4.0.0",
@@ -3443,6 +3930,7 @@
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -3450,6 +3938,7 @@
             "yargs-parser": {
               "version": "9.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
               }
@@ -3459,13 +3948,15 @@
         "yargs-parser": {
           "version": "8.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         }
@@ -3475,6 +3966,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3483,6 +3975,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
       }
@@ -3490,17 +3983,20 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-limit": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
       "requires": {
         "p-try": "^1.0.0"
       }
@@ -3509,6 +4005,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
       }
@@ -3516,12 +4013,14 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
       "requires": {
         "got": "^6.7.1",
         "registry-auth-token": "^3.0.1",
@@ -3533,6 +4032,7 @@
           "version": "6.7.1",
           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
@@ -3550,49 +4050,58 @@
         "timed-out": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+          "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+          "dev": true
         }
       }
     },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
     },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
       "requires": {
         "pify": "^3.0.0"
       }
@@ -3600,29 +4109,34 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
     },
     "rc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
-        "deep-extend": "~0.4.0",
+        "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
@@ -3630,8 +4144,9 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -3639,6 +4154,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
       "requires": {
         "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
@@ -3649,6 +4165,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
       "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "dev": true,
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
@@ -3658,6 +4175,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
       "requires": {
         "indent-string": "^3.0.0",
         "strip-indent": "^2.0.0"
@@ -3667,6 +4185,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
       "requires": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
@@ -3676,6 +4195,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
       "requires": {
         "rc": "^1.0.1"
       }
@@ -3684,6 +4204,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
       }
@@ -3692,6 +4213,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -3701,6 +4223,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -3709,6 +4232,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
@@ -3716,12 +4240,14 @@
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
       "requires": {
         "rx-lite": "*"
       }
@@ -3729,7 +4255,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -3740,6 +4267,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
       "requires": {
         "semver": "^5.0.3"
       }
@@ -3748,6 +4276,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -3755,7 +4284,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shimmer": {
       "version": "1.2.0",
@@ -3765,12 +4295,14 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
       "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+      "dev": true,
       "requires": {
         "source-map": "^0.6.0"
       },
@@ -3778,7 +4310,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -3786,6 +4319,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -3794,12 +4328,14 @@
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -3808,17 +4344,20 @@
     "spdx-license-ids": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -3826,27 +4365,32 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-indent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
       "requires": {
         "has-flag": "^2.0.0"
       }
@@ -3855,6 +4399,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
       "requires": {
         "execa": "^0.7.0"
       }
@@ -3862,12 +4407,14 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -3875,12 +4422,14 @@
     "trim-newlines": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true
     },
     "ts-node": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
       "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+      "dev": true,
       "requires": {
         "arrify": "^1.0.0",
         "chalk": "^2.3.0",
@@ -3897,7 +4446,8 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -3905,6 +4455,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
       "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
       "requires": {
         "@types/strip-bom": "^3.0.0",
         "@types/strip-json-comments": "0.0.30",
@@ -3915,12 +4466,14 @@
     "tslib": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "dev": true
     },
     "tslint": {
       "version": "5.9.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
       "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -3939,7 +4492,8 @@
         "commander": {
           "version": "2.15.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
         }
       }
     },
@@ -3947,6 +4501,7 @@
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.22.2.tgz",
       "integrity": "sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.1"
       }
@@ -3954,12 +4509,14 @@
     "typescript": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "dev": true
     },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
@@ -3968,6 +4525,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "dev": true,
       "requires": {
         "boxen": "^1.2.1",
         "chalk": "^2.0.1",
@@ -3984,6 +4542,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
       "requires": {
         "prepend-http": "^1.0.1"
       }
@@ -3997,6 +4556,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.2.tgz",
       "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
+      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -4005,6 +4565,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -4014,6 +4575,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -4022,6 +4584,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "dev": true,
       "requires": {
         "string-width": "^2.1.1"
       },
@@ -4029,17 +4592,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -4049,6 +4615,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -4058,12 +4625,14 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -4073,17 +4642,20 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     }
   }
 }

--- a/packages/opencensus-core/src/common/validations.ts
+++ b/packages/opencensus-core/src/common/validations.ts
@@ -37,8 +37,9 @@ export function validateNotNull<T>(reference: T, errorMessage: string): T {
  */
 export function validateArrayElementsNotNull<T>(
     array: T[], errorMessage: string) {
-  if (array.every(
-          element => element !== null || typeof element !== 'undefined')) {
+  const areAllNotNullOrUndefined = array.every(
+      element => element !== null && typeof element !== 'undefined');
+  if (!areAllNotNullOrUndefined) {
     throw new Error(`${errorMessage} elements should not be a NULL`);
   }
 }

--- a/packages/opencensus-core/src/common/validations.ts
+++ b/packages/opencensus-core/src/common/validations.ts
@@ -37,9 +37,9 @@ export function validateNotNull<T>(reference: T, errorMessage: string): T {
  */
 export function validateArrayElementsNotNull<T>(
     array: T[], errorMessage: string) {
-  const areAllNotNullOrUndefined = array.every(
+  const areAllDefined = array.every(
       element => element !== null && typeof element !== 'undefined');
-  if (!areAllNotNullOrUndefined) {
+  if (!areAllDefined) {
     throw new Error(`${errorMessage} elements should not be a NULL`);
   }
 }

--- a/packages/opencensus-core/src/metrics/export/types.ts
+++ b/packages/opencensus-core/src/metrics/export/types.ts
@@ -121,7 +121,7 @@ export interface TimeSeries {
    * interval (start_timestamp, timestamp]. If not specified, the backend can
    * use the previous recorded value.
    */
-  readonly startTimestamp: Timestamp;
+  readonly startTimestamp?: Timestamp;
   /**
    * The set of label values that uniquely identify this timeseries. Applies to
    * all points. The order of label values must match that of label keys in the

--- a/packages/opencensus-core/src/metrics/gauges/gauge.ts
+++ b/packages/opencensus-core/src/metrics/gauges/gauge.ts
@@ -28,6 +28,20 @@ export class Gauge implements types.Meter {
   private defaultLabelValues: LabelValue[];
   private registeredPoints: Map<string, types.Point> = new Map();
 
+  private static readonly LABEL_VALUE = 'labelValue';
+  private static readonly LABEL_VALUES = 'labelValues';
+  private static readonly ERROR_MESSAGE_INVALID_SIZE =
+      'Label Keys and Label Values don\'t have same size';
+
+  /**
+   * Constructs a new Gauge instance.
+   *
+   * @param {string} name The name of the metric.
+   * @param {string} description The description of the metric.
+   * @param {string} unit The unit of the metric.
+   * @param {MetricDescriptorType} type The type of metric.
+   * @param {LabelKey[]} labelKeys The list of the label keys.
+   */
   constructor(
       name: string, description: string, unit: string,
       type: MetricDescriptorType, readonly labelKeys: LabelKey[]) {
@@ -49,7 +63,7 @@ export class Gauge implements types.Meter {
    */
   getOrCreateTimeSeries(labelValues: LabelValue[]): types.Point {
     validateArrayElementsNotNull(
-        validateNotNull(labelValues, 'labelValues'), 'labelValue');
+        validateNotNull(labelValues, Gauge.LABEL_VALUES), Gauge.LABEL_VALUE);
     return this.registerTimeSeries(labelValues);
   }
 
@@ -71,7 +85,7 @@ export class Gauge implements types.Meter {
    * @param {LabelValue[]} labelValues The list of label values.
    */
   removeTimeSeries(labelValues: LabelValue[]): void {
-    validateNotNull(labelValues, 'labelValues');
+    validateNotNull(labelValues, Gauge.LABEL_VALUES);
     this.registeredPoints.delete(hashLabelValues(labelValues));
   }
 
@@ -98,7 +112,7 @@ export class Gauge implements types.Meter {
       return this.registeredPoints.get(hash);
     }
     if (this.labelKeysLength !== labelValues.length) {
-      throw new Error('Label Keys and Label Values don\'t have same size');
+      throw new Error(Gauge.ERROR_MESSAGE_INVALID_SIZE);
     }
 
     const point = new PointEntry(labelValues);

--- a/packages/opencensus-core/src/metrics/gauges/gauge.ts
+++ b/packages/opencensus-core/src/metrics/gauges/gauge.ts
@@ -143,9 +143,10 @@ export class Gauge implements types.Meter {
  * The value of a single point in the Gauge.TimeSeries.
  */
 export class PointEntry implements types.Point {
+  private readonly labelValues: LabelValue[];
   private value = 0;
 
-  constructor(private readonly labelValues: LabelValue[]) {
+  constructor(labelValues: LabelValue[]) {
     this.labelValues = labelValues;
   }
 

--- a/packages/opencensus-core/src/metrics/gauges/gauge.ts
+++ b/packages/opencensus-core/src/metrics/gauges/gauge.ts
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {validateArrayElementsNotNull, validateNotNull} from '../../common/validations';
+import {LabelKey, LabelValue, Metric, MetricDescriptor, MetricDescriptorType, TimeSeries, Timestamp} from '../export/types';
+import * as types from '../gauges/types';
+import {hashLabelValues, initializeDefaultLabels} from '../utils';
+
+/**
+ * Gauge metric
+ */
+export class Gauge {
+  private readonly metricDescriptor: MetricDescriptor;
+  private labelKeysLength: number;
+  private defaultLabelValues: LabelValue[];
+  private registeredPoints: Map<string, types.Point> = new Map();
+
+  constructor(
+      name: string, description: string, unit: string,
+      type: MetricDescriptorType, readonly labelKeys: LabelKey[]) {
+    this.metricDescriptor = {name, description, unit, type, labelKeys};
+    this.labelKeysLength = labelKeys.length;
+    this.defaultLabelValues = initializeDefaultLabels(this.labelKeysLength);
+  }
+
+  /**
+   * Creates a TimeSeries and returns a Point if the specified
+   * labelValues is not already associated with this gauge, else returns an
+   * existing Point.
+   *
+   * It is recommended to keep a reference to the Point instead of always
+   * calling this method for manual operations.
+   *
+   * @param {LabelValue[]} labelValues The list of the label values.
+   * @returns {types.Point} The value of single gauge.
+   */
+  getOrCreateTimeSeries(labelValues: LabelValue[]): types.Point {
+    validateArrayElementsNotNull(
+        validateNotNull(labelValues, 'labelValues'), 'labelValue');
+    return this.registerTimeSeries(labelValues);
+  }
+
+  /**
+   * Returns a Point for a gauge with all labels not set, or default
+   * labels.
+   *
+   * @returns {types.Point} The value of single gauge.
+   */
+  getDefaultTimeSeries(): types.Point {
+    return this.registerTimeSeries(this.defaultLabelValues);
+  }
+
+  /**
+   * Removes the TimeSeries from the gauge metric, if it is present. i.e.
+   * references to previous Point objects are invalid (not part of the
+   * metric).
+   *
+   * @param {LabelValue[]} labelValues The list of label values.
+   */
+  removeTimeSeries(labelValues: LabelValue[]): void {
+    validateNotNull(labelValues, 'labelValues');
+    this.registeredPoints.delete(hashLabelValues(labelValues));
+  }
+
+  /**
+   * Removes all TimeSeries from the gauge metric. i.e. references to all
+   * previous Point objects are invalid (not part of the metric).
+   */
+  clear(): void {
+    this.registeredPoints.clear();
+  }
+
+  /**
+   * Registers a TimeSeries and returns a Point if the specified
+   * labelValues is not already associated with this gauge, else returns an
+   * existing Point.
+   *
+   * @param {LabelValue[]} labelValues The list of the label values.
+   * @returns {types.Point} The value of single gauge.
+   */
+  private registerTimeSeries(labelValues: LabelValue[]): types.Point {
+    const hash = hashLabelValues(labelValues);
+    // return if the specified labelValues is already associated with the point.
+    if (this.registeredPoints.has(hash)) {
+      return this.registeredPoints.get(hash);
+    }
+    if (this.labelKeysLength !== labelValues.length) {
+      throw new Error('Label Keys and Label Values don\'t have same size');
+    }
+
+    const point = new PointEntry(labelValues);
+    this.registeredPoints.set(hash, point);
+    return point;
+  }
+
+  /**
+   * Provides a Metric with one or more TimeSeries.
+   *
+   * @returns {Metric} The Metric.
+   */
+  getMetric(): Metric {
+    if (this.registeredPoints.size === 0) {
+      return null;
+    }
+    const hrtimeLocal = process.hrtime();
+    const timeSeriesList: TimeSeries[] = new Array();
+    this.registeredPoints.forEach((point: types.Point) => {
+      timeSeriesList.push(point.getTimeSeries(
+          {seconds: hrtimeLocal[0], nanos: hrtimeLocal[1]}));
+    });
+    return {descriptor: this.metricDescriptor, timeseries: timeSeriesList};
+  }
+}
+
+/**
+ * The value of a single point in the Gauge.TimeSeries.
+ */
+export class PointEntry implements types.Point {
+  private value = 0;
+
+  constructor(private readonly labelValues: LabelValue[]) {
+    this.labelValues = labelValues;
+  }
+
+  /**
+   * Adds the given value to the current value. The values can be negative.
+   *
+   * @param {number} amt The value to add.
+   */
+  add(amt: number): void {
+    this.value = this.value + amt;
+  }
+
+  /**
+   * Sets the given value.
+   *
+   * @param {number} val The new value.
+   */
+  set(val: number): void {
+    this.value = val;
+  }
+
+  /**
+   * Returns the TimeSeries with one or more Point.
+   *
+   * @param {Timestamp} timestamp The time at which the gauge is recorded.
+   * @returns {TimeSeries} The TimeSeries.
+   */
+  getTimeSeries(timestamp: Timestamp): TimeSeries {
+    return {
+      labelValues: this.labelValues,
+      points: [{value: this.value, timestamp}],
+      startTimestamp: null
+    };
+  }
+}

--- a/packages/opencensus-core/src/metrics/gauges/types.ts
+++ b/packages/opencensus-core/src/metrics/gauges/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Metric, TimeSeries, Timestamp} from '../export/types';
+
+export interface Meter {
+  /**
+   * Provides a Metric with one or more TimeSeries.
+   *
+   * @returns {Metric} The Metric.
+   */
+  getMetric(): Metric;
+}
+
+export interface Point {
+  /**
+   * Adds the given value to the current value. The values can be negative.
+   *
+   * @param {number} amt The value to add.
+   */
+  add(amt: number): void;
+
+  /**
+   * Sets the given value.
+   *
+   * @param {number} val The new value.
+   */
+  set(val: number): void;
+
+  /**
+   * Returns the TimeSeries with one or more Point.
+   *
+   * @param {Timestamp} timestamp The time at which the gauge is recorded.
+   * @returns {TimeSeries} The TimeSeries.
+   */
+  getTimeSeries(timestamp: Timestamp): TimeSeries;
+}

--- a/packages/opencensus-core/src/metrics/utils.ts
+++ b/packages/opencensus-core/src/metrics/utils.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LabelValue} from './export/types';
+
+/**
+ * Returns a string(comma separated) from the list of label values.
+ *
+ * @param  {LabelValue[]} labelValues The list of the label values.
+ * @returns {string} The hashed label values string.
+ */
+export function hashLabelValues(labelValues: LabelValue[]): string {
+  if (labelValues.length === 0) {
+    return '';
+  }
+  if (labelValues.length > 1) {
+    labelValues = labelValues.sort((obj1, obj2) => {
+      if (obj1.value > obj2.value) {
+        return 1;
+      }
+      if (obj1.value < obj2.value) {
+        return -1;
+      }
+      return 0;
+    });
+  }
+  const elems = [];
+  for (let i = 0; i < labelValues.length; i++) {
+    elems.push(labelValues[i].value);
+  }
+  return elems.join(',');
+}
+
+/**
+ * Returns default label values.
+ *
+ * @param  {number} count The number of label values.
+ * @returns {LabelValue[]} The list of the label values.
+ */
+export function initializeDefaultLabels(count: number): LabelValue[] {
+  const UNSET_LABEL_VALUE: LabelValue = {value: null};
+  const defaultLabels: LabelValue[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    defaultLabels[i] = UNSET_LABEL_VALUE;
+  }
+  return defaultLabels;
+}

--- a/packages/opencensus-core/src/metrics/utils.ts
+++ b/packages/opencensus-core/src/metrics/utils.ts
@@ -16,6 +16,11 @@
 
 import {LabelValue} from './export/types';
 
+const COMMA_SEPARATOR = ',';
+const UNSET_LABEL_VALUE: LabelValue = {
+  value: null
+};
+
 /**
  * Returns a string(comma separated) from the list of label values.
  *
@@ -23,25 +28,7 @@ import {LabelValue} from './export/types';
  * @returns {string} The hashed label values string.
  */
 export function hashLabelValues(labelValues: LabelValue[]): string {
-  if (labelValues.length === 0) {
-    return '';
-  }
-  if (labelValues.length > 1) {
-    labelValues = labelValues.sort((obj1, obj2) => {
-      if (obj1.value > obj2.value) {
-        return 1;
-      }
-      if (obj1.value < obj2.value) {
-        return -1;
-      }
-      return 0;
-    });
-  }
-  const elems = [];
-  for (let i = 0; i < labelValues.length; i++) {
-    elems.push(labelValues[i].value);
-  }
-  return elems.join(',');
+  return labelValues.map(lv => lv.value).sort().join(COMMA_SEPARATOR);
 }
 
 /**
@@ -51,10 +38,5 @@ export function hashLabelValues(labelValues: LabelValue[]): string {
  * @returns {LabelValue[]} The list of the label values.
  */
 export function initializeDefaultLabels(count: number): LabelValue[] {
-  const UNSET_LABEL_VALUE: LabelValue = {value: null};
-  const defaultLabels: LabelValue[] = new Array(count);
-  for (let i = 0; i < count; i++) {
-    defaultLabels[i] = UNSET_LABEL_VALUE;
-  }
-  return defaultLabels;
+  return new Array(count).fill(UNSET_LABEL_VALUE);
 }

--- a/packages/opencensus-core/test/test-gauge.ts
+++ b/packages/opencensus-core/test/test-gauge.ts
@@ -32,6 +32,7 @@ const UNSET_LABEL_VALUE: LabelValue = {
 };
 
 describe('GAUGE_INT64', () => {
+  const oldProcessHrtime = process.hrtime;
   let instance: Gauge;
   const expectedMetricDescriptor = {
     name: METRIC_NAME,
@@ -46,6 +47,11 @@ describe('GAUGE_INT64', () => {
         METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_INT64, LABEL_KEYS);
     process.hrtime = () => [1000, 1e7];
   });
+
+  afterEach(() => {
+    process.hrtime = oldProcessHrtime;
+  });
+
   describe('getOrCreateTimeSeries()', () => {
     it('should throw an error when the labelvalues are null', () => {
       assert.throws(() => {
@@ -227,6 +233,7 @@ describe('GAUGE_INT64', () => {
 });
 
 describe('GAUGE_DOUBLE', () => {
+  const oldProcessHrtime = process.hrtime;
   let instance: Gauge;
   const expectedMetricDescriptor = {
     name: METRIC_NAME,
@@ -235,10 +242,17 @@ describe('GAUGE_DOUBLE', () => {
     type: GAUGE_DOUBLE,
     labelKeys: LABEL_KEYS
   };
+
   beforeEach(() => {
     instance = new Gauge(
         METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_DOUBLE, LABEL_KEYS);
+    process.hrtime = () => [1000, 1e7];
   });
+
+  afterEach(() => {
+    process.hrtime = oldProcessHrtime;
+  });
+
   describe('getOrCreateTimeSeries()', () => {
     it('should throw an error when the labelvalues are null', () => {
       assert.throws(() => {

--- a/packages/opencensus-core/test/test-gauge.ts
+++ b/packages/opencensus-core/test/test-gauge.ts
@@ -1,0 +1,425 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {LabelKey, LabelValue, MetricDescriptorType} from '../src/metrics/export/types';
+import {Gauge} from '../src/metrics/gauges/gauge';
+
+const METRIC_NAME = 'metric-name';
+const METRIC_DESCRIPTION = 'metric-description';
+const UNIT = '1';
+const GAUGE_INT64 = MetricDescriptorType.GAUGE_INT64;
+const GAUGE_DOUBLE = MetricDescriptorType.GAUGE_DOUBLE;
+const LABEL_KEYS: LabelKey[] = [{key: 'code', description: 'desc'}];
+const LABEL_VALUES_200: LabelValue[] = [{value: '200'}];
+const LABEL_VALUES_400: LabelValue[] = [{value: '400'}];
+const LABEL_VALUES_EXRTA: LabelValue[] = [{value: '200'}, {value: '400'}];
+const UNSET_LABEL_VALUE: LabelValue = {
+  value: null
+};
+
+describe('GAUGE_INT64', () => {
+  let instance: Gauge;
+  const expectedMetricDescriptor = {
+    name: METRIC_NAME,
+    description: METRIC_DESCRIPTION,
+    unit: UNIT,
+    type: GAUGE_INT64,
+    labelKeys: LABEL_KEYS
+  };
+
+  beforeEach(() => {
+    instance = new Gauge(
+        METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_INT64, LABEL_KEYS);
+    process.hrtime = () => [1000, 1e7];
+  });
+  describe('getOrCreateTimeSeries()', () => {
+    it('should throw an error when the labelvalues are null', () => {
+      assert.throws(() => {
+        instance.getOrCreateTimeSeries(null);
+      }, /^Error: Missing mandatory labelValues parameter$/);
+    });
+    it('should throw an error when the labelValues elements contains NULL',
+       () => {
+         const LABEL_VALUES_WITH_NULL: LabelValue[] = [null];
+         assert.throws(() => {
+           instance.getOrCreateTimeSeries(LABEL_VALUES_WITH_NULL);
+         }, /^Error: labelValue elements should not be a NULL$/);
+       });
+    it('should throw an error when the keys and values dont have same size',
+       () => {
+         assert.throws(() => {
+           instance.getOrCreateTimeSeries(LABEL_VALUES_EXRTA);
+         }, /^Error: Label Keys and Label Values don't have same size$/);
+       });
+    it('should return a Metric', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(10);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+      // add value and create new timeseries.
+      point.add(5);
+      const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_400);
+      point1.set(-8);
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 2);
+      assert.deepStrictEqual(metric.timeseries, [
+        {
+          labelValues: LABEL_VALUES_200,
+          points: [{value: 15, timestamp: {nanos: 1e7, seconds: 1000}}],
+          startTimestamp: null
+        },
+        {
+          labelValues: LABEL_VALUES_400,
+          points: [{value: -8, timestamp: {nanos: 1e7, seconds: 1000}}],
+          startTimestamp: null
+        }
+      ]);
+    });
+    it('should not create same timeseries again', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(10);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+      // create timeseries with same labels.
+      const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point1.add(30);
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 40, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+  });
+  describe('getDefaultTimeSeries()', () => {
+    it('should create new default timeseries', () => {
+      const point = instance.getDefaultTimeSeries();
+      point.add(10);
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: [UNSET_LABEL_VALUE],
+            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+    it('should return same timeseries for interchanged labels', () => {
+      instance = new Gauge(
+          METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_INT64,
+          [{key: 'k1', description: 'desc'}, {key: 'k2', description: 'desc'}]);
+      const point =
+          instance.getOrCreateTimeSeries([{value: '200'}, {value: '400'}]);
+      point.add(200);
+      const point1 =
+          instance.getOrCreateTimeSeries([{value: '400'}, {value: '200'}]);
+      point1.add(400);
+      const metric = instance.getMetric();
+      assert.equal(metric.timeseries.length, 1);
+    });
+    it('should create same labelValues as labelKeys', () => {
+      instance = new Gauge(METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_INT64, [
+        {key: 'k1', description: 'desc'}, {key: 'k2', description: 'desc'},
+        {key: 'k3', description: 'desc'}
+      ]);
+      const point = instance.getDefaultTimeSeries();
+      point.add(200);
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor.labelKeys.length, 3);
+      assert.deepStrictEqual(metric.descriptor.type, 1);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues:
+                [UNSET_LABEL_VALUE, UNSET_LABEL_VALUE, UNSET_LABEL_VALUE],
+            points: [{value: 200, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+    it('should use previously created default timeseries', () => {
+      const point = instance.getDefaultTimeSeries();
+      point.add(300);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: [UNSET_LABEL_VALUE],
+            points: [{value: 300, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+      // get default timeseries again.
+      const point1 = instance.getDefaultTimeSeries();
+      point1.add(400);
+      metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: [UNSET_LABEL_VALUE],
+            points: [{value: 700, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+  });
+  describe('removeTimeSeries()', () => {
+    it('should throw an error when the labelvalues are null', () => {
+      assert.throws(() => {
+        instance.removeTimeSeries(null);
+      }, /^Error: Missing mandatory labelValues parameter$/);
+    });
+    it('should remove TimeSeries', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(10);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      instance.removeTimeSeries(LABEL_VALUES_200);
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+  describe('clear()', () => {
+    it('should clear all TimeSeries', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(10);
+      const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_400);
+      point1.add(10);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 2);
+      instance.clear();
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+});
+
+describe('GAUGE_DOUBLE', () => {
+  let instance: Gauge;
+  const expectedMetricDescriptor = {
+    name: METRIC_NAME,
+    description: METRIC_DESCRIPTION,
+    unit: UNIT,
+    type: GAUGE_DOUBLE,
+    labelKeys: LABEL_KEYS
+  };
+  beforeEach(() => {
+    instance = new Gauge(
+        METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_DOUBLE, LABEL_KEYS);
+  });
+  describe('getOrCreateTimeSeries()', () => {
+    it('should throw an error when the labelvalues are null', () => {
+      assert.throws(() => {
+        instance.getOrCreateTimeSeries(null);
+      }, /^Error: Missing mandatory labelValues parameter$/);
+    });
+    it('should throw an error when the labelValues elements contains NULL',
+       () => {
+         const LABEL_VALUES_WITH_NULL: LabelValue[] = [null];
+         assert.throws(() => {
+           instance.getOrCreateTimeSeries(LABEL_VALUES_WITH_NULL);
+         }, /^Error: labelValue elements should not be a NULL$/);
+       });
+    it('should throw an error when the keys and values dont have same size',
+       () => {
+         assert.throws(() => {
+           instance.getOrCreateTimeSeries(LABEL_VALUES_EXRTA);
+         }, /^Error: Label Keys and Label Values don't have same size$/);
+       });
+    it('should return a Metric', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(10.34);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 10.34, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+      // add value and create new timeseries.
+      point.add(5.12);
+      const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_400);
+      point1.set(-8.3);
+      metric = instance.getMetric();
+      assert.equal(metric.timeseries.length, 2);
+      assert.deepStrictEqual(metric.timeseries, [
+        {
+          labelValues: LABEL_VALUES_200,
+          points: [{value: 15.46, timestamp: {nanos: 1e7, seconds: 1000}}],
+          startTimestamp: null
+        },
+        {
+          labelValues: LABEL_VALUES_400,
+          points: [{value: -8.3, timestamp: {nanos: 1e7, seconds: 1000}}],
+          startTimestamp: null
+        }
+      ]);
+    });
+    it('should not create same timeseries again', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(12.1);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 12.1, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+      // create timeseries with same labels.
+      const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point1.add(30.18);
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 42.28, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+  });
+  describe('getDefaultTimeSeries()', () => {
+    it('should create new default timeseries', () => {
+      const point = instance.getDefaultTimeSeries();
+      point.add(10.1);
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: [UNSET_LABEL_VALUE],
+            points: [{value: 10.1, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+    it('should use previously created default timeseries', () => {
+      const point = instance.getDefaultTimeSeries();
+      point.add(300.1);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: [UNSET_LABEL_VALUE],
+            points: [{value: 300.1, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+      // get default timeseries again.
+      const point1 = instance.getDefaultTimeSeries();
+      point1.add(400.1);
+      metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: [UNSET_LABEL_VALUE],
+            points: [{value: 700.2, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+    it('should create same labelValues as labelKeys', () => {
+      instance =
+          new Gauge(METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_DOUBLE, [
+            {key: 'k1', description: 'desc'}, {key: 'k2', description: 'desc'},
+            {key: 'k3', description: 'desc'}
+          ]);
+      const point = instance.getDefaultTimeSeries();
+      point.add(10.1);
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor.labelKeys.length, 3);
+      assert.deepStrictEqual(metric.descriptor.type, 2);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues:
+                [UNSET_LABEL_VALUE, UNSET_LABEL_VALUE, UNSET_LABEL_VALUE],
+            points: [{value: 10.1, timestamp: {nanos: 1e7, seconds: 1000}}],
+            startTimestamp: null
+          }]);
+    });
+  });
+  describe('removeTimeSeries()', () => {
+    it('should throw an error when the labelvalues are null', () => {
+      assert.throws(() => {
+        instance.removeTimeSeries(null);
+      }, /^Error: Missing mandatory labelValues parameter$/);
+    });
+    it('should remove TimeSeries', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(10.23);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      instance.removeTimeSeries(LABEL_VALUES_200);
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+  describe('clear()', () => {
+    it('should clear all TimeSeries', () => {
+      const point = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
+      point.add(10.34);
+      const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_400);
+      point1.add(15.2);
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 2);
+      instance.clear();
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+});

--- a/packages/opencensus-core/test/test-gauge.ts
+++ b/packages/opencensus-core/test/test-gauge.ts
@@ -75,8 +75,7 @@ describe('GAUGE_INT64', () => {
       assert.deepStrictEqual(
           metric.timeseries, [{
             labelValues: LABEL_VALUES_200,
-            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
+            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}]
           }]);
       // add value and create new timeseries.
       point.add(5);
@@ -88,13 +87,11 @@ describe('GAUGE_INT64', () => {
       assert.deepStrictEqual(metric.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
-          points: [{value: 15, timestamp: {nanos: 1e7, seconds: 1000}}],
-          startTimestamp: null
+          points: [{value: 15, timestamp: {nanos: 1e7, seconds: 1000}}]
         },
         {
           labelValues: LABEL_VALUES_400,
-          points: [{value: -8, timestamp: {nanos: 1e7, seconds: 1000}}],
-          startTimestamp: null
+          points: [{value: -8, timestamp: {nanos: 1e7, seconds: 1000}}]
         }
       ]);
     });
@@ -108,8 +105,7 @@ describe('GAUGE_INT64', () => {
       assert.deepStrictEqual(
           metric.timeseries, [{
             labelValues: LABEL_VALUES_200,
-            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
+            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}]
           }]);
       // create timeseries with same labels.
       const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
@@ -120,8 +116,7 @@ describe('GAUGE_INT64', () => {
       assert.deepStrictEqual(
           metric.timeseries, [{
             labelValues: LABEL_VALUES_200,
-            points: [{value: 40, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
+            points: [{value: 40, timestamp: {nanos: 1e7, seconds: 1000}}]
           }]);
     });
   });
@@ -136,8 +131,7 @@ describe('GAUGE_INT64', () => {
       assert.deepStrictEqual(
           metric.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
-            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
+            points: [{value: 10, timestamp: {nanos: 1e7, seconds: 1000}}]
           }]);
     });
     it('should return same timeseries for interchanged labels', () => {
@@ -169,8 +163,7 @@ describe('GAUGE_INT64', () => {
           metric.timeseries, [{
             labelValues:
                 [UNSET_LABEL_VALUE, UNSET_LABEL_VALUE, UNSET_LABEL_VALUE],
-            points: [{value: 200, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
+            points: [{value: 200, timestamp: {nanos: 1e7, seconds: 1000}}]
           }]);
     });
     it('should use previously created default timeseries', () => {
@@ -183,8 +176,7 @@ describe('GAUGE_INT64', () => {
       assert.deepStrictEqual(
           metric.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
-            points: [{value: 300, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
+            points: [{value: 300, timestamp: {nanos: 1e7, seconds: 1000}}]
           }]);
       // get default timeseries again.
       const point1 = instance.getDefaultTimeSeries();
@@ -196,8 +188,7 @@ describe('GAUGE_INT64', () => {
       assert.deepStrictEqual(
           metric.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
-            points: [{value: 700, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
+            points: [{value: 700, timestamp: {nanos: 1e7, seconds: 1000}}]
           }]);
     });
   });
@@ -278,7 +269,6 @@ describe('GAUGE_DOUBLE', () => {
           metric.timeseries, [{
             labelValues: LABEL_VALUES_200,
             points: [{value: 10.34, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
           }]);
       // add value and create new timeseries.
       point.add(5.12);
@@ -289,13 +279,11 @@ describe('GAUGE_DOUBLE', () => {
       assert.deepStrictEqual(metric.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
-          points: [{value: 15.46, timestamp: {nanos: 1e7, seconds: 1000}}],
-          startTimestamp: null
+          points: [{value: 15.46, timestamp: {nanos: 1e7, seconds: 1000}}]
         },
         {
           labelValues: LABEL_VALUES_400,
-          points: [{value: -8.3, timestamp: {nanos: 1e7, seconds: 1000}}],
-          startTimestamp: null
+          points: [{value: -8.3, timestamp: {nanos: 1e7, seconds: 1000}}]
         }
       ]);
     });
@@ -310,7 +298,6 @@ describe('GAUGE_DOUBLE', () => {
           metric.timeseries, [{
             labelValues: LABEL_VALUES_200,
             points: [{value: 12.1, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
           }]);
       // create timeseries with same labels.
       const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_200);
@@ -322,7 +309,6 @@ describe('GAUGE_DOUBLE', () => {
           metric.timeseries, [{
             labelValues: LABEL_VALUES_200,
             points: [{value: 42.28, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
           }]);
     });
   });
@@ -338,7 +324,6 @@ describe('GAUGE_DOUBLE', () => {
           metric.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
             points: [{value: 10.1, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
           }]);
     });
     it('should use previously created default timeseries', () => {
@@ -352,7 +337,6 @@ describe('GAUGE_DOUBLE', () => {
           metric.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
             points: [{value: 300.1, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
           }]);
       // get default timeseries again.
       const point1 = instance.getDefaultTimeSeries();
@@ -365,7 +349,6 @@ describe('GAUGE_DOUBLE', () => {
           metric.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
             points: [{value: 700.2, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
           }]);
     });
     it('should create same labelValues as labelKeys', () => {
@@ -386,7 +369,6 @@ describe('GAUGE_DOUBLE', () => {
             labelValues:
                 [UNSET_LABEL_VALUE, UNSET_LABEL_VALUE, UNSET_LABEL_VALUE],
             points: [{value: 10.1, timestamp: {nanos: 1e7, seconds: 1000}}],
-            startTimestamp: null
           }]);
     });
   });

--- a/packages/opencensus-core/test/test-utils.ts
+++ b/packages/opencensus-core/test/test-utils.ts
@@ -28,11 +28,14 @@ describe('hashLabelValues', () => {
   });
   it('should return hash for Value and null', () => {
     const hash = hashLabelValues(LABEL_VALUES_WITH_NULL);
-    assert.deepStrictEqual(hash, ',200');
+    assert.deepStrictEqual(hash, '200,');
   });
   it('should return same hash for interchanged labels', () => {
     assert.deepStrictEqual(
         hashLabelValues(LABEL_VALUES_1), hashLabelValues(LABEL_VALUES_2));
+  });
+  it('should return empty string for empty array', () => {
+    assert.deepStrictEqual(hashLabelValues([]), '');
   });
 });
 describe('initializeDefaultLabels', () => {

--- a/packages/opencensus-core/test/test-utils.ts
+++ b/packages/opencensus-core/test/test-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+import {LabelValue} from '../src/metrics/export/types';
+import {hashLabelValues, initializeDefaultLabels} from '../src/metrics/utils';
+
+describe('hashLabelValues', () => {
+  const LABEL_VALUES: LabelValue[] = [{value: '200'}];
+  const LABEL_VALUES_WITH_NULL: LabelValue[] = [{value: '200'}, {value: null}];
+  const LABEL_VALUES_1: LabelValue[] = [{value: '200'}, {value: '400'}];
+  const LABEL_VALUES_2: LabelValue[] = [{value: '400'}, {value: '200'}];
+  it('should return hash for single Value', () => {
+    const hash = hashLabelValues(LABEL_VALUES);
+    assert.deepStrictEqual(hash, '200');
+  });
+  it('should return hash for Value and null', () => {
+    const hash = hashLabelValues(LABEL_VALUES_WITH_NULL);
+    assert.deepStrictEqual(hash, ',200');
+  });
+  it('should return same hash for interchanged labels', () => {
+    assert.deepStrictEqual(
+        hashLabelValues(LABEL_VALUES_1), hashLabelValues(LABEL_VALUES_2));
+  });
+});
+describe('initializeDefaultLabels', () => {
+  const UNSET_VALUE: LabelValue = {value: null};
+  it('should return single default labels', () => {
+    const labelValues = initializeDefaultLabels(1);
+    assert.deepStrictEqual(labelValues, [UNSET_VALUE]);
+  });
+  it('should return multiple default labels', () => {
+    const labelValues = initializeDefaultLabels(3);
+    assert.deepStrictEqual(
+        labelValues, [UNSET_VALUE, UNSET_VALUE, UNSET_VALUE]);
+  });
+});


### PR DESCRIPTION
The Gauges API work is split into multiple PRs. This is the second installment.

Completed:
**- Add metric registry and validations util** (https://github.com/census-instrumentation/opencensus-node/pull/203)

Current:
- Add Double and INT64 Gauges APIs

Next in line:
- Plug-in gauges into the registry.
- Add derived gauges API and Plug-in gauges into the registry.
- Add Metric Collector interface.
- Register Metric-Registry with MetricProducer.