### PR TITLE
Minor changes to Stackdriver example

### DIFF
--- a/examples/stats/exporter/stackdriver.js
+++ b/examples/stats/exporter/stackdriver.js
@@ -62,35 +62,35 @@ const stream = fs.createReadStream("./test.txt");
 // Create an interface to read and process our file line by line
 const lineReader = readline.createInterface({ input: stream });
 
-const tagKey = "method";
+const tagKeys = ["method", "status"];
 
-// Register the view.
-const latencyView = stats.createView(
+// Create the view.
+stats.createView(
   "demo/latency",
   mLatencyMs,
   AggregationType.DISTRIBUTION,
-  [tagKey],
+  tagKeys,
   "The distribution of the repl latencies",
   // Latency in buckets:
   // [>=0ms, >=25ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms, >=600ms, >=800ms, >=1s, >=2s, >=4s, >=6s]
   [0, 25, 50, 75, 100, 200, 400, 600, 800, 1000, 2000, 4000, 6000]
 );
 
-// Register the view.
-const lineCountView = stats.createView(
+// Create the view.
+stats.createView(
   "demo/lines_in",
   mLineLengths,
   AggregationType.COUNT,
-  [tagKey],
+  tagKeys,
   "The number of lines from standard input"
 );
 
-// Register the view.
-const lineLengthView = stats.createView(
+// Create the view.
+stats.createView(
   "demo/line_lengths",
   mLineLengths,
   AggregationType.DISTRIBUTION,
-  [tagKey],
+  tagKeys,
   "Groups the lengths of keys in buckets",
   // Bucket Boudaries:
   // [>=0B, >=5B, >=10B, >=15B, >=20B, >=40B, >=60B, >=80, >=100B, >=200B, >=400, >=600, >=800, >=1000]


### PR DESCRIPTION
Two changes (one needs to be fixed):

-- tagKeys used when creating the view ought match those used when recording stats. The code now creates tagKeys of `["method", "status"];`

-- views should be created and then registered but this appears to not be required with this implementation. The code now creates the views without assigning these to unused constants. If the library is amended to require the `createView(X)` followed by `registeredView(X)`, then these constants may be reverted. Or the result `createView` may be applied directly to `stats.registerView(stats.createView(...)`.