### PR TITLE
Add derived gauge API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 - Add Resource API.
 - Add Metrics API.
 - Remove support for `min`/`max` in the stats Distribution to make it compatible with Metrics.
-- Add Gauges (`DoubleGauge`, `LongGauge`) APIs.
 - Remove default prefix from [exporter-prometheus]. This could be a breaking change if you have Prometheus metrics from OpenCensus Prometheus exporter of previous versions, please point to the new metrics with no prefix instead.
+- Add Gauges (`DoubleGauge`, `LongGauge`, `DerivedDoubleGauge`, `DerivedLongGauge`) APIs.
 
 ## 0.0.7 - 2018-11-12
  **Contains API breaking changes for stats/metrics implementations**

--- a/packages/opencensus-core/package-lock.json
+++ b/packages/opencensus-core/package-lock.json
@@ -4115,7 +4115,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/packages/opencensus-core/src/metrics/gauges/derived-gauge.ts
+++ b/packages/opencensus-core/src/metrics/gauges/derived-gauge.ts
@@ -47,8 +47,8 @@ export interface ToValueInterface { getValue(): number; }
 type ValueExtractor = () => number;
 
 interface GaugeEntry {
-  labelValues: LabelValue[];
-  extractor: ValueExtractor;
+  readonly labelValues: LabelValue[];
+  readonly extractor: ValueExtractor;
 }
 
 /**
@@ -127,7 +127,9 @@ export class DerivedGauge implements types.Meter {
    * metrics are collected, meaning the reported value is up-to-date.
    *
    * @param {LabelValue[]} labelValues The list of the label values.
-   * @param obj The obj to get the size / length / value from.
+   * @param obj The obj to get the size or length or value from. If multiple
+   *    options are available, the value (ToValueInterface) takes precedence
+   *    first, followed by length and size. e.g value -> length -> size.
    */
   createTimeSeries(
       labelValues: LabelValue[],

--- a/packages/opencensus-core/src/metrics/gauges/derived-gauge.ts
+++ b/packages/opencensus-core/src/metrics/gauges/derived-gauge.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {validateArrayElementsNotNull, validateNotNull} from '../../common/validations';
+import {LabelKey, LabelValue, Metric, MetricDescriptor, MetricDescriptorType, TimeSeries} from '../export/types';
+import * as types from '../gauges/types';
+import {hashLabelValues} from '../utils';
+
+/**
+ * Interface for objects with "length()" method.
+ */
+export interface LengthMethodInterface { length(): number; }
+
+/**
+ * Interface for objects with "length" attribute (e.g. Array).
+ */
+export interface LengthAttributeInterface { length: number; }
+
+/**
+ * Interface for objects with "size" method.
+ */
+export interface SizeMethodInterface { size(): number; }
+
+/**
+ * Interface for objects with "size" attribute (e.g. Map, Set).
+ */
+export interface SizeAttributeInterface { size: number; }
+
+/**
+ * Interface for objects with "getValue" method.
+ */
+export interface ToValueInterface { getValue(): number; }
+
+type ValueExtractor = () => number;
+
+interface GaugeEntry {
+  labelValues: LabelValue[];
+  extractor: ValueExtractor;
+}
+
+/**
+ * DerivedGauge metric
+ */
+export class DerivedGauge implements types.Meter {
+  private metricDescriptor: MetricDescriptor;
+  private labelKeysLength: number;
+  private registeredPoints: Map<string, GaugeEntry> = new Map();
+  private extractor: ValueExtractor;
+
+  private static readonly LABEL_VALUE = 'labelValue';
+  private static readonly LABEL_VALUES = 'labelValues';
+  private static readonly OBJECT = 'obj';
+  private static readonly NUMBER = 'number';
+  private static readonly FUNCTION = 'function';
+  private static readonly ERROR_MESSAGE_INVALID_SIZE =
+      'Label Keys and Label Values don\'t have same size';
+  private static readonly ERROR_MESSAGE_DUPLICATE_TIME_SERIES =
+      'A different time series with the same labels already exists.';
+  private static readonly ERROR_MESSAGE_UNKNOWN_INTERFACE =
+      'Unknown interface/object type';
+
+  /**
+   * Constructs a new DerivedGauge instance.
+   *
+   * @param {string} name The name of the metric.
+   * @param {string} description The description of the metric.
+   * @param {string} unit The unit of the metric.
+   * @param {MetricDescriptorType} type The type of metric.
+   * @param {LabelKey[]} labelKeys The list of the label keys.
+   */
+  constructor(
+      name: string, description: string, unit: string,
+      type: MetricDescriptorType, labelKeys: LabelKey[]) {
+    this.metricDescriptor = {name, description, unit, type, labelKeys};
+    this.labelKeysLength = labelKeys.length;
+  }
+
+  // Checks if the specified collection is a LengthAttributeInterface.
+  // tslint:disable-next-line:no-any
+  protected static isLengthAttributeInterface(obj: any):
+      obj is LengthAttributeInterface {
+    return obj && typeof obj.length === DerivedGauge.NUMBER;
+  }
+
+  // Checks if the specified collection is a LengthMethodInterface.
+  // tslint:disable-next-line:no-any
+  protected static isLengthMethodInterface(obj: any):
+      obj is LengthMethodInterface {
+    return obj && typeof obj.length === DerivedGauge.FUNCTION;
+  }
+
+  // Checks if the specified collection is a SizeAttributeInterface.
+  // tslint:disable-next-line:no-any
+  protected static isSizeAttributeInterface(obj: any):
+      obj is SizeAttributeInterface {
+    return obj && typeof obj.size === DerivedGauge.NUMBER;
+  }
+
+  // Checks if the specified collection is a SizeMethodInterface.
+  // tslint:disable-next-line:no-any
+  protected static isSizeMethodInterface(obj: any): obj is SizeMethodInterface {
+    return obj && typeof obj.size === DerivedGauge.FUNCTION;
+  }
+
+  // Checks if the specified callbackFn is a ToValueInterface.
+  // tslint:disable-next-line:no-any
+  protected static isToValueInterface(obj: any): obj is ToValueInterface {
+    return obj && typeof obj.getValue === DerivedGauge.FUNCTION;
+  }
+
+  /**
+   * Creates a TimeSeries. The value of a single point in the TimeSeries is
+   * observed from a obj. The ValueExtractor is invoked whenever
+   * metrics are collected, meaning the reported value is up-to-date.
+   *
+   * @param {LabelValue[]} labelValues The list of the label values.
+   * @param obj The obj to get the size / length / value from.
+   */
+  createTimeSeries(
+      labelValues: LabelValue[],
+      obj:|LengthAttributeInterface|LengthMethodInterface|
+      SizeAttributeInterface|SizeMethodInterface|ToValueInterface): void {
+    validateArrayElementsNotNull(
+        validateNotNull(labelValues, DerivedGauge.LABEL_VALUES),
+        DerivedGauge.LABEL_VALUE);
+    validateNotNull(obj, DerivedGauge.OBJECT);
+
+    const hash = hashLabelValues(labelValues);
+    if (this.registeredPoints.has(hash)) {
+      throw new Error(DerivedGauge.ERROR_MESSAGE_DUPLICATE_TIME_SERIES);
+    }
+    if (this.labelKeysLength !== labelValues.length) {
+      throw new Error(DerivedGauge.ERROR_MESSAGE_INVALID_SIZE);
+    }
+
+    if (DerivedGauge.isToValueInterface(obj)) {
+      this.extractor = () => obj.getValue();
+    } else if (DerivedGauge.isLengthAttributeInterface(obj)) {
+      this.extractor = () => obj.length;
+    } else if (DerivedGauge.isLengthMethodInterface(obj)) {
+      this.extractor = () => obj.length();
+    } else if (DerivedGauge.isSizeAttributeInterface(obj)) {
+      this.extractor = () => obj.size;
+    } else if (DerivedGauge.isSizeMethodInterface(obj)) {
+      this.extractor = () => obj.size();
+    } else {
+      throw new Error(DerivedGauge.ERROR_MESSAGE_UNKNOWN_INTERFACE);
+    }
+
+    this.registeredPoints.set(hash, {labelValues, extractor: this.extractor});
+  }
+
+  /**
+   * Removes the TimeSeries from the gauge metric, if it is present. i.e.
+   * references to previous Point objects are invalid (not part of the
+   * metric).
+   *
+   * @param {LabelValue[]} labelValues The list of label values.
+   */
+  removeTimeSeries(labelValues: LabelValue[]): void {
+    validateNotNull(labelValues, DerivedGauge.LABEL_VALUES);
+    this.registeredPoints.delete(hashLabelValues(labelValues));
+  }
+
+  /**
+   * Removes all TimeSeries from the gauge metric. i.e. references to all
+   * previous Point objects are invalid (not part of the metric).
+   */
+  clear(): void {
+    this.registeredPoints.clear();
+  }
+
+  /**
+   * Provides a Metric with one or more TimeSeries.
+   *
+   * @returns {Metric} The Metric.
+   */
+  getMetric(): Metric {
+    if (this.registeredPoints.size === 0) {
+      return null;
+    }
+    const [seconds, nanos] = process.hrtime();
+    return {
+      descriptor: this.metricDescriptor,
+      timeseries: Array.from(
+          this.registeredPoints,
+          ([_, gaugeEntry]) => ({
+            labelValues: gaugeEntry.labelValues,
+            points: [
+              {value: gaugeEntry.extractor(), timestamp: {seconds, nanos}}
+            ]
+          } as TimeSeries))
+    };
+  }
+}

--- a/packages/opencensus-core/src/metrics/gauges/derived-gauge.ts
+++ b/packages/opencensus-core/src/metrics/gauges/derived-gauge.ts
@@ -22,27 +22,37 @@ import {hashLabelValues} from '../utils';
 /**
  * Interface for objects with "length()" method.
  */
-export interface LengthMethodInterface { length(): number; }
+export interface LengthMethodInterface {
+  length(): number;
+}
 
 /**
  * Interface for objects with "length" attribute (e.g. Array).
  */
-export interface LengthAttributeInterface { length: number; }
+export interface LengthAttributeInterface {
+  length: number;
+}
 
 /**
  * Interface for objects with "size" method.
  */
-export interface SizeMethodInterface { size(): number; }
+export interface SizeMethodInterface {
+  size(): number;
+}
 
 /**
  * Interface for objects with "size" attribute (e.g. Map, Set).
  */
-export interface SizeAttributeInterface { size: number; }
+export interface SizeAttributeInterface {
+  size: number;
+}
 
 /**
  * Interface for objects with "getValue" method.
  */
-export interface ToValueInterface { getValue(): number; }
+export interface ToValueInterface {
+  getValue(): number;
+}
 
 type ValueExtractor = () => number;
 
@@ -50,6 +60,9 @@ interface GaugeEntry {
   readonly labelValues: LabelValue[];
   readonly extractor: ValueExtractor;
 }
+
+export type AccessorInterface = LengthAttributeInterface|LengthMethodInterface|
+    SizeAttributeInterface|SizeMethodInterface|ToValueInterface;
 
 /**
  * DerivedGauge metric
@@ -131,10 +144,7 @@ export class DerivedGauge implements types.Meter {
    *    options are available, the value (ToValueInterface) takes precedence
    *    first, followed by length and size. e.g value -> length -> size.
    */
-  createTimeSeries(
-      labelValues: LabelValue[],
-      obj:|LengthAttributeInterface|LengthMethodInterface|
-      SizeAttributeInterface|SizeMethodInterface|ToValueInterface): void {
+  createTimeSeries(labelValues: LabelValue[], obj: AccessorInterface): void {
     validateArrayElementsNotNull(
         validateNotNull(labelValues, DerivedGauge.LABEL_VALUES),
         DerivedGauge.LABEL_VALUE);

--- a/packages/opencensus-core/test/test-derived-gauge.ts
+++ b/packages/opencensus-core/test/test-derived-gauge.ts
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {LabelKey, LabelValue, MetricDescriptorType} from '../src/metrics/export/types';
+import {DerivedGauge} from '../src/metrics/gauges/derived-gauge';
+
+const METRIC_NAME = 'metric-name';
+const METRIC_DESCRIPTION = 'metric-description';
+const UNIT = '1';
+const GAUGE_INT64 = MetricDescriptorType.GAUGE_INT64;
+const GAUGE_DOUBLE = MetricDescriptorType.GAUGE_DOUBLE;
+const LABEL_KEYS: LabelKey[] = [{key: 'code', description: 'desc'}];
+const LABEL_VALUES_200: LabelValue[] = [{value: '200'}];
+const LABEL_VALUES_400: LabelValue[] = [{value: '400'}];
+const LABEL_VALUES_EXRTA: LabelValue[] = [{value: '200'}, {value: '400'}];
+
+describe('DerivedGauge', () => {
+  const oldProcessHrtime = process.hrtime;
+  let instance: DerivedGauge;
+  const expectedMetricDescriptor = {
+    name: METRIC_NAME,
+    description: METRIC_DESCRIPTION,
+    unit: UNIT,
+    type: GAUGE_INT64,
+    labelKeys: LABEL_KEYS
+  };
+
+  beforeEach(() => {
+    instance = new DerivedGauge(
+        METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_INT64, LABEL_KEYS);
+    process.hrtime = () => [1000, 1e7];
+  });
+
+  afterEach(() => {
+    process.hrtime = oldProcessHrtime;
+  });
+
+  describe('createTimeSeries()', () => {
+    it('should throw an error when the labelvalues are null', () => {
+      assert.throws(() => {
+        instance.createTimeSeries(null, new Map());
+      }, /^Error: Missing mandatory labelValues parameter$/);
+    });
+    it('should throw an error when the labelValues elements contains NULL',
+       () => {
+         const LABEL_VALUES_WITH_NULL: LabelValue[] = [null];
+         assert.throws(() => {
+           instance.createTimeSeries(LABEL_VALUES_WITH_NULL, new Map());
+         }, /^Error: labelValue elements should not be a NULL$/);
+       });
+    it('should throw an error when the keys and values dont have same size',
+       () => {
+         assert.throws(() => {
+           instance.createTimeSeries(LABEL_VALUES_EXRTA, new Map());
+         }, /^Error: Label Keys and Label Values don't have same size$/);
+       });
+    it('should return a Metric', () => {
+      const map = new Map();
+      map.set('key', 'value');
+      instance.createTimeSeries(LABEL_VALUES_200, map);
+      map.set('key1', 'value1');
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 2, timestamp: {nanos: 1e7, seconds: 1000}}]
+          }]);
+      // add data in collection
+      map.set('key2', 'value2');
+      map.set('key3', 'value3');
+
+      // add new timeseries with length-method
+      const arr = new Array(5).fill('test');
+      instance.createTimeSeries(LABEL_VALUES_400, {
+        size: () => arr.length,
+      });
+
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 2);
+      assert.deepStrictEqual(metric.timeseries, [
+        {
+          labelValues: LABEL_VALUES_200,
+          points: [{value: 4, timestamp: {nanos: 1e7, seconds: 1000}}]
+        },
+        {
+          labelValues: LABEL_VALUES_400,
+          points: [{value: 5, timestamp: {nanos: 1e7, seconds: 1000}}]
+        }
+      ]);
+    });
+    it('should return a Metric (INT64) - custom object', () => {
+      class QueueManager {
+        getValue(): number {
+          return 45;
+        }
+      }
+      const obj = new QueueManager();
+      instance.createTimeSeries(LABEL_VALUES_200, obj);
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 45, timestamp: {nanos: 1e7, seconds: 1000}}]
+          }]);
+    });
+    it('should return a Metric (Double) - custom object', () => {
+      class QueueManager {
+        getValue(): number {
+          return 0.7;
+        }
+      }
+      const obj = new QueueManager();
+      const doubleInstance = new DerivedGauge(
+          METRIC_NAME, METRIC_DESCRIPTION, UNIT, GAUGE_DOUBLE, LABEL_KEYS);
+      doubleInstance.createTimeSeries(LABEL_VALUES_200, obj);
+      const metric = doubleInstance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, {
+        name: METRIC_NAME,
+        description: METRIC_DESCRIPTION,
+        unit: UNIT,
+        type: GAUGE_DOUBLE,
+        labelKeys: LABEL_KEYS
+      });
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 0.7, timestamp: {nanos: 1e7, seconds: 1000}}]
+          }]);
+    });
+    it('should throw an error when obj is null', () => {
+      assert.throws(() => {
+        instance.createTimeSeries(LABEL_VALUES_200, null);
+      }, /^Error: Missing mandatory obj parameter$/);
+    });
+    it('should not create same timeseries again', () => {
+      const map = new Map();
+      instance.createTimeSeries(LABEL_VALUES_200, map);
+      map.set('key', 'value');
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric.timeseries, [{
+            labelValues: LABEL_VALUES_200,
+            points: [{value: 1, timestamp: {nanos: 1e7, seconds: 1000}}]
+          }]);
+
+      // create timeseries with same labels.
+      assert.throws(() => {
+        instance.createTimeSeries(LABEL_VALUES_200, map);
+      }, /^Error: A different time series with the same labels already exists.$/);
+    });
+  });
+  describe('removeTimeSeries()', () => {
+    it('should throw an error when the labelvalues are null', () => {
+      assert.throws(() => {
+        instance.removeTimeSeries(null);
+      }, /^Error: Missing mandatory labelValues parameter$/);
+    });
+    it('should remove TimeSeries', () => {
+      const arr: string[] = [];
+      instance.createTimeSeries(LABEL_VALUES_200, arr);
+      arr.push('test');
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      instance.removeTimeSeries(LABEL_VALUES_200);
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+  describe('clear()', () => {
+    it('should clear all TimeSeries', () => {
+      const map = new Map();
+      instance.createTimeSeries(LABEL_VALUES_200, {
+        size: () => map.size,
+      });
+      map.set('key', 'value');
+
+      const arr: string[] = [];
+      instance.createTimeSeries(LABEL_VALUES_400, {
+        size: () => arr.length,
+      });
+      arr.push('test');
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric.descriptor, expectedMetricDescriptor);
+      assert.equal(metric.timeseries.length, 2);
+      instance.clear();
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+});


### PR DESCRIPTION
The Gauges API work is split into multiple PRs.

**Completed:**
- Add metric registry and validations util (#203)
- Add Double and INT64 Gauges APIs (#207)

**Current:**
- Add derived gauges API (This is a more convenient API when users want to define a gauge by executing extractor on object/collection. The ```ValueExtractor``` is invoked whenever metrics are collected, meaning the reported value is up-to-date).

**Next in line:**
- Plug-in gauges into the registry and register Metric-Registry with MetricProducer.