### PR TITLE
fixes http.get patches for header propagation #117

### DIFF
--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -24,7 +24,7 @@ import * as uuid from 'uuid';
 import {HttpPluginConfig, IgnoreMatcher} from './types';
 
 
-export type HttpGetCallback = (res: httpModule.IncomingMessage) => void
+export type HttpGetCallback = (res: httpModule.IncomingMessage) => void;
 export type HttpModule = typeof httpModule;
 export type RequestFunction = typeof httpModule.request;
 
@@ -64,26 +64,25 @@ export class HttpPlugin extends BasePlugin {
     // In Node 8, http.get calls a private request method, therefore we patch it
     // here too.
     if (semver.satisfies(this.version, '>=8.0.0')) {
-      
-      shimmer.wrap(
-          this.moduleExports, 'get', () => {
-            // Re-implement http.get. This needs to be done (instead of using
-            // getPatchOutgoingRequestFunction to patch it) because we need to 
-            // set the trace context header before the returned ClientRequest is ended.
-            // The Node.js docs state that the only differences between request and
-            // get are that (1) get defaults to the HTTP GET method and (2) the
-            // returned request object is ended immediately.
-            // The former is already true (at least in supported Node versions up to
-            // v9), so we simply follow the latter.
-            // Ref:
-            // https://nodejs.org/dist/latest/docs/api/http.html#http_http_get_options_callback
-            // https://github.com/googleapis/cloud-trace-nodejs/blob/master/src/plugins/plugin-http.ts#L198
-            return function getTrace (options: httpModule.RequestOptions|string, callback: HttpGetCallback) {
-              const req = httpModule.request(options, callback)
-              req.end()
-              return req
-            }
-          })
+      shimmer.wrap(this.moduleExports, 'get', () => {
+        // Re-implement http.get. This needs to be done (instead of using
+        // getPatchOutgoingRequestFunction to patch it) because we need to
+        // set the trace context header before the returned ClientRequest is
+        // ended. The Node.js docs state that the only differences between
+        // request and get are that (1) get defaults to the HTTP GET method and
+        // (2) the returned request object is ended immediately. The former is
+        // already true (at least in supported Node versions up to v9), so we
+        // simply follow the latter. Ref:
+        // https://nodejs.org/dist/latest/docs/api/http.html#http_http_get_options_callback
+        // https://github.com/googleapis/cloud-trace-nodejs/blob/master/src/plugins/plugin-http.ts#L198
+        return function getTrace(
+            options: httpModule.RequestOptions|string,
+            callback: HttpGetCallback) {
+          const req = httpModule.request(options, callback);
+          req.end();
+          return req;
+        };
+      });
     }
 
     if (this.moduleExports && this.moduleExports.Server &&

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -24,7 +24,7 @@ import * as uuid from 'uuid';
 import {HttpPluginConfig, IgnoreMatcher} from './types';
 
 
-
+export type HttpGetCallback = (res: httpModule.IncomingMessage) => void
 export type HttpModule = typeof httpModule;
 export type RequestFunction = typeof httpModule.request;
 
@@ -64,8 +64,26 @@ export class HttpPlugin extends BasePlugin {
     // In Node 8, http.get calls a private request method, therefore we patch it
     // here too.
     if (semver.satisfies(this.version, '>=8.0.0')) {
+      
       shimmer.wrap(
-          this.moduleExports, 'get', this.getPatchOutgoingRequestFunction());
+          this.moduleExports, 'get', () => {
+            // Re-implement http.get. This needs to be done (instead of using
+            // getPatchOutgoingRequestFunction to patch it) because we need to 
+            // set the trace context header before the returned ClientRequest is ended.
+            // The Node.js docs state that the only differences between request and
+            // get are that (1) get defaults to the HTTP GET method and (2) the
+            // returned request object is ended immediately.
+            // The former is already true (at least in supported Node versions up to
+            // v9), so we simply follow the latter.
+            // Ref:
+            // https://nodejs.org/dist/latest/docs/api/http.html#http_http_get_options_callback
+            // https://github.com/googleapis/cloud-trace-nodejs/blob/master/src/plugins/plugin-http.ts#L198
+            return function getTrace (options: httpModule.RequestOptions|string, callback: HttpGetCallback) {
+              const req = httpModule.request(options, callback)
+              req.end()
+              return req
+            }
+          })
     }
 
     if (this.moduleExports && this.moduleExports.Server &&

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CoreTracer, RootSpan, Span, SpanEventListener, HeaderGetter, HeaderSetter, Propagation, SpanContext} from '@opencensus/core';
+import {CoreTracer, HeaderGetter, HeaderSetter, Propagation, RootSpan, Span, SpanContext, SpanEventListener} from '@opencensus/core';
 import {logger} from '@opencensus/core';
 import * as assert from 'assert';
 import * as http from 'http';
@@ -57,10 +57,7 @@ const VERSION = process.versions.node;
 
 class DummyPropagation implements Propagation {
   extract(getter: HeaderGetter): SpanContext {
-    return {
-      traceId: 'dummy-trace-id',
-      spanId: 'dummy-span-id'
-    } as SpanContext;
+    return {traceId: 'dummy-trace-id', spanId: 'dummy-span-id'} as SpanContext;
   }
 
   inject(setter: HeaderSetter, spanContext: SpanContext): void {
@@ -69,10 +66,7 @@ class DummyPropagation implements Propagation {
   }
 
   generate(): SpanContext {
-    return {
-      traceId: 'dummy-trace-id',
-      spanId: 'dummy-span-id'
-    } as SpanContext;
+    return {traceId: 'dummy-trace-id', spanId: 'dummy-span-id'} as SpanContext;
   }
 }
 
@@ -112,7 +106,8 @@ describe('HttpPlugin', () => {
   const log = logger.logger();
   const tracer = new CoreTracer();
   const rootSpanVerifier = new RootSpanVerifier();
-  tracer.start({samplingRate: 1, logger: log, propagation: new DummyPropagation()});
+  tracer.start(
+      {samplingRate: 1, logger: log, propagation: new DummyPropagation()});
 
 
   it('should return a plugin', () => {
@@ -295,19 +290,20 @@ describe('HttpPlugin', () => {
       });
     }
 
-    it('should create a rootSpan for GET requests and add propagation headers', async () => {
-      nock.enableNetConnect();
-      assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
-      await httpRequest.get(`http://google.fr/`).then((result) => {
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
-        assert.ok(
-            rootSpanVerifier.endedRootSpans[0].name.indexOf('GET /') >= 0);
+    it('should create a rootSpan for GET requests and add propagation headers',
+       async () => {
+         nock.enableNetConnect();
+         assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+         await httpRequest.get(`http://google.fr/`).then((result) => {
+           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
+           assert.ok(
+               rootSpanVerifier.endedRootSpans[0].name.indexOf('GET /') >= 0);
 
-        const span = rootSpanVerifier.endedRootSpans[0];
-        assertSpanAttributes(span, 301, 'GET', 'google.fr', '/', undefined);
-      });
-      nock.disableNetConnect();
-    });
+           const span = rootSpanVerifier.endedRootSpans[0];
+           assertSpanAttributes(span, 301, 'GET', 'google.fr', '/', undefined);
+         });
+         nock.disableNetConnect();
+       });
   });
 
 


### PR DESCRIPTION
I got the same issue as #117 while integrating the tracing system into my APM.
I did go over https://github.com/googleapis/cloud-trace-nodejs/ to checkout their implementation and found a details that could explain the problem: https://github.com/googleapis/cloud-trace-nodejs/blob/master/src/plugins/plugin-http.ts#L198

The test are passing for one good reason: they are all `nocked`, so the actual http code never run. I added a test that make a GET request to `google.fr`, it might be better to spawn a local server to avoid instability due to network.

