### PR TITLE
WIP: Export global singleton stats and register MetricProducerForStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,24 @@ All notable changes to this project will be documented in this file.
 - Add support for supplying instrumentation configuration via tracing option. Option argument added to instrumentation interface.
 - Add ignoreIncomingPaths and ignoreOutgoingUrls support to the http and https tracing instrumentations.
 
- **Contains API breaking changes for trace implementations**
+ **This release has multiple breaking changes. Please test your code accordingly after upgrading.**
 
 - Modify `Logger` interface: `level` made optional, `silly` removed.
+- The ```new Stats()``` has been deprecated on Stats class. The global singleton ```stats``` object should be used instead.
+
+##### Old code
+```js
+const { Stats } = require("@opencensus/core");
+const stats = new Stats();
+stats.createView(...);
+```
+
+##### New code
+```js
+// Get the global singleton stats object
+const { stats } = require("@opencensus/core");
+stats.createView(...);
+```
 
 ## 0.0.8 - 2018-12-14
  **Contains API breaking changes for stats/metrics implementations**

--- a/packages/opencensus-core/src/index.ts
+++ b/packages/opencensus-core/src/index.ts
@@ -66,7 +66,6 @@ export * from './exporters/console-exporter';
 // STATS CLASSES
 
 // classes
-export * from './stats/stats';
 export * from './stats/view';
 export * from './stats/recorder';
 export * from './stats/bucket-boundaries';
@@ -90,3 +89,8 @@ export * from './metrics/metric-registry';
 // GAUGES CLASSES
 export * from './metrics/gauges/derived-gauge';
 export * from './metrics/gauges/gauge';
+
+// Stats singleton instance
+import {Stats} from './stats/stats';
+const stats = Stats.instance;
+export {stats};

--- a/packages/opencensus-core/src/stats/stats.ts
+++ b/packages/opencensus-core/src/stats/stats.ts
@@ -17,7 +17,10 @@
 import * as defaultLogger from '../common/console-logger';
 import * as loggerTypes from '../common/types';
 import {StatsEventListener} from '../exporters/types';
+import {MetricProducer} from '../metrics/export/types';
 import {Metric} from '../metrics/export/types';
+import {Metrics} from '../metrics/metrics';
+import {MetricProducerForStats} from './metric-producer';
 
 import {AggregationType, Measure, Measurement, MeasureType, MeasureUnit, View} from './types';
 import {BaseView} from './view';
@@ -29,6 +32,8 @@ export class Stats {
   private registeredViews: {[key: string]: View[]} = {};
   /** An object to log information to */
   private logger: loggerTypes.Logger;
+  /** Singleton instance */
+  private static singletonInstance: Stats;
 
   /**
    * Creates stats
@@ -37,14 +42,17 @@ export class Stats {
   constructor(logger = defaultLogger) {
     this.logger = logger.logger();
 
-    // TODO (mayurkale): Decide how to inject MetricProducerForStats.
-    // It should be something like below, but looks like not the right place.
-
     // Create a new MetricProducerForStats and register it to
     // MetricProducerManager when Stats is initialized.
-    // const metricProducer: MetricProducer = new MetricProducerForStats(this);
-    // Metrics.getMetricProducerManager().add(metricProducer);
+    const metricProducer: MetricProducer = new MetricProducerForStats(this);
+    Metrics.getMetricProducerManager().add(metricProducer);
   }
+
+  /** Gets the stats instance. */
+  static get instance(): Stats {
+    return this.singletonInstance || (this.singletonInstance = new this());
+  }
+
 
   /**
    * Registers a view to listen to new measurements in its measure. Prefer using

--- a/packages/opencensus-core/src/stats/stats.ts
+++ b/packages/opencensus-core/src/stats/stats.ts
@@ -53,7 +53,6 @@ export class Stats {
     return this.singletonInstance || (this.singletonInstance = new this());
   }
 
-
   /**
    * Registers a view to listen to new measurements in its measure. Prefer using
    * the method createView() that creates an already registered view.

--- a/packages/opencensus-core/test/test-metric-producer.ts
+++ b/packages/opencensus-core/test/test-metric-producer.ts
@@ -15,12 +15,11 @@
  */
 
 import * as assert from 'assert';
-import {AggregationType, Measurement, MeasureUnit, Stats, Tags, View} from '../src';
+import {AggregationType, Measurement, MeasureUnit, stats, Tags, View} from '../src';
 import {LabelKey, LabelValue, MetricDescriptorType} from '../src/metrics/export/types';
 import {MetricProducerForStats} from '../src/stats/metric-producer';
 
 describe('Metric producer for stats', () => {
-  const stats = new Stats();
   const metricProducerForStats = new MetricProducerForStats(stats);
 
   // constants for view name

--- a/packages/opencensus-core/test/test-stats.ts
+++ b/packages/opencensus-core/test/test-stats.ts
@@ -15,7 +15,9 @@
  */
 
 import * as assert from 'assert';
-import {BaseView, Stats, StatsEventListener} from '../src';
+
+import {BaseView, StatsEventListener} from '../src';
+import {Stats} from '../src/stats/stats';
 import {AggregationType, LastValueData, Measure, Measurement, MeasureType, MeasureUnit, View} from '../src/stats/types';
 
 class TestExporter implements StatsEventListener {
@@ -53,6 +55,23 @@ describe('Stats', () => {
   const measureName = 'testMeasureDouble';
   const measureUnit = MeasureUnit.UNIT;
   const description = 'test description';
+
+  /** Should create a Stats instance */
+  describe('new Stats()', () => {
+    it('should create a Stats instance', () => {
+      const stats = new Stats();
+      assert.ok(stats instanceof Stats);
+    });
+  });
+
+
+  /** Should get the singleton stats instance. */
+  describe('static get instance()', () => {
+    it('should get the singleton stats instance', () => {
+      const stats = Stats.instance;
+      assert.ok(stats instanceof Stats);
+    });
+  });
 
   describe('createMeasureDouble()', () => {
     it('should create a measure of type double', () => {

--- a/packages/opencensus-core/test/test-stats.ts
+++ b/packages/opencensus-core/test/test-stats.ts
@@ -15,7 +15,6 @@
  */
 
 import * as assert from 'assert';
-
 import {BaseView, StatsEventListener} from '../src';
 import {Stats} from '../src/stats/stats';
 import {AggregationType, LastValueData, Measure, Measurement, MeasureType, MeasureUnit, View} from '../src/stats/types';

--- a/packages/opencensus-exporter-prometheus/test/test-prometheus-stats.ts
+++ b/packages/opencensus-exporter-prometheus/test/test-prometheus-stats.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AggregationType, Measure, MeasureUnit, Stats} from '@opencensus/core';
+import {AggregationType, Measure, MeasureUnit, stats} from '@opencensus/core';
 import * as assert from 'assert';
 import * as http from 'http';
 import {PrometheusStatsExporter} from '../src/';
@@ -26,10 +26,8 @@ describe('Prometheus Stats Exporter', () => {
   const tagKeys = Object.keys(tags);
   let exporter: PrometheusStatsExporter;
   let measure: Measure;
-  let stats: Stats;
 
   beforeEach((done) => {
-    stats = new Stats();
     measure = stats.createMeasureDouble('testMeasureDouble', MeasureUnit.UNIT);
     exporter = new PrometheusStatsExporter(options);
     stats.registerExporter(exporter);
@@ -195,10 +193,8 @@ describe('Prometheus Stats Exporter with prefix option', () => {
   const tagKeys = Object.keys(tags);
   let exporter: PrometheusStatsExporter;
   let measure: Measure;
-  let stats: Stats;
 
   beforeEach((done) => {
-    stats = new Stats();
     measure = stats.createMeasureDouble('testMeasureDouble', MeasureUnit.UNIT);
     exporter = new PrometheusStatsExporter(options);
     stats.registerExporter(exporter);

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AggregationType, BaseView, logger, Logger, Measurement, MeasureUnit, Stats} from '@opencensus/core';
+import {AggregationType, BaseView, logger, Logger, Measurement, MeasureUnit, stats} from '@opencensus/core';
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as nock from 'nock';
@@ -60,7 +60,6 @@ describe('Stackdriver Stats Exporter', function() {
   const exporterTestLogger = new ExporterTestLogger();
   let exporterOptions: StackdriverExporterOptions;
   let exporter: StackdriverStatsExporter;
-  const stats = new Stats();
 
   const tags = {tagKey1: 'valueKey1'};
   const tagKeys = Object.keys(tags);

--- a/packages/opencensus-exporter-zpages/test/test-zpages.ts
+++ b/packages/opencensus-exporter-zpages/test/test-zpages.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AggregationType, CountData, DistributionData, Measure, Measurement, MeasureUnit, RootSpan, Stats, SumData, Tags, TracerConfig} from '@opencensus/core';
+import {AggregationType, CountData, DistributionData, Measure, Measurement, MeasureUnit, RootSpan, SumData, Tags, TracerConfig} from '@opencensus/core';
 import * as assert from 'assert';
 import axios from 'axios';
 import * as http from 'http';
@@ -243,20 +243,13 @@ describe('Zpages Exporter', () => {
       return tags[tagKey];
     });
     let zpages: ZpagesExporter;
-    let stats: Stats;
     let measure: Measure;
     let zpagesData: StatsViewData;
     let measurement: Measurement;
     let measurement2: Measurement;
 
     beforeEach((done) => {
-      stats = new Stats();
       zpages = new ZpagesExporter(options);
-      stats.registerExporter(zpages);
-      measure = stats.createMeasureDouble(
-          'testMeasureDouble', MeasureUnit.UNIT, 'A test measure');
-      measurement = {measure, tags, value: 22};
-      measurement2 = {measure, tags, value: 11};
       zpages.startServer(done);
     });
 
@@ -265,7 +258,15 @@ describe('Zpages Exporter', () => {
     });
 
     describe('with COUNT aggregation type', () => {
+      /** Creating here because stats is a singleton */
+      const {stats} = require('@opencensus/core');
+      measure = stats.createMeasureDouble(
+          'testMeasureDouble', MeasureUnit.UNIT, 'A test measure');
+      measurement = {measure, tags, value: 22};
+      measurement2 = {measure, tags, value: 11};
+
       it('should get view information', async () => {
+        stats.registerExporter(zpages);
         stats.createView(
             'test/CountView', measure, AggregationType.COUNT, tagKeys,
             'A count test', null);
@@ -280,6 +281,7 @@ describe('Zpages Exporter', () => {
       });
 
       it('should get stats for view', async () => {
+        stats.registerExporter(zpages);
         stats.createView(
             'test/CountView', measure, AggregationType.COUNT, tagKeys,
             'A count test', null);
@@ -298,6 +300,12 @@ describe('Zpages Exporter', () => {
     });
 
     describe('with SUM aggregation type', () => {
+      /** Creating here because stats is a singleton */
+      const {stats} = require('@opencensus/core');
+      measure = stats.createMeasureDouble(
+          'testMeasureDouble', MeasureUnit.UNIT, 'A test measure');
+      measurement = {measure, tags, value: 22};
+      measurement2 = {measure, tags, value: 11};
       it('should get view information', async () => {
         stats.registerExporter(zpages);
         stats.createView(
@@ -334,6 +342,13 @@ describe('Zpages Exporter', () => {
     });
 
     describe('with LAST VALUE aggregation type', () => {
+      /** Creating here because stats is a singleton */
+      const {stats} = require('@opencensus/core');
+      measure = stats.createMeasureDouble(
+          'testMeasureDouble', MeasureUnit.UNIT, 'A test measure');
+      measurement = {measure, tags, value: 22};
+      measurement2 = {measure, tags, value: 11};
+
       it('should get view information', async () => {
         stats.registerExporter(zpages);
         stats.createView(
@@ -370,6 +385,13 @@ describe('Zpages Exporter', () => {
     });
 
     describe('with DISTRIBUTION aggregation type', () => {
+      /** Creating here because stats is a singleton */
+      const {stats} = require('@opencensus/core');
+      measure = stats.createMeasureDouble(
+          'testMeasureDouble', MeasureUnit.UNIT, 'A test measure');
+      measurement = {measure, tags, value: 22};
+      measurement2 = {measure, tags, value: 11};
+
       it('should get view information', async () => {
         const boundaries = [10, 20, 30, 40];
         stats.registerExporter(zpages);
@@ -414,12 +436,13 @@ describe('Zpages Exporter', () => {
 
   describe('when a view is accessed in rpcz page', () => {
     let zpages: ZpagesExporter;
-    let stats: Stats;
     let rpczData: RpczData;
     const boundaries = [10, 20, 30, 40];
+    /** Creating here because stats is a singleton */
+    const {stats} = require('@opencensus/core');
+
 
     beforeEach((done) => {
-      stats = new Stats();
       zpages = new ZpagesExporter(options);
       stats.registerExporter(zpages);
       zpages.startServer(done);


### PR DESCRIPTION
This PR is based on #276 - The ```new Stats()``` has been deprecated on Stats class. The global singleton ```stats``` object should be used instead.