### PR TITLE
Simplify Logger interface, remove silly, make level optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Add Gauges (`DoubleGauge`, `LongGauge`, `DerivedDoubleGauge`, `DerivedLongGauge`) APIs.
 - Add support for supplying instrumentation configuration via tracing option. Option argument added to instrumentation interface.
 - Add ignoreIncomingPaths and ignoreOutgoingUrls support to the http and https tracing instrumentations.
+- Modify `Logger` interface: `level` made optional, `silly` removed.
 
 ## 0.0.8 - 2018-12-14
  **Contains API breaking changes for stats/metrics implementations**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Add Gauges (`DoubleGauge`, `LongGauge`, `DerivedDoubleGauge`, `DerivedLongGauge`) APIs.
 - Add support for supplying instrumentation configuration via tracing option. Option argument added to instrumentation interface.
 - Add ignoreIncomingPaths and ignoreOutgoingUrls support to the http and https tracing instrumentations.
+
+ **Contains API breaking changes for trace implementations**
+
 - Modify `Logger` interface: `level` made optional, `silly` removed.
 
 ## 0.0.8 - 2018-12-14

--- a/packages/opencensus-core/src/common/console-logger.ts
+++ b/packages/opencensus-core/src/common/console-logger.ts
@@ -24,7 +24,7 @@ const logDriver = require('log-driver');
  */
 export class ConsoleLogger implements types.Logger {
   private logger: typeof logDriver;
-  static LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
+  static LEVELS = ['silent', 'error', 'warn', 'info', 'debug'];
   level: string;
 
   /**
@@ -88,16 +88,6 @@ export class ConsoleLogger implements types.Logger {
   // tslint:disable-next-line:no-any
   debug(message: any, ...args: any[]): void {
     this.logger.debug(util.format(message, ...args));
-  }
-
-  /**
-   * Logger silly function.
-   * @param message menssage silly to log in console
-   * @param args arguments to log in console
-   */
-  // tslint:disable-next-line:no-any
-  silly(message: any, ...args: any[]): void {
-    this.logger.silly(util.format(message, ...args));
   }
 }
 

--- a/packages/opencensus-core/src/common/types.ts
+++ b/packages/opencensus-core/src/common/types.ts
@@ -19,12 +19,13 @@ export type LogFunction = (message: any, ...args: any[]) => void;
 
 /** Defines an logger interface. */
 export interface Logger {
-  level: string;
+  /** Logger verbosity level. If omitted, `debug` level is assumed. */
+  level?: string;
+
   error: LogFunction;
   warn: LogFunction;
   info: LogFunction;
   debug: LogFunction;
-  silly: LogFunction;
 }
 
 /** Defines an logger options interface. */

--- a/packages/opencensus-core/test/test-console-logger.ts
+++ b/packages/opencensus-core/test/test-console-logger.ts
@@ -19,7 +19,7 @@ import * as logger from '../src/common/console-logger';
 import {ConsoleLogger} from '../src/common/console-logger';
 
 
-const LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
+const LEVELS = ['silent', 'error', 'warn', 'info', 'debug'];
 let consoleTxt = '';
 
 // TODO: Review test cases: Maybe testing the info log level is sufficient
@@ -86,15 +86,6 @@ describe('ConsoleLogger', () => {
 
       assert.equal(validateString, -1);
     });
-
-    it('should not log silly', () => {
-      consoleTxt = '';
-      consoleLogger.silly('silly test logger');
-      unhookIntercept();
-      const validateString = consoleTxt.indexOf('silly');
-
-      assert.equal(validateString, -1);
-    });
   });
 
   /** Should disable logger  */
@@ -135,15 +126,6 @@ describe('ConsoleLogger', () => {
       consoleLogger.debug('debug test logger');
       unhookIntercept();
       const validateString = consoleTxt.indexOf('debug');
-
-      assert.equal(validateString, -1);
-    });
-
-    it('should not log silly', () => {
-      consoleTxt = '';
-      consoleLogger.silly('silly test logger');
-      unhookIntercept();
-      const validateString = consoleTxt.indexOf('silly');
 
       assert.equal(validateString, -1);
     });

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -44,8 +44,6 @@ class ExporterTestLogger implements Logger {
   warn(...args: any[]) {}
   // tslint:disable-next-line:no-any
   info(...args: any[]) {}
-  // tslint:disable-next-line:no-any
-  silly(...args: any[]) {}
 }
 
 describe('Stackdriver Stats Exporter', function() {


### PR DESCRIPTION
By removing `silly` and making the `level` attribute optional (and defaulted to `debug`) then the `console` interface itself will implement `Logger`. See [this TS playground](http://www.typescriptlang.org/play/#src=export%20type%20LogFunction%20%3D%20(message%3A%20any%2C%20...args%3A%20any%5B%5D)%20%3D%3E%20void%3B%0D%0A%0D%0A%2F**%20Defines%20an%20logger%20interface.%20*%2F%0D%0Aexport%20interface%20Logger%20%7B%0D%0A%20%20level%3F%3A%20string%3B%0D%0A%20%20error%3A%20LogFunction%3B%0D%0A%20%20warn%3A%20LogFunction%3B%0D%0A%20%20info%3A%20LogFunction%3B%0D%0A%20%20debug%3A%20LogFunction%3B%20%20%0D%0A%7D%0D%0A%0D%0Aconst%20logger%3A%20Logger%20%3D%20console%3B)

This will be useful for `opencensus-web` where a major goal is small code size for web clients, so being able to just use `console` itself as a logger cuts down on code size.

This does seem like a relatively minor breaking change though.