### PR TITLE
Jaeger exporter: remove require wrapper and make requires direct

### DIFF
--- a/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
@@ -15,20 +15,10 @@
  */
 
 import {Span} from '@opencensus/core';
-import * as path from 'path';
 
-const indexPath = path.dirname(require.resolve('jaeger-client'));
-
-function requireJaegerClientModule(nodeName: string) {
-  return require(path.join(indexPath, nodeName)).default;
-}
-
-// tslint:disable-next-line:variable-name
-export const UDPSender = requireJaegerClientModule('reporters/udp_sender');
-// tslint:disable-next-line:variable-name
-export const Utils = requireJaegerClientModule('util');
-// tslint:disable-next-line:variable-name
-export const ThriftUtils = requireJaegerClientModule('thrift');
+export const UDPSender = require('jaeger-client/reporters/udp_sender').default;
+export const Utils = require('jaeger-client/util').default;
+export const ThriftUtils = require('jaeger-client/thrift').default;
 
 export type TagValue = string|number|boolean;
 

--- a/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
@@ -17,7 +17,8 @@
 import {Span} from '@opencensus/core';
 
 // tslint:disable-next-line:variable-name
-export const UDPSender = require('jaeger-client/dist/src/reporters/udp_sender').default;
+export const UDPSender =
+    require('jaeger-client/dist/src/reporters/udp_sender').default;
 // tslint:disable-next-line:variable-name
 export const Utils = require('jaeger-client/dist/src/util').default;
 // tslint:disable-next-line:variable-name

--- a/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
@@ -16,9 +16,9 @@
 
 import {Span} from '@opencensus/core';
 
-export const UDPSender = require('jaeger-client/reporters/udp_sender').default;
-export const Utils = require('jaeger-client/util').default;
-export const ThriftUtils = require('jaeger-client/thrift').default;
+export const UDPSender = require('jaeger-client/dist/src/reporters/udp_sender').default;
+export const Utils = require('jaeger-client/dist/src/util').default;
+export const ThriftUtils = require('jaeger-client/dist/src/thrift').default;
 
 export type TagValue = string|number|boolean;
 

--- a/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger-driver/index.ts
@@ -16,8 +16,11 @@
 
 import {Span} from '@opencensus/core';
 
+// tslint:disable-next-line:variable-name
 export const UDPSender = require('jaeger-client/dist/src/reporters/udp_sender').default;
+// tslint:disable-next-line:variable-name
 export const Utils = require('jaeger-client/dist/src/util').default;
+// tslint:disable-next-line:variable-name
 export const ThriftUtils = require('jaeger-client/dist/src/thrift').default;
 
 export type TagValue = string|number|boolean;


### PR DESCRIPTION
## Motivation
See #301.

It seems like this was done for developer convenience, and this function is only used in this file. While I don't have a problem with that in principle, it breaks things for Webpack.

## Changes
Remove the require wrapper and make the requires direct

## Testing
See that the build still builds correctly.