### PR TITLE
Exporter/Stackdriver: Add common utils

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/common-utils.ts
+++ b/packages/opencensus-exporter-stackdriver/src/common-utils.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Labels} from '@opencensus/core';
+import * as resource from '@opencensus/resource-util';
+import {MonitoredResource} from './types';
+
+const STACKDRIVER_PROJECT_ID_KEY = 'project_id';
+const AWS_REGION_VALUE_PREFIX = 'aws:';
+
+/* Return a self-configured StackDriver monitored resource. */
+export async function getDefaultResource(projectId: string):
+    Promise<MonitoredResource> {
+  const labels: Labels = {project_id: projectId};
+  const autoDetectedResource = await resource.detectResource();
+  const [type, mappings] = getTypeAndMappings(autoDetectedResource.type);
+  Object.keys(mappings).forEach((key) => {
+    if (autoDetectedResource.labels[mappings[key]]) {
+      if (mappings[key] === resource.AWS_REGION_KEY) {
+        labels[key] = `${AWS_REGION_VALUE_PREFIX}${
+            autoDetectedResource.labels[mappings[key]]}`;
+      } else {
+        labels[key] = autoDetectedResource.labels[mappings[key]];
+      }
+    }
+  });
+  return {type, labels};
+}
+
+function getTypeAndMappings(resourceType: string): [string, Labels] {
+  switch (resourceType) {
+    case resource.GCP_GCE_INSTANCE_TYPE:
+      // https://cloud.google.com/monitoring/api/resources#tag_gce_instance
+      return [
+        'gce_instance', {
+          'project_id': STACKDRIVER_PROJECT_ID_KEY,
+          'instance_id': resource.GCP_INSTANCE_ID_KEY,
+          'zone': resource.GCP_ZONE_KEY
+        }
+      ];
+    case resource.K8S_CONTAINER_TYPE:
+      // https://cloud.google.com/monitoring/api/resources#tag_k8s_container
+      return [
+        'k8s_container', {
+          'project_id': STACKDRIVER_PROJECT_ID_KEY,
+          'location': resource.GCP_ZONE_KEY,
+          'cluster_name': resource.K8S_CLUSTER_NAME_KEY,
+          'namespace_name': resource.K8S_NAMESPACE_NAME_KEY,
+          'pod_name': resource.K8S_POD_NAME_KEY,
+          'container_name': resource.K8S_CONTAINER_NAME_KEY
+        }
+      ];
+    case resource.AWS_EC2_INSTANCE_TYPE:
+      // https://cloud.google.com/monitoring/api/resources#tag_aws_ec2_instance
+      return [
+        'aws_ec2_instance', {
+          'project_id': STACKDRIVER_PROJECT_ID_KEY,
+          'instance_id': resource.AWS_INSTANCE_ID_KEY,
+          'region': resource.AWS_REGION_KEY,
+          'aws_account': resource.AWS_ACCOUNT_KEY
+        }
+      ];
+    default:
+      return ['global', {}];
+  }
+}

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import {Exporter, ExporterBuffer, ExporterConfig, RootSpan, Span, SpanContext} from '@opencensus/core';
+import {Exporter, ExporterBuffer, RootSpan, Span, SpanContext} from '@opencensus/core';
 import {logger, Logger} from '@opencensus/core';
 import {auth, JWT} from 'google-auth-library';
 import {google} from 'googleapis';
 // TODO change to use import when types for hex2dec will be available
 const {hexToDec}: {[key: string]: (input: string) => string} =
     require('hex2dec');
-
 import {StackdriverExporterOptions, TracesWithCredentials, TranslatedSpan, TranslatedTrace} from './types';
 
 google.options({headers: {'x-opencensus-outgoing-request': 0x1}});

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -17,8 +17,8 @@
 import {logger, Logger, Measurement, Metric, MetricDescriptor as OCMetricDescriptor, MetricProducerManager, Metrics, StatsEventListener, TagKey, TagValue, version, View} from '@opencensus/core';
 import {auth, JWT} from 'google-auth-library';
 import {google} from 'googleapis';
-
-import {createMetricDescriptorData, createTimeSeriesList, getDefaultResource} from './stackdriver-stats-utils';
+import {getDefaultResource} from './common-utils';
+import {createMetricDescriptorData, createTimeSeriesList} from './stackdriver-stats-utils';
 import {MonitoredResource, StackdriverExporterOptions, TimeSeries} from './types';
 
 const OC_USER_AGENT = {

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-stats-utils.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-stats-utils.ts
@@ -14,36 +14,14 @@
  * limitations under the License.
  */
 
-import {BucketOptions, DistributionBucket, DistributionValue, LabelKey, Labels, LabelValue, Metric, MetricDescriptor as OCMetricDescriptor, MetricDescriptorType, TimeSeriesPoint, Timestamp} from '@opencensus/core';
-import * as resource from '@opencensus/resource-util';
+import {BucketOptions, DistributionBucket, DistributionValue, LabelKey, LabelValue, Metric, MetricDescriptor as OCMetricDescriptor, MetricDescriptorType, TimeSeriesPoint, Timestamp} from '@opencensus/core';
 import * as os from 'os';
 import * as path from 'path';
-
 import {Distribution, LabelDescriptor, MetricDescriptor, MetricKind, MonitoredResource, Point, TimeSeries, ValueType} from './types';
 
 const OPENCENSUS_TASK = 'opencensus_task';
 const OPENCENSUS_TASK_DESCRIPTION = 'Opencensus task identifier';
 export const OPENCENSUS_TASK_VALUE_DEFAULT = generateDefaultTaskValue();
-const STACKDRIVER_PROJECT_ID_KEY = 'project_id';
-
-/* Return a self-configured StackDriver monitored resource. */
-export async function getDefaultResource(projectId: string):
-    Promise<MonitoredResource> {
-  const labels: Labels = {project_id: projectId};
-  const autoDetectedResource = await resource.detectResource();
-  const [type, mappings] = getTypeAndMappings(autoDetectedResource.type);
-  Object.keys(mappings).forEach((key) => {
-    if (autoDetectedResource.labels[mappings[key]]) {
-      if (mappings[key] === resource.AWS_REGION_KEY) {
-        labels[key] = `${resource.AWS_REGION_VALUE_PREFIX}${
-            autoDetectedResource.labels[mappings[key]]}`;
-      } else {
-        labels[key] = autoDetectedResource.labels[mappings[key]];
-      }
-    }
-  });
-  return {type, labels};
-}
 
 /** Converts a OpenCensus MetricDescriptor to a StackDriver MetricDescriptor. */
 export function createMetricDescriptorData(
@@ -256,44 +234,6 @@ function leftZeroPad(ns: number) {
   const str = `${ns}`;
   const pad = '000000000'.substring(0, 9 - str.length);
   return `${pad}${str}`;
-}
-
-function getTypeAndMappings(resourceType: string): [string, Labels] {
-  switch (resourceType) {
-    case resource.GCP_GCE_INSTANCE_TYPE:
-      // https://cloud.google.com/monitoring/api/resources#tag_gce_instance
-      return [
-        'gce_instance', {
-          'project_id': STACKDRIVER_PROJECT_ID_KEY,
-          'instance_id': resource.GCP_INSTANCE_ID_KEY,
-          'zone': resource.GCP_ZONE_KEY
-        }
-      ];
-    case resource.K8S_CONTAINER_TYPE:
-      // https://cloud.google.com/monitoring/api/resources#tag_k8s_container
-      return [
-        'k8s_container', {
-          'project_id': STACKDRIVER_PROJECT_ID_KEY,
-          'location': resource.GCP_ZONE_KEY,
-          'cluster_name': resource.K8S_CLUSTER_NAME_KEY,
-          'namespace_name': resource.K8S_NAMESPACE_NAME_KEY,
-          'pod_name': resource.K8S_POD_NAME_KEY,
-          'container_name': resource.K8S_CONTAINER_NAME_KEY
-        }
-      ];
-    case resource.AWS_EC2_INSTANCE_TYPE:
-      // https://cloud.google.com/monitoring/api/resources#tag_aws_ec2_instance
-      return [
-        'aws_ec2_instance', {
-          'project_id': STACKDRIVER_PROJECT_ID_KEY,
-          'instance_id': resource.AWS_INSTANCE_ID_KEY,
-          'region': resource.AWS_REGION_KEY,
-          'aws_account': resource.AWS_ACCOUNT_KEY
-        }
-      ];
-    default:
-      return ['global', {}];
-  }
 }
 
 export const TEST_ONLY = {

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-stats-utils.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-stats-utils.ts
@@ -17,8 +17,9 @@
 import {CoreResource, DistributionValue, LabelKey, LabelValue, MetricDescriptor as OCMetricDescriptor, MetricDescriptorType, TimeSeriesPoint, Timestamp} from '@opencensus/core';
 import * as assert from 'assert';
 
+import {getDefaultResource} from '../src/common-utils';
 import {StackdriverStatsExporter} from '../src/stackdriver-monitoring';
-import {createMetricDescriptorData, createTimeSeriesList, getDefaultResource, OPENCENSUS_TASK_VALUE_DEFAULT, TEST_ONLY} from '../src/stackdriver-stats-utils';
+import {createMetricDescriptorData, createTimeSeriesList, OPENCENSUS_TASK_VALUE_DEFAULT, TEST_ONLY} from '../src/stackdriver-stats-utils';
 import {Distribution, MetricDescriptor, MetricKind, ValueType} from '../src/types';
 
 import * as nocks from './nocks';

--- a/packages/opencensus-resource-util/src/resource-labels.ts
+++ b/packages/opencensus-resource-util/src/resource-labels.ts
@@ -28,9 +28,6 @@ export const AWS_ACCOUNT_KEY = 'aws.com/ec2/account_id';
 /** AWS key that represents the VM instance identifier assigned by AWS. */
 export const AWS_INSTANCE_ID_KEY = 'aws.com/ec2/instance_id';
 
-/** AWS key that represents a prefix for region value. */
-export const AWS_REGION_VALUE_PREFIX = 'aws:';
-
 /** GCP GCE key that represents a type of the resource. */
 export const GCP_GCE_INSTANCE_TYPE = 'cloud.google.com/gce/instance';
 


### PR DESCRIPTION
This PR contains common utils which is shared between stats and trace exporter especially to get default resources and its SD specific mappings. Also, removed some unused imports (I am planning to enforce ```"noUnusedLocals": true``` very soon on SD package) and ```AWS_REGION_VALUE_PREFIX``` constant moved in exporter as this prefix is only important to SD.

This PR is foundation for issuse #39.