### PR TITLE
Add validation for tagkey & tagvalue. Fix issue #268

### DIFF
--- a/packages/opencensus-core/src/stats/view.ts
+++ b/packages/opencensus-core/src/stats/view.ts
@@ -73,12 +73,10 @@ export class BaseView implements View {
   /** An object to log information to */
   // @ts-ignore
   private logger: loggerTypes.Logger;
-
-  
   /**
-   * A list of tag keys that represents the possible column labels
+   * Max Length of a TagKey
    */
-    private readonly MAX_LENGTH: number = 256;
+  private readonly MAX_LENGTH: number = 256;
   /**
    * Creates a new View instance. This constructor is used by Stats. User should
    * prefer using Stats.createView() instead.

--- a/packages/opencensus-core/src/stats/view.ts
+++ b/packages/opencensus-core/src/stats/view.ts
@@ -22,6 +22,7 @@ import {BucketBoundaries} from './bucket-boundaries';
 import {MetricUtils} from './metric-utils';
 import {Recorder} from './recorder';
 import {AggregationData, AggregationType, Measure, Measurement, Tags, View} from './types';
+import { logger } from '..';
 
 const RECORD_SEPARATOR = String.fromCharCode(30);
 const UNIT_SEPARATOR = String.fromCharCode(31);
@@ -158,7 +159,11 @@ export class BaseView implements View {
    * @param tags The tags to be checked
    */
   private invalidTags(tags: Tags): boolean {
-    return this.invalidPrintableCharacters(tags) || this.invalidLength(tags);
+    const result: boolean =  this.invalidPrintableCharacters(tags) || this.invalidLength(tags);
+    if(result) {
+      this.logger.warn('Unable to create tagkey/tagvalue with the specified tags.');
+    }
+    return result;
   }
 
   /**

--- a/packages/opencensus-core/src/stats/view.ts
+++ b/packages/opencensus-core/src/stats/view.ts
@@ -74,6 +74,11 @@ export class BaseView implements View {
   // @ts-ignore
   private logger: loggerTypes.Logger;
 
+  
+  /**
+   * A list of tag keys that represents the possible column labels
+   */
+    private readonly MAX_LENGTH: number = 256;
   /**
    * Creates a new View instance. This constructor is used by Stats. User should
    * prefer using Stats.createView() instead.
@@ -151,15 +156,32 @@ export class BaseView implements View {
   }
 
   /**
-   * Checks if tag keys and values have only printable characters.
+   * Checks if tag keys and values are valid.
    * @param tags The tags to be checked
    */
   private invalidTags(tags: Tags): boolean {
+    return this.invalidPrintableCharacters(tags) || this.invalidLength(tags);
+  }
+
+  /**
+   * Checks if tag keys and values have only printable characters.
+   * @param tags The tags to be checked
+   */
+  private invalidPrintableCharacters(tags: Tags): boolean {
     return Object.keys(tags).some(tagKey => {
       return invalidString.test(tagKey) || invalidString.test(tags[tagKey]);
     });
   }
 
+  /**
+   * Checks if length of tagkey is greater than 0 & less than 256.
+   * @param tags The tags to be checked
+   */
+  private invalidLength(tags: Tags): boolean {
+    return Object.keys(tags).some(tagKey => {
+      return tagKey.length <= 0 || tagKey.length >= this.MAX_LENGTH;
+    });
+  }
   /**
    * Creates an empty aggregation data for a given tags.
    * @param tags The tags for that aggregation data

--- a/packages/opencensus-core/src/stats/view.ts
+++ b/packages/opencensus-core/src/stats/view.ts
@@ -158,9 +158,11 @@ export class BaseView implements View {
    * @param tags The tags to be checked
    */
   private invalidTags(tags: Tags): boolean {
-    const result: boolean =  this.invalidPrintableCharacters(tags) || this.invalidLength(tags);
-    if(result) {
-      this.logger.warn('Unable to create tagkey/tagvalue with the specified tags.');
+    const result: boolean =
+        this.invalidPrintableCharacters(tags) || this.invalidLength(tags);
+    if (result) {
+      this.logger.warn(
+          'Unable to create tagkey/tagvalue with the specified tags.');
     }
     return result;
   }

--- a/packages/opencensus-core/src/stats/view.ts
+++ b/packages/opencensus-core/src/stats/view.ts
@@ -22,7 +22,6 @@ import {BucketBoundaries} from './bucket-boundaries';
 import {MetricUtils} from './metric-utils';
 import {Recorder} from './recorder';
 import {AggregationData, AggregationType, Measure, Measurement, Tags, View} from './types';
-import { logger } from '..';
 
 const RECORD_SEPARATOR = String.fromCharCode(30);
 const UNIT_SEPARATOR = String.fromCharCode(31);

--- a/packages/opencensus-core/test/test-view.ts
+++ b/packages/opencensus-core/test/test-view.ts
@@ -192,6 +192,28 @@ describe('BaseView', () => {
          view.recordMeasurement(measurement);
          assert.ok(!view.getSnapshot(measurement.tags));
        });
+
+    it('should not record a measurement when a tag key is longer than 255 characters', () => {
+        const tagkey = 'NHHcUMQtGf7kFjSvy86aZZMIp5zx1aoRH4FFjOJnU4AvwVmAD5GPcmQmwnP6NuWx5NmHdts3xgqyAjn57i9Yc5mak22duPlf7JehY3bMcjbacocAEC1TepDCEt3ihzSOuI9mRvKL4vop7AZ3Uahge6OL3ogIJOhulRlIkK2qeT2avh8FeoGcnNV3O6yKHNovvUoUf01vxnwhG3ruPTh6j2E8G51q1tGAbSUd0UE0Sf2KceRQTr28GOp8zGlIj6lpqJXg';
+        const measurement = {
+          measure,
+          tags: {[tagkey]: 'testValue'},
+          value: 10
+        };
+        view.recordMeasurement(measurement);
+        assert.ok(!view.getSnapshot(measurement.tags));
+    });
+
+      it('should not record a measurement when tag key is 0 character long', () => {
+          const tagkey = '';
+          const measurement = {
+            measure,
+            tags: {[tagkey]: 'testValue'},
+            value: 10
+          };
+          view.recordMeasurement(measurement);
+          assert.ok(!view.getSnapshot(measurement.tags));
+      });
   });
 
   describe('getMetric()', () => {

--- a/packages/opencensus-core/test/test-view.ts
+++ b/packages/opencensus-core/test/test-view.ts
@@ -193,27 +193,30 @@ describe('BaseView', () => {
          assert.ok(!view.getSnapshot(measurement.tags));
        });
 
-    it('should not record a measurement when a tag key is longer than 255 characters', () => {
-        const tagkey = 'NHHcUMQtGf7kFjSvy86aZZMIp5zx1aoRH4FFjOJnU4AvwVmAD5GPcmQmwnP6NuWx5NmHdts3xgqyAjn57i9Yc5mak22duPlf7JehY3bMcjbacocAEC1TepDCEt3ihzSOuI9mRvKL4vop7AZ3Uahge6OL3ogIJOhulRlIkK2qeT2avh8FeoGcnNV3O6yKHNovvUoUf01vxnwhG3ruPTh6j2E8G51q1tGAbSUd0UE0Sf2KceRQTr28GOp8zGlIj6lpqJXg';
-        const measurement = {
-          measure,
-          tags: {[tagkey]: 'testValue'},
-          value: 10
-        };
-        view.recordMeasurement(measurement);
-        assert.ok(!view.getSnapshot(measurement.tags));
-    });
+    it('should not record a measurement when a tag key is longer than 255 characters',
+       () => {
+         const tagkey =
+             'NHHcUMQtGf7kFjSvy86aZZMIp5zx1aoRH4FFjOJnU4AvwVmAD5GPcmQmwnP6NuWx5NmHdts3xgqyAjn57i9Yc5mak22duPlf7JehY3bMcjbacocAEC1TepDCEt3ihzSOuI9mRvKL4vop7AZ3Uahge6OL3ogIJOhulRlIkK2qeT2avh8FeoGcnNV3O6yKHNovvUoUf01vxnwhG3ruPTh6j2E8G51q1tGAbSUd0UE0Sf2KceRQTr28GOp8zGlIj6lpqJXg';
+         const measurement = {
+           measure,
+           tags: {[tagkey]: 'testValue'},
+           value: 10
+         };
+         view.recordMeasurement(measurement);
+         assert.ok(!view.getSnapshot(measurement.tags));
+       });
 
-      it('should not record a measurement when tag key is 0 character long', () => {
-          const tagkey = '';
-          const measurement = {
-            measure,
-            tags: {[tagkey]: 'testValue'},
-            value: 10
-          };
-          view.recordMeasurement(measurement);
-          assert.ok(!view.getSnapshot(measurement.tags));
-      });
+    it('should not record a measurement when tag key is 0 character long',
+       () => {
+         const tagkey = '';
+         const measurement = {
+           measure,
+           tags: {[tagkey]: 'testValue'},
+           value: 10
+         };
+         view.recordMeasurement(measurement);
+         assert.ok(!view.getSnapshot(measurement.tags));
+       });
   });
 
   describe('getMetric()', () => {

--- a/packages/opencensus-core/test/test-view.ts
+++ b/packages/opencensus-core/test/test-view.ts
@@ -195,8 +195,7 @@ describe('BaseView', () => {
 
     it('should not record a measurement when a tag key is longer than 255 characters',
        () => {
-         const tagkey =
-             'NHHcUMQtGf7kFjSvy86aZZMIp5zx1aoRH4FFjOJnU4AvwVmAD5GPcmQmwnP6NuWx5NmHdts3xgqyAjn57i9Yc5mak22duPlf7JehY3bMcjbacocAEC1TepDCEt3ihzSOuI9mRvKL4vop7AZ3Uahge6OL3ogIJOhulRlIkK2qeT2avh8FeoGcnNV3O6yKHNovvUoUf01vxnwhG3ruPTh6j2E8G51q1tGAbSUd0UE0Sf2KceRQTr28GOp8zGlIj6lpqJXg';
+         const tagkey = 'a'.repeat(256);
          const measurement = {
            measure,
            tags: {[tagkey]: 'testValue'},


### PR DESCRIPTION
Validates tagkey & tagvalues as per the specification given in https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagMap.md#tagkey
ran `npm test` & `npm run complie` with no errors.