### PR TITLE
Add message event size fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Add support for supplying instrumentation configuration via tracing option. Option argument added to instrumentation interface.
 - Add ignoreIncomingPaths and ignoreOutgoingUrls support to the http and https tracing instrumentations.
 - Add ```opencensus-resource-util``` to auto detect AWS, GCE and Kubernetes(K8S) monitored resource, based on the environment where the application is running.
+- Add optional `uncompressedSize` and `compressedSize` fields to `MessageEvent` interface.
 
  **This release has multiple breaking changes. Please test your code accordingly after upgrading.**
 

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -48,6 +48,13 @@ export interface MessageEvent {
   type: string;
   /** An identifier for the MessageEvent's message. */
   id: string;
+  /** The number of uncompressed bytes sent or received. */
+  uncompressedSize?: number;
+  /**
+   * The number of compressed bytes sent or received. If zero or
+   * undefined, assumed to be the same size as uncompressed.
+   */
+  compressedSize?: number;
 }
 
 /**


### PR DESCRIPTION
This will be useful for the `opencensus-web` project since message sizes are often known in the browser performance timing API and I'd like to make it include message events per the [OpenCensus HTTP specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md).