### PR TITLE
 Make Stats singleton (globalStats), separate registerView from createView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,31 @@ All notable changes to this project will be documented in this file.
 - Add ignoreIncomingPaths and ignoreOutgoingUrls support to the http and https tracing instrumentations.
 - Add ```opencensus-resource-util``` to auto detect AWS, GCE and Kubernetes(K8S) monitored resource, based on the environment where the application is running.
 
- **Contains API breaking changes for trace implementations**
+ **This release has multiple breaking changes. Please test your code accordingly after upgrading.**
 
 - Modify `Logger` interface: `level` made optional, `silly` removed.
+- The ```new Stats()``` has been deprecated on Stats class. The global singleton ```globalStats``` object should be used instead. Also, ```registerView()``` is separated out from ```createView()```.
+
+##### Old code
+```js
+const { Stats } = require("@opencensus/core");
+const stats = new Stats();
+
+// Create and register the view
+stats.createView(...);
+```
+
+##### New code
+```js
+// Get the global singleton stats object
+const { globalStats } = require("@opencensus/core");
+
+// Create the view
+const view = globalStats.createView(...);
+
+// register the view
+globalStats.registerView(view);
+```
 
 ## 0.0.8 - 2018-12-14
  **Contains API breaking changes for stats/metrics implementations**

--- a/packages/opencensus-core/src/index.ts
+++ b/packages/opencensus-core/src/index.ts
@@ -66,7 +66,6 @@ export * from './exporters/console-exporter';
 // STATS CLASSES
 
 // classes
-export * from './stats/stats';
 export * from './stats/view';
 export * from './stats/recorder';
 export * from './stats/bucket-boundaries';
@@ -94,3 +93,10 @@ export * from './metrics/metric-registry';
 // GAUGES CLASSES
 export * from './metrics/gauges/derived-gauge';
 export * from './metrics/gauges/gauge';
+
+
+// Stats singleton instance
+import {BaseStats} from './stats/stats';
+import {Stats} from './stats/types';
+const globalStats: Stats = BaseStats.instance;
+export {globalStats};

--- a/packages/opencensus-core/src/stats/metric-producer.ts
+++ b/packages/opencensus-core/src/stats/metric-producer.ts
@@ -17,7 +17,7 @@
 import {BaseMetricProducer} from '../metrics/export/base-metric-producer';
 import {Metric} from '../metrics/export/types';
 
-import {Stats} from './stats';
+import {Stats} from './types';
 
 /**
  * A MetricProducer producer that can be registered for exporting using

--- a/packages/opencensus-core/src/stats/stats.ts
+++ b/packages/opencensus-core/src/stats/stats.ts
@@ -17,7 +17,6 @@
 import * as defaultLogger from '../common/console-logger';
 import * as loggerTypes from '../common/types';
 import {StatsEventListener} from '../exporters/types';
-import {MetricProducer} from '../metrics/export/types';
 import {Metric} from '../metrics/export/types';
 import {Metrics} from '../metrics/metrics';
 
@@ -44,7 +43,7 @@ export class BaseStats implements Stats {
 
     // Create a new MetricProducerForStats and register it to
     // MetricProducerManager when Stats is initialized.
-    const metricProducer: MetricProducer = new MetricProducerForStats(this);
+    const metricProducer = new MetricProducerForStats(this);
     Metrics.getMetricProducerManager().add(metricProducer);
   }
 
@@ -54,8 +53,7 @@ export class BaseStats implements Stats {
   }
 
   /**
-   * Registers a view to listen to new measurements in its measure. Prefer using
-   * the method createView() that creates an already registered view.
+   * Registers a view to listen to new measurements in its measure.
    * @param view The view to be registered
    */
   registerView(view: View): void {

--- a/packages/opencensus-core/src/stats/stats.ts
+++ b/packages/opencensus-core/src/stats/stats.ts
@@ -17,18 +17,23 @@
 import * as defaultLogger from '../common/console-logger';
 import * as loggerTypes from '../common/types';
 import {StatsEventListener} from '../exporters/types';
+import {MetricProducer} from '../metrics/export/types';
 import {Metric} from '../metrics/export/types';
+import {Metrics} from '../metrics/metrics';
 
-import {AggregationType, Measure, Measurement, MeasureType, MeasureUnit, View} from './types';
+import {MetricProducerForStats} from './metric-producer';
+import {AggregationType, Measure, Measurement, MeasureType, MeasureUnit, Stats, View} from './types';
 import {BaseView} from './view';
 
-export class Stats {
+export class BaseStats implements Stats {
   /** A list of Stats exporters */
   private statsEventListeners: StatsEventListener[] = [];
   /** A map of Measures (name) to their corresponding Views */
   private registeredViews: {[key: string]: View[]} = {};
   /** An object to log information to */
   private logger: loggerTypes.Logger;
+  /** Singleton instance */
+  private static singletonInstance: BaseStats;
 
   /**
    * Creates stats
@@ -37,13 +42,15 @@ export class Stats {
   constructor(logger = defaultLogger) {
     this.logger = logger.logger();
 
-    // TODO (mayurkale): Decide how to inject MetricProducerForStats.
-    // It should be something like below, but looks like not the right place.
-
     // Create a new MetricProducerForStats and register it to
     // MetricProducerManager when Stats is initialized.
-    // const metricProducer: MetricProducer = new MetricProducerForStats(this);
-    // Metrics.getMetricProducerManager().add(metricProducer);
+    const metricProducer: MetricProducer = new MetricProducerForStats(this);
+    Metrics.getMetricProducerManager().add(metricProducer);
+  }
+
+  /** Gets the stats instance. */
+  static get instance(): Stats {
+    return this.singletonInstance || (this.singletonInstance = new this());
   }
 
   /**
@@ -51,7 +58,7 @@ export class Stats {
    * the method createView() that creates an already registered view.
    * @param view The view to be registered
    */
-  registerView(view: View) {
+  registerView(view: View): void {
     if (this.registeredViews[view.measure.name]) {
       this.registeredViews[view.measure.name].push(view);
     } else {
@@ -67,7 +74,7 @@ export class Stats {
   }
 
   /**
-   * Creates and registers a view.
+   * Creates a view.
    * @param name The view name
    * @param measure The view measure
    * @param aggregation The view aggregation type
@@ -82,7 +89,6 @@ export class Stats {
       bucketBoundaries?: number[]): View {
     const view = new BaseView(
         name, measure, aggregation, tagKeys, description, bucketBoundaries);
-    this.registerView(view);
     return view;
   }
 
@@ -90,7 +96,7 @@ export class Stats {
    * Registers an exporter to send stats data to a service.
    * @param exporter An stats exporter
    */
-  registerExporter(exporter: StatsEventListener) {
+  registerExporter(exporter: StatsEventListener): void {
     this.statsEventListeners.push(exporter);
 
     for (const measureName of Object.keys(this.registeredViews)) {
@@ -153,7 +159,7 @@ export class Stats {
    * Updates all views with the new measurements.
    * @param measurements A list of measurements to record
    */
-  record(...measurements: Measurement[]) {
+  record(...measurements: Measurement[]): void {
     if (this.hasNegativeValue(measurements)) {
       this.logger.warn(`Dropping measurments ${measurements}, value to record
           must be non-negative.`);
@@ -175,5 +181,13 @@ export class Stats {
         exporter.onRecord(views, measurement);
       }
     }
+  }
+
+  /**
+   * Remove all registered Views and exporters from the stats.
+   */
+  clear(): void {
+    this.registeredViews = {};
+    this.statsEventListeners = [];
   }
 }

--- a/packages/opencensus-core/src/stats/types.ts
+++ b/packages/opencensus-core/src/stats/types.ts
@@ -35,8 +35,7 @@ export interface Stats {
       bucketBoundaries?: number[]): View;
 
   /**
-   * Registers a view to listen to new measurements in its measure. Prefer using
-   * the method createView() that creates an already registered view.
+   * Registers a view to listen to new measurements in its measure.
    * @param view The view to be registered
    */
   registerView(view: View): void;

--- a/packages/opencensus-core/src/stats/types.ts
+++ b/packages/opencensus-core/src/stats/types.ts
@@ -14,7 +14,76 @@
  * limitations under the License.
  */
 
+import {StatsEventListener} from '../exporters/types';
 import {Metric} from '../metrics/export/types';
+
+/** Main interface for stats. */
+export interface Stats {
+  /**
+   * Creates a view.
+   * @param name The view name
+   * @param measure The view measure
+   * @param aggregation The view aggregation type
+   * @param tagKeys The view columns (tag keys)
+   * @param description The view description
+   * @param bucketBoundaries The view bucket boundaries for a distribution
+   * aggregation type
+   */
+  createView(
+      name: string, measure: Measure, aggregation: AggregationType,
+      tagKeys: string[], description: string,
+      bucketBoundaries?: number[]): View;
+
+  /**
+   * Registers a view to listen to new measurements in its measure. Prefer using
+   * the method createView() that creates an already registered view.
+   * @param view The view to be registered
+   */
+  registerView(view: View): void;
+
+  /**
+   * Creates a measure of type Double.
+   * @param name The measure name
+   * @param unit The measure unit
+   * @param description The measure description
+   */
+  createMeasureDouble(name: string, unit: MeasureUnit, description?: string):
+      Measure;
+
+  /**
+   * Creates a measure of type Int64. Values must be integers up to
+   * Number.MAX_SAFE_INTERGER.
+   * @param name The measure name
+   * @param unit The measure unit
+   * @param description The measure description
+   */
+  createMeasureInt64(name: string, unit: MeasureUnit, description?: string):
+      Measure;
+
+  /**
+   * Updates all views with the new measurements.
+   * @param measurements A list of measurements to record
+   */
+  record(...measurements: Measurement[]): void;
+
+  /**
+   * Remove all registered Views and exporters from the stats.
+   */
+  clear(): void;
+
+  /**
+   * Gets a collection of produced Metric`s to be exported.
+   * @returns {Metric[]} List of metrics
+   */
+  getMetrics(): Metric[];
+
+  /**
+   * Registers an exporter to send stats data to a service.
+   * @param exporter An stats exporter
+   */
+  registerExporter(exporter: StatsEventListener): void;
+}
+
 
 /** Tags are maps of names -> values */
 export interface Tags {

--- a/packages/opencensus-core/test/test-metric-producer.ts
+++ b/packages/opencensus-core/test/test-metric-producer.ts
@@ -15,13 +15,13 @@
  */
 
 import * as assert from 'assert';
-import {AggregationType, Measurement, MeasureUnit, Stats, Tags, View} from '../src';
+
+import {AggregationType, globalStats, Measurement, MeasureUnit, Tags, View} from '../src';
 import {LabelKey, LabelValue, MetricDescriptorType} from '../src/metrics/export/types';
 import {MetricProducerForStats} from '../src/stats/metric-producer';
 
 describe('Metric producer for stats', () => {
-  const stats = new Stats();
-  const metricProducerForStats = new MetricProducerForStats(stats);
+  const metricProducerForStats = new MetricProducerForStats(globalStats);
 
   // constants for view name
   const viewName1 = 'test/view/name1';
@@ -29,7 +29,7 @@ describe('Metric producer for stats', () => {
   const viewName3 = 'test/view/name2';
   const description = 'test description';
 
-  const measureDouble = stats.createMeasureDouble(
+  const measureDouble = globalStats.createMeasureDouble(
       'opencensus.io/test/double', MeasureUnit.UNIT, 'Measure Double');
   const tags: Tags = {testKey1: 'testValue1', testKey2: 'testValue2'};
   const labelKeys: LabelKey[] = [
@@ -72,9 +72,10 @@ describe('Metric producer for stats', () => {
   };
 
   it('should add sum stats', () => {
-    const view: View = stats.createView(
+    const view: View = globalStats.createView(
         viewName1, measureDouble, AggregationType.SUM, Object.keys(tags),
         description);
+    globalStats.registerView(view);
     view.recordMeasurement(measurement1);
 
     const metrics = metricProducerForStats.getMetrics();
@@ -92,9 +93,10 @@ describe('Metric producer for stats', () => {
 
   it('should add count stats',
      () => {
-       const view: View = stats.createView(
+       const view: View = globalStats.createView(
            viewName2, measureDouble, AggregationType.COUNT, Object.keys(tags),
            description);
+       globalStats.registerView(view);
        view.recordMeasurement(measurement1);
 
        let metrics = metricProducerForStats.getMetrics();
@@ -122,9 +124,10 @@ describe('Metric producer for stats', () => {
      });
 
   it('should add lastValue stats', () => {
-    const view: View = stats.createView(
+    const view: View = globalStats.createView(
         viewName3, measureDouble, AggregationType.LAST_VALUE, Object.keys(tags),
         description);
+    globalStats.registerView(view);
     view.recordMeasurement(measurement1);
     view.recordMeasurement(measurement2);
 
@@ -153,9 +156,10 @@ describe('Metric producer for stats', () => {
     const measurementValues = [1.1, 2.3, 3.2, 4.3, 5.2];
     const buckets = [2, 4, 6];
 
-    const view: View = stats.createView(
+    const view: View = globalStats.createView(
         viewName3, measureDouble, AggregationType.DISTRIBUTION,
         Object.keys(tags), description, buckets);
+    globalStats.registerView(view);
     for (const value of measurementValues) {
       const measurement: Measurement = {measure: measureDouble, value, tags};
       view.recordMeasurement(measurement);

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import {LabelKey, Logger, MeasureUnit, Metrics, Stats} from '@opencensus/core';
+import {globalStats, LabelKey, Logger, MeasureUnit, Metrics} from '@opencensus/core';
 import * as assert from 'assert';
 
 import {StackdriverStatsExporter} from '../src/stackdriver-monitoring';
 import {MetricKind, StackdriverExporterOptions, ValueType} from '../src/types';
+
 import * as nocks from './nocks';
 
 const PROJECT_ID = 'fake-project-id';
@@ -58,7 +59,6 @@ describe('Stackdriver Stats Exporter', () => {
   });
 
   describe('Send data to Stackdriver', () => {
-    const stats = new Stats();
     const mockLogger = new MockLogger();
     let exporterOptions: StackdriverExporterOptions;
     let exporter: StackdriverStatsExporter;
@@ -73,10 +73,11 @@ describe('Stackdriver Stats Exporter', () => {
     afterEach(() => {
       exporter.close();
       mockLogger.cleanAll();
+      globalStats.clear();
     });
 
     it('should not export for empty data', () => {
-      stats.registerExporter(exporter);
+      globalStats.registerExporter(exporter);
       assert.equal(mockLogger.debugBuffer.length, 0);
     });
 

--- a/packages/opencensus-exporter-zpages/test/test-zpages.ts
+++ b/packages/opencensus-exporter-zpages/test/test-zpages.ts
@@ -317,10 +317,10 @@ describe('Zpages Exporter', () => {
 
       it('should get stats for view', async () => {
         globalStats.registerExporter(zpages);
-        globalStats.createView(
+        const view = globalStats.createView(
             'test/SumView', measure, AggregationType.SUM, tagKeys, 'A sum test',
             null);
-
+        globalStats.registerView(view);
         globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/SumView'});
@@ -338,9 +338,10 @@ describe('Zpages Exporter', () => {
     describe('with LAST VALUE aggregation type', () => {
       it('should get view information', async () => {
         globalStats.registerExporter(zpages);
-        globalStats.createView(
+        const view = globalStats.createView(
             'test/LastValueView', measure, AggregationType.LAST_VALUE, tagKeys,
             'A last value test', null);
+        globalStats.registerView(view);
         globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/LastValueView'});
@@ -353,10 +354,10 @@ describe('Zpages Exporter', () => {
 
       it('should get stats for view', async () => {
         globalStats.registerExporter(zpages);
-        globalStats.createView(
+        const view = globalStats.createView(
             'test/LastValueView', measure, AggregationType.LAST_VALUE, tagKeys,
             'A last value test', null);
-
+        globalStats.registerView(view);
         globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/LastValueView'});
@@ -375,9 +376,10 @@ describe('Zpages Exporter', () => {
       it('should get view information', async () => {
         const boundaries = [10, 20, 30, 40];
         globalStats.registerExporter(zpages);
-        globalStats.createView(
+        const view = globalStats.createView(
             'test/DistributionView', measure, AggregationType.DISTRIBUTION,
             tagKeys, 'A distribution test', boundaries);
+        globalStats.registerView(view);
         globalStats.record(measurement, measurement2);
 
         zpagesData =
@@ -392,10 +394,10 @@ describe('Zpages Exporter', () => {
       it('should get stats for view', async () => {
         const boundaries = [10, 20, 30, 40];
         globalStats.registerExporter(zpages);
-        globalStats.createView(
+        const view = globalStats.createView(
             'test/DistributionView', measure, AggregationType.DISTRIBUTION,
             tagKeys, 'A distribution test', boundaries);
-
+        globalStats.registerView(view);
         globalStats.record(measurement, measurement2);
 
         zpagesData =
@@ -454,28 +456,33 @@ describe('Zpages Exporter', () => {
           'grpc.io/client/started_rpcs', MeasureUnit.UNIT,
           'Number of started client RPCs.');
 
-      globalStats.createView(
+      const view1 = globalStats.createView(
           'grpc.io/client/sent_bytes_per_rpc', measure,
           AggregationType.DISTRIBUTION, tagKeys, 'Sent bytes per RPC',
           boundaries);
+      globalStats.registerView(view1);
 
-      globalStats.createView(
+      const view2 = globalStats.createView(
           'grpc.io/client/received_bytes_per_rpc', measure2,
           AggregationType.DISTRIBUTION, tagKeys, 'Sent bytes per RPC',
           boundaries);
+      globalStats.registerView(view2);
 
-      globalStats.createView(
+      const view3 = globalStats.createView(
           'grpc.io/client/roundtrip_latency', measure3,
           AggregationType.DISTRIBUTION, tagKeys, 'Latency in msecs',
           boundaries);
+      globalStats.registerView(view3);
 
-      globalStats.createView(
+      const view4 = globalStats.createView(
           'grpc.io/client/completed_rpcs', measure3, AggregationType.COUNT,
           tagKeys, 'Number of completed client RPCs', null);
+      globalStats.registerView(view4);
 
-      globalStats.createView(
+      const view5 = globalStats.createView(
           'grpc.io/client/started_rpcs', measure4, AggregationType.COUNT,
           tagKeys, 'Number of started client RPCs', null);
+      globalStats.registerView(view5);
 
       const measurement = {measure, tags, value: 22000};
       const measurement2 = {measure: measure2, tags, value: 1100};
@@ -521,28 +528,33 @@ describe('Zpages Exporter', () => {
           'grpc.io/server/started_rpcs', MeasureUnit.UNIT,
           'Number of started client RPCs.');
 
-      globalStats.createView(
+      const view1 = globalStats.createView(
           'grpc.io/server/received_bytes_per_rpc', measure5,
           AggregationType.DISTRIBUTION, tagKeys2, 'Sent bytes per RPC',
           boundaries);
+      globalStats.registerView(view1);
 
-      globalStats.createView(
+      const view2 = globalStats.createView(
           'grpc.io/server/sent_bytes_per_rpc', measure6,
           AggregationType.DISTRIBUTION, tagKeys2, 'Sent bytes per RPC',
           boundaries);
+      globalStats.registerView(view2);
 
-      globalStats.createView(
+      const view3 = globalStats.createView(
           'grpc.io/server/server_latency', measure7,
           AggregationType.DISTRIBUTION, tagKeys2, 'Latency in msecs',
           boundaries);
+      globalStats.registerView(view3);
 
-      globalStats.createView(
+      const view4 = globalStats.createView(
           'grpc.io/server/completed_rpcs', measure7, AggregationType.COUNT,
           tagKeys2, 'Number of completed client RPCs', null);
+      globalStats.registerView(view4);
 
-      globalStats.createView(
+      const view5 = globalStats.createView(
           'grpc.io/server/started_rpcs', measure8, AggregationType.COUNT,
           tagKeys2, 'Number of started client RPCs', null);
+      globalStats.registerView(view5);
 
       const measurement6 = {measure: measure5, tags: tags3, value: 2200};
       const measurement7 = {measure: measure6, tags: tags3, value: 1100};

--- a/packages/opencensus-exporter-zpages/test/test-zpages.ts
+++ b/packages/opencensus-exporter-zpages/test/test-zpages.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AggregationType, CountData, DistributionData, Measure, Measurement, MeasureUnit, RootSpan, Stats, SumData, Tags, TracerConfig} from '@opencensus/core';
+import {AggregationType, CountData, DistributionData, globalStats, Measure, Measurement, MeasureUnit, RootSpan, SumData, Tags, TracerConfig} from '@opencensus/core';
 import * as assert from 'assert';
 import axios from 'axios';
 import * as http from 'http';
@@ -243,17 +243,15 @@ describe('Zpages Exporter', () => {
       return tags[tagKey];
     });
     let zpages: ZpagesExporter;
-    let stats: Stats;
     let measure: Measure;
     let zpagesData: StatsViewData;
     let measurement: Measurement;
     let measurement2: Measurement;
 
     beforeEach((done) => {
-      stats = new Stats();
       zpages = new ZpagesExporter(options);
-      stats.registerExporter(zpages);
-      measure = stats.createMeasureDouble(
+      globalStats.registerExporter(zpages);
+      measure = globalStats.createMeasureDouble(
           'testMeasureDouble', MeasureUnit.UNIT, 'A test measure');
       measurement = {measure, tags, value: 22};
       measurement2 = {measure, tags, value: 11};
@@ -262,14 +260,16 @@ describe('Zpages Exporter', () => {
 
     afterEach((done) => {
       zpages.stopServer(done);
+      globalStats.clear();
     });
 
     describe('with COUNT aggregation type', () => {
       it('should get view information', async () => {
-        stats.createView(
+        const view = globalStats.createView(
             'test/CountView', measure, AggregationType.COUNT, tagKeys,
             'A count test', null);
-        stats.record(measurement, measurement2);
+        globalStats.registerView(view);
+        globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/CountView'});
 
@@ -280,10 +280,11 @@ describe('Zpages Exporter', () => {
       });
 
       it('should get stats for view', async () => {
-        stats.createView(
+        const view = globalStats.createView(
             'test/CountView', measure, AggregationType.COUNT, tagKeys,
             'A count test', null);
-        stats.record(measurement, measurement2);
+        globalStats.registerView(view);
+        globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/CountView'});
 
@@ -299,11 +300,12 @@ describe('Zpages Exporter', () => {
 
     describe('with SUM aggregation type', () => {
       it('should get view information', async () => {
-        stats.registerExporter(zpages);
-        stats.createView(
+        globalStats.registerExporter(zpages);
+        const view = globalStats.createView(
             'test/SumView', measure, AggregationType.SUM, tagKeys, 'A sum test',
             null);
-        stats.record(measurement, measurement2);
+        globalStats.registerView(view);
+        globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/SumView'});
 
@@ -314,12 +316,12 @@ describe('Zpages Exporter', () => {
       });
 
       it('should get stats for view', async () => {
-        stats.registerExporter(zpages);
-        stats.createView(
+        globalStats.registerExporter(zpages);
+        globalStats.createView(
             'test/SumView', measure, AggregationType.SUM, tagKeys, 'A sum test',
             null);
 
-        stats.record(measurement, measurement2);
+        globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/SumView'});
 
@@ -335,11 +337,11 @@ describe('Zpages Exporter', () => {
 
     describe('with LAST VALUE aggregation type', () => {
       it('should get view information', async () => {
-        stats.registerExporter(zpages);
-        stats.createView(
+        globalStats.registerExporter(zpages);
+        globalStats.createView(
             'test/LastValueView', measure, AggregationType.LAST_VALUE, tagKeys,
             'A last value test', null);
-        stats.record(measurement, measurement2);
+        globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/LastValueView'});
 
@@ -350,12 +352,12 @@ describe('Zpages Exporter', () => {
       });
 
       it('should get stats for view', async () => {
-        stats.registerExporter(zpages);
-        stats.createView(
+        globalStats.registerExporter(zpages);
+        globalStats.createView(
             'test/LastValueView', measure, AggregationType.LAST_VALUE, tagKeys,
             'A last value test', null);
 
-        stats.record(measurement, measurement2);
+        globalStats.record(measurement, measurement2);
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/LastValueView'});
 
@@ -372,11 +374,11 @@ describe('Zpages Exporter', () => {
     describe('with DISTRIBUTION aggregation type', () => {
       it('should get view information', async () => {
         const boundaries = [10, 20, 30, 40];
-        stats.registerExporter(zpages);
-        stats.createView(
+        globalStats.registerExporter(zpages);
+        globalStats.createView(
             'test/DistributionView', measure, AggregationType.DISTRIBUTION,
             tagKeys, 'A distribution test', boundaries);
-        stats.record(measurement, measurement2);
+        globalStats.record(measurement, measurement2);
 
         zpagesData =
             await zpagesClient.getStatsz({path: 'test/DistributionView'});
@@ -389,12 +391,12 @@ describe('Zpages Exporter', () => {
 
       it('should get stats for view', async () => {
         const boundaries = [10, 20, 30, 40];
-        stats.registerExporter(zpages);
-        stats.createView(
+        globalStats.registerExporter(zpages);
+        globalStats.createView(
             'test/DistributionView', measure, AggregationType.DISTRIBUTION,
             tagKeys, 'A distribution test', boundaries);
 
-        stats.record(measurement, measurement2);
+        globalStats.record(measurement, measurement2);
 
         zpagesData =
             await zpagesClient.getStatsz({path: 'test/DistributionView'});
@@ -414,19 +416,18 @@ describe('Zpages Exporter', () => {
 
   describe('when a view is accessed in rpcz page', () => {
     let zpages: ZpagesExporter;
-    let stats: Stats;
     let rpczData: RpczData;
     const boundaries = [10, 20, 30, 40];
 
     beforeEach((done) => {
-      stats = new Stats();
       zpages = new ZpagesExporter(options);
-      stats.registerExporter(zpages);
+      globalStats.registerExporter(zpages);
       zpages.startServer(done);
     });
 
     afterEach((done) => {
       zpages.stopServer(done);
+      globalStats.clear();
     });
 
     it('should get the sent stats', async () => {
@@ -437,42 +438,42 @@ describe('Zpages Exporter', () => {
       };
       const tagKeys = Object.keys(tags);
 
-      const measure = stats.createMeasureDouble(
+      const measure = globalStats.createMeasureDouble(
           'grpc.io/client/sent_bytes_per_rpc', MeasureUnit.BYTE,
           'Total bytes sent across all request messages per RPC');
 
-      const measure2 = stats.createMeasureDouble(
+      const measure2 = globalStats.createMeasureDouble(
           'grpc.io/client/received_bytes_per_rpc', MeasureUnit.BYTE,
           'Total bytes received across all request messages per RPC');
 
-      const measure3 = stats.createMeasureDouble(
+      const measure3 = globalStats.createMeasureDouble(
           'grpc.io/client/roundtrip_latency', MeasureUnit.MS,
           'Time between first byte of request sent to last byte of response received or terminal error');
 
-      const measure4 = stats.createMeasureDouble(
+      const measure4 = globalStats.createMeasureDouble(
           'grpc.io/client/started_rpcs', MeasureUnit.UNIT,
           'Number of started client RPCs.');
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/client/sent_bytes_per_rpc', measure,
           AggregationType.DISTRIBUTION, tagKeys, 'Sent bytes per RPC',
           boundaries);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/client/received_bytes_per_rpc', measure2,
           AggregationType.DISTRIBUTION, tagKeys, 'Sent bytes per RPC',
           boundaries);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/client/roundtrip_latency', measure3,
           AggregationType.DISTRIBUTION, tagKeys, 'Latency in msecs',
           boundaries);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/client/completed_rpcs', measure3, AggregationType.COUNT,
           tagKeys, 'Number of completed client RPCs', null);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/client/started_rpcs', measure4, AggregationType.COUNT,
           tagKeys, 'Number of started client RPCs', null);
 
@@ -482,7 +483,7 @@ describe('Zpages Exporter', () => {
       const measurement4 = {measure: measure3, tags: tags2, value: 2};
       const measurement5 = {measure: measure4, tags, value: 2};
 
-      stats.record(
+      globalStats.record(
           measurement, measurement2, measurement3, measurement4, measurement5);
 
       rpczData = await zpagesClient.getRpcz();
@@ -504,42 +505,42 @@ describe('Zpages Exporter', () => {
       const tagKeys2 = Object.keys(tags3);
       const boundaries = [10, 20, 30, 40];
 
-      const measure5 = stats.createMeasureDouble(
+      const measure5 = globalStats.createMeasureDouble(
           'grpc.io/server/received_bytes_per_rpc', MeasureUnit.BYTE,
           'Total bytes sent across all request messages per RPC');
 
-      const measure6 = stats.createMeasureDouble(
+      const measure6 = globalStats.createMeasureDouble(
           'grpc.io/server/sent_bytes_per_rpc', MeasureUnit.BYTE,
           'Total bytes received across all request messages per RPC');
 
-      const measure7 = stats.createMeasureDouble(
+      const measure7 = globalStats.createMeasureDouble(
           'grpc.io/server/server_latency', MeasureUnit.MS,
           'Time between first byte of request sent to last byte of response received or terminal error');
 
-      const measure8 = stats.createMeasureDouble(
+      const measure8 = globalStats.createMeasureDouble(
           'grpc.io/server/started_rpcs', MeasureUnit.UNIT,
           'Number of started client RPCs.');
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/server/received_bytes_per_rpc', measure5,
           AggregationType.DISTRIBUTION, tagKeys2, 'Sent bytes per RPC',
           boundaries);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/server/sent_bytes_per_rpc', measure6,
           AggregationType.DISTRIBUTION, tagKeys2, 'Sent bytes per RPC',
           boundaries);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/server/server_latency', measure7,
           AggregationType.DISTRIBUTION, tagKeys2, 'Latency in msecs',
           boundaries);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/server/completed_rpcs', measure7, AggregationType.COUNT,
           tagKeys2, 'Number of completed client RPCs', null);
 
-      stats.createView(
+      globalStats.createView(
           'grpc.io/server/started_rpcs', measure8, AggregationType.COUNT,
           tagKeys2, 'Number of started client RPCs', null);
 
@@ -549,7 +550,7 @@ describe('Zpages Exporter', () => {
       const measurement9 = {measure: measure7, tags: tags4, value: 2};
       const measurement10 = {measure: measure8, tags: tags3, value: 2};
 
-      stats.record(
+      globalStats.record(
           measurement6, measurement7, measurement8, measurement9,
           measurement10);
 


### PR DESCRIPTION
This PR is based on #276.

This PR contains two breaking changes:
1. The ```new Stats()``` has been deprecated on Stats class. The global singleton ```globalStats``` object should be used instead.
2. ```registerView()``` hook has been removed from ```createView()``` API. This is related to https://github.com/census-instrumentation/opencensus-node/issues/287.

Fixes #290 #276 