### PR TITLE
Converting `timestamp` and `duration` to the `number` type to follow Zipkin span types

### DIFF
--- a/packages/opencensus-exporter-zipkin/src/zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/src/zipkin.ts
@@ -31,8 +31,8 @@ interface TranslatedSpan {
   id: string;
   parentId?: string;
   kind: string;
-  timestamp: string;
-  duration: string;
+  timestamp: number;
+  duration: number;
   debug: boolean;
   shared: boolean;
   localEndpoint: {serviceName: string};
@@ -145,8 +145,8 @@ export class ZipkinTraceExporter implements Exporter {
       id: span.id,
       parentId: span.parentSpanId,
       kind: 'SERVER',
-      timestamp: (span.startTime.getTime() * 1000).toFixed(),
-      duration: (span.duration * 1000).toFixed(),
+      timestamp: span.startTime.getTime() * 1000,
+      duration: Math.round(span.duration * 1000),
       debug: true,
       shared: true,
       localEndpoint: {serviceName: this.serviceName}


### PR DESCRIPTION
In order to follow a `Zipkin` [Span](https://github.com/openzipkin/zipkin/blob/9b91acbaa3b90ad1c9e4ab62489db05dfd9edf74/zipkin/src/main/java/zipkin2/Span.java#L289) specification, I'm proposing to change `string` type to `number` for `timestamp` and `duration`.