### PR TITLE
Metrics: Fix DistributionValue buckets properties

### DIFF
--- a/packages/opencensus-core/src/stats/view.ts
+++ b/packages/opencensus-core/src/stats/view.ts
@@ -16,7 +16,7 @@
 
 import * as defaultLogger from '../common/console-logger';
 import * as loggerTypes from '../common/types';
-import {LabelValue, Metric, MetricDescriptor, MetricDescriptorType, Point, TimeSeries, Timestamp} from '../metrics/export/types';
+import {DistributionValue, LabelValue, Metric, MetricDescriptor, MetricDescriptorType, Point, TimeSeries, Timestamp} from '../metrics/export/types';
 
 import {BucketBoundaries} from './bucket-boundaries';
 import {MetricUtils} from './metric-utils';
@@ -254,10 +254,12 @@ export class BaseView implements View {
         sum,
         sumOfSquaredDeviation,
         bucketOptions: {explicit: {bounds: data.buckets}},
-        buckets: data.bucketCounts
-      };
+        // Bucket without an Exemplar.
+        buckets:
+            data.bucketCounts.map(bucketCount => ({count: bucketCount}))
+      } as DistributionValue;
     } else {
-      value = data.value;
+      value = data.value as number;
     }
     return {timestamp, value};
   }

--- a/packages/opencensus-core/test/test-metric-producer.ts
+++ b/packages/opencensus-core/test/test-metric-producer.ts
@@ -98,7 +98,7 @@ describe('Metric producer for stats', () => {
     points: [{
       value: {
         'bucketOptions': {'explicit': {'bounds': [2, 4, 6]}},
-        'buckets': [1, 2, 2, 0],
+        'buckets': [{count: 1}, {count: 2}, {count: 2}, {count: 0}],
         'count': 5,
         'sum': 16.099999999999998,
         'sumOfSquaredDeviation': 10.427999999999997

--- a/packages/opencensus-core/test/test-view.ts
+++ b/packages/opencensus-core/test/test-view.ts
@@ -292,7 +292,7 @@ describe('BaseView', () => {
         assert.notEqual(typeof value, 'number');
         assert.deepStrictEqual((value as DistributionValue), {
           bucketOptions: {explicit: {bounds: buckets}},
-          buckets: [1, 2, 2, 0],
+          buckets: [{count: 1}, {count: 2}, {count: 2}, {count: 0}],
           count: 5,
           sum: total,
           sumOfSquaredDeviation: 10.427999999999997
@@ -334,7 +334,7 @@ describe('BaseView', () => {
             assert.notEqual(typeof value, 'number');
             assert.deepStrictEqual((value as DistributionValue), {
               bucketOptions: {explicit: {bounds: buckets}},
-              buckets: [1, 2, 2, 0],
+              buckets: [{count: 1}, {count: 2}, {count: 2}, {count: 0}],
               count: 5,
               sum: total,
               sumOfSquaredDeviation: 10.427999999999997
@@ -353,7 +353,7 @@ describe('BaseView', () => {
             assert.notEqual(typeof value, 'number');
             assert.deepStrictEqual((value as DistributionValue), {
               bucketOptions: {explicit: {bounds: buckets}},
-              buckets: [1, 2, 2, 0],
+              buckets: [{count: 1}, {count: 2}, {count: 2}, {count: 0}],
               count: 5,
               sum: total,
               sumOfSquaredDeviation: 10.427999999999997


### PR DESCRIPTION
[DistributionValue -> Bucket](https://github.com/census-instrumentation/opencensus-proto/blob/master/src/opencensus/proto/metrics/v1/metrics.proto#L237-L249) has two properties ```count``` and ```exemplar``` in the metrics data model. This PR will honor these properties and assign values as per proto definition.