### PR TITLE
Add start method to StatsEventListener

### DIFF
--- a/packages/opencensus-core/src/exporters/console-exporter.ts
+++ b/packages/opencensus-core/src/exporters/console-exporter.ts
@@ -96,4 +96,12 @@ export class ConsoleStatsExporter implements types.StatsEventListener {
   onRecord(views: View[], measurement: Measurement) {
     console.log(`Measurement recorded: ${measurement.measure.name}`);
   }
+
+  /**
+   * Starts the Console exporter that polls Metric from Metrics library and
+   * shows in the log console..
+   */
+  start(): void {
+    // TODO(mayurkale): dependency with PR#253.
+  }
 }

--- a/packages/opencensus-core/src/exporters/types.ts
+++ b/packages/opencensus-core/src/exporters/types.ts
@@ -34,15 +34,23 @@ export interface Exporter extends modelTypes.SpanEventListener {
 export interface StatsEventListener {
   /**
    * Is called whenever a new view is registered
+   * @deprecated since version 0.0.9 - use {@link start} instead
    * @param view The registered view
    */
   onRegisterView(view: View): void;
   /**
    * Is called whenever a new measurement is recorded.
+   * @deprecated since version 0.0.9 - use {@link start} instead
    * @param views The views related to the measurement
    * @param measurement The recorded measurement
    */
   onRecord(views: View[], measurement: Measurement): void;
+
+  /**
+   * Starts the exporter that polls Metric from Metrics library and send
+   * batched data to backend.
+   */
+  start(): void;
 }
 
 export type ExporterConfig = configTypes.BufferConfig;

--- a/packages/opencensus-core/src/stats/stats.ts
+++ b/packages/opencensus-core/src/stats/stats.ts
@@ -90,6 +90,10 @@ export class Stats {
         exporter.onRegisterView(view);
       }
     }
+
+    // dependency with PR#253 and once start method is implemented in all stats
+    // exporters
+    // exporter.start();
   }
 
   /**

--- a/packages/opencensus-core/test/test-stats.ts
+++ b/packages/opencensus-core/test/test-stats.ts
@@ -30,6 +30,10 @@ class TestExporter implements StatsEventListener {
     this.recordedMeasurements.push(measurement);
   }
 
+  start(): void {
+    // TODO(mayurkale): dependency with PR#253.
+  }
+
   clean() {
     this.registeredViews = [];
     this.recordedMeasurements = [];

--- a/packages/opencensus-exporter-prometheus/src/prometheus-stats.ts
+++ b/packages/opencensus-exporter-prometheus/src/prometheus-stats.ts
@@ -85,6 +85,15 @@ export class PrometheusStatsExporter implements StatsEventListener {
   }
 
   /**
+   * Starts the Prometheus exporter that polls Metric from Metrics library and
+   * send batched data to backend.
+   */
+  start(): void {
+    // TODO(mayurkale): add setInterval here to poll Metric, transform and send
+    // // it to backend (dependency with PR#253).
+  }
+
+  /**
    * Register or get a metric in Prometheus
    * @param view View will be used to register the metric
    * @param tags Optional, used only for histogram metric

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -98,6 +98,15 @@ export class StackdriverStatsExporter implements StatsEventListener {
   }
 
   /**
+   * Starts the Stackdriver exporter that polls Metric from Metrics library and
+   * send batched data to backend.
+   */
+  start(): void {
+    // TODO(mayurkale): add setInterval here to poll Metric, transform and send
+    // // it to backend (dependency with PR#253).
+  }
+
+  /**
    * Clear the interval timer to stop uploading metrics. It should be called
    * whenever the exporter is not needed anymore.
    */

--- a/packages/opencensus-exporter-zpages/src/zpages.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages.ts
@@ -127,6 +127,10 @@ export class ZpagesExporter implements Exporter, StatsEventListener {
     });
   }
 
+  start(): void {
+    // TODO(mayurkale): dependency with PR#253.
+  }
+
   /**
    * Send a trace to traces array
    * @param trace the rootSpan to be sent to the array list


### PR DESCRIPTION
With the current approach, we execute below apis for each request of new view and measurement.
```onRegisterView``` - whenever a new view is registered and 
```onRecord``` - whenever a new measurement is recorded. 

**New approach:** The plan is to start exporter that polls Metric from Metrics library (which is collection of metric from stats and gauges apis) and send **batched** data to backend. 

_Once the new approach is ready I will deprecate and remove ```onRegisterView```  and  ```onRecord``` apis._