### PR TITLE
update googleapis -> 37.1.0

### DIFF
--- a/packages/opencensus-exporter-stackdriver/package-lock.json
+++ b/packages/opencensus-exporter-stackdriver/package-lock.json
@@ -328,15 +328,6 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-      "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
-      }
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -873,11 +864,6 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
     "external-editor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
@@ -930,14 +916,6 @@
         "locate-path": "^2.0.0"
       }
     },
-    "follow-redirects": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
-      "requires": {
-        "debug": "^3.1.0"
-      }
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -976,16 +954,6 @@
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         }
-      }
-    },
-    "gcp-metadata": {
-      "version": "0.6.3",
-      "resolved": "http://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
-      "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
-      "requires": {
-        "axios": "^0.18.0",
-        "extend": "^3.0.1",
-        "retry-axios": "0.3.2"
       }
     },
     "get-func-name": {
@@ -1105,50 +1073,36 @@
       }
     },
     "googleapis": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-27.0.0.tgz",
-      "integrity": "sha512-Cz0BRsZmewc21N50x5nAUW5cqaGhJ9ETQKZMGqGL4BxmCV7ETELazSqmNi4oCDeRwM4Iub/fIJWAWZk2i6XLCg==",
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-37.1.0.tgz",
+      "integrity": "sha512-ajQF/BA95pCknQWtNFelcSuwZpiUKyKlfbEFd/q3gWMWJWlkMd4Bb+oI6+A0lQ0spqQF/zzMyviTiLCaws5hkw==",
       "requires": {
-        "google-auth-library": "^1.3.1",
-        "pify": "^3.0.0",
-        "qs": "^6.5.1",
-        "string-template": "1.0.0",
+        "google-auth-library": "^3.0.0",
+        "googleapis-common": "^0.7.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-0.7.2.tgz",
+      "integrity": "sha512-9DEJIiO4nS7nw0VE1YVkEfXEj8x8MxsuB+yZIpOBULFSN9OIKcUU8UuKgSZFU4lJmRioMfngktrbkMwWJcUhQg==",
+      "requires": {
+        "gaxios": "^1.2.2",
+        "google-auth-library": "^3.0.0",
+        "pify": "^4.0.0",
+        "qs": "^6.5.2",
+        "url-template": "^2.0.8",
         "uuid": "^3.2.1"
       },
       "dependencies": {
-        "google-auth-library": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
-          "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
-          "requires": {
-            "axios": "^0.18.0",
-            "gcp-metadata": "^0.6.3",
-            "gtoken": "^2.3.0",
-            "jws": "^3.1.5",
-            "lodash.isstring": "^4.0.1",
-            "lru-cache": "^4.1.3",
-            "retry-axios": "^0.3.2"
-          },
-          "dependencies": {
-            "jws": {
-              "version": "3.1.5",
-              "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-              "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
-              "requires": {
-                "jwa": "^1.1.5",
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "lru-cache": {
-              "version": "4.1.3",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-              "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            }
-          }
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        },
+        "qs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
         }
       }
     },
@@ -1182,18 +1136,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
-    },
-    "gtoken": {
-      "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
-      "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
-      "requires": {
-        "axios": "^0.18.0",
-        "google-p12-pem": "^1.0.0",
-        "jws": "^3.1.4",
-        "mime": "^2.2.0",
-        "pify": "^3.0.0"
-      }
     },
     "gts": {
       "version": "0.9.0",
@@ -1416,11 +1358,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1673,11 +1610,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -3200,7 +3132,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.29",
@@ -3217,7 +3150,8 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -3368,11 +3302,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "retry-axios": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
-      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
-    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -3521,11 +3450,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
-    },
-    "string-template": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
-      "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
     },
     "string-width": {
       "version": "2.1.1",
@@ -3809,6 +3733,11 @@
         "prepend-http": "^1.0.1"
       }
     },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
     "urlgrey": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
@@ -3885,7 +3814,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs-parser": {
       "version": "10.1.0",

--- a/packages/opencensus-exporter-stackdriver/package.json
+++ b/packages/opencensus-exporter-stackdriver/package.json
@@ -55,7 +55,7 @@
     "@opencensus/core": "^0.0.8",
     "@opencensus/resource-util": "^0.0.1",
     "google-auth-library": "^3.0.0",
-    "googleapis": "27.0.0",
+    "googleapis": "37.1.0",
     "hex2dec": "^1.1.0"
   }
 }


### PR DESCRIPTION
The new version has support(feat.) for adding user agent as a client header (https://github.com/googleapis/nodejs-googleapis-common/pull/76/files), will unblock long pending issue: https://github.com/census-instrumentation/opencensus-node/issues/194 and PR: https://github.com/census-instrumentation/opencensus-node/pull/214.

**Other noticeable changes for us:**

- fix: accept lowercase env vars (https://github.com/googleapis/google-auth-library-nodejs/pull/578)
-  use gaxios for HTTP requests instead of axios (https://github.com/googleapis/google-auth-library-nodejs/pull/593)