### PR TITLE
Update examples to work with global stats instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OpenCensus Libraries for Node.js
-[![Gitter chat][gitter-image]][gitter-url] ![Node Version][node-img] [![NPM Published Version][npm-img]][npm-url] ![Apache License][license-image]
+[![Gitter chat][gitter-image]][gitter-url] ![Node Version][node-img] [![NPM Published Version][npm-img]][npm-url] [![codecov][codecov-image]][codecov-url] ![Apache License][license-image]
 
 OpenCensus Node.js is an implementation of OpenCensus, a toolkit for collecting application performance and behavior monitoring data. Right now OpenCensus for Node.js supports custom tracing and automatic tracing for HTTP and HTTPS. Please visit the [OpenCensus Node.js package](https://github.com/census-instrumentation/opencensus-node/tree/master/packages/opencensus-nodejs) for usage.
 
@@ -73,6 +73,8 @@ months before removing it, if possible.
 - For more information on OpenCensus, visit: <https://opencensus.io/>
 - For help or feedback on this project, join us on [gitter](https://gitter.im/census-instrumentation/Lobby)
 
+[codecov-image]: https://codecov.io/gh/census-instrumentation/opencensus-node/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/census-instrumentation/opencensus-node
 [gitter-image]: https://badges.gitter.im/census-instrumentation/lobby.svg
 [gitter-url]: https://gitter.im/census-instrumentation/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [npm-url]: https://www.npmjs.com/package/@opencensus/exporter-prometheus

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "opencensus",
     "nodejs",
     "tracing",
-    "profiling"
+    "profiling",
+    "metrics",
+    "stats"
   ],
   "author": "Google Inc.",
   "license": "Apache-2.0",

--- a/packages/opencensus-core/README.md
+++ b/packages/opencensus-core/README.md
@@ -73,6 +73,19 @@ function sinceInMilliseconds(startNanoseconds) {
 }
 ```
 
+Measures can be of type `Int64` or `DOUBLE`, created by calling `createMeasureInt64` and `createMeasureDouble` respectively. Its units can be:
+
+| MeasureUnit | Usage |
+| ----------- | ----- |
+| `UNIT` | for general counts |
+| `BYTE` | bytes |
+| `KBYTE` | Kbytes |
+| `SEC` | seconds |
+| `MS` | millisecond |
+| `NS` | nanosecond |
+
+Views can have agregations of type `SUM`, `LAST_VALUE`, `COUNT` and `DISTRIBUTION`. To know more about Stats core concepts, please visit: [https://opencensus.io/core-concepts/metrics/](https://opencensus.io/core-concepts/metrics/)
+
 See [Quickstart/Metrics](https://opencensus.io/quickstart/nodejs/metrics/) for a full example of registering and collecting metrics.
 
 ## Useful links

--- a/packages/opencensus-core/package.json
+++ b/packages/opencensus-core/package.json
@@ -21,7 +21,9 @@
     "opencensus",
     "nodejs",
     "tracing",
-    "profiling"
+    "profiling",
+    "metrics",
+    "stats"
   ],
   "author": "Google Inc.",
   "license": "Apache-2.0",

--- a/packages/opencensus-exporter-prometheus/README.md
+++ b/packages/opencensus-exporter-prometheus/README.md
@@ -1,7 +1,7 @@
 # OpenCensus Prometheus Exporter for Node.js
 [![Gitter chat][gitter-image]][gitter-url] ![Node Version][node-img] [![NPM Published Version][npm-img]][npm-url] ![dependencies Status][dependencies-status] ![devDependencies Status][devdependencies-status] ![Apache License][license-image]
 
-The OpenCensus Prometheus Exporter allows the user to send collected stats with [OpenCensus Node.js](https://github.com/census-instrumentation/opencensus-node) to Prometheus.
+The OpenCensus Prometheus Exporter allows the user to send collected stats with [OpenCensus Core](https://github.com/census-instrumentation/opencensus-core) to Prometheus.
 
 This package is still at an early stage of development, and is subject to change.
 
@@ -15,9 +15,9 @@ npm install @opencensus/exporter-prometheus
 
 ## Usage
 
-Instance the exporter on your application.
+Create & register the exporter on your application.
 
-For javascript:
+For Javascript:
 ```javascript
 const { globalStats } = require('@opencensus/core');
 const { PrometheusStatsExporter } = require('@opencensus/exporter-prometheus');
@@ -36,7 +36,7 @@ Now, register the exporter.
 globalStats.registerExporter(exporter);
 ```
 
-Similarly for Typescript (Since the source is written in TypeScript):
+Similarly for TypeScript (Since the source is written in TypeScript):
 ```typescript
 import { PrometheusStatsExporter } from '@opencensus/exporter-prometheus';
 import { globalStats } from '@opencensus/core';

--- a/packages/opencensus-exporter-prometheus/README.md
+++ b/packages/opencensus-exporter-prometheus/README.md
@@ -15,49 +15,38 @@ npm install @opencensus/exporter-prometheus
 
 ## Usage
 
-Instance the exporter on your application. 
+Instance the exporter on your application.
 
 For javascript:
 ```javascript
-const { Stats } = require('@opencensus/core');
+const { globalStats } = require('@opencensus/core');
 const { PrometheusStatsExporter } = require('@opencensus/exporter-prometheus');
 
 // Add your port and startServer to the Prometheus options
 const exporter = new PrometheusStatsExporter({
   port: 9464,
-  startServer: false
+  startServer: true
 });
 ```
 
 Now, register the exporter.
 
 ```javascript
-// Our Stats manager
-const stats = new Stats();
-
 // Pass the created exporter to Stats
-stats.registerExporter(exporter);
-
-// Run the server
-exporter.startServer(function callback() {
-  // Callback
-});
+globalStats.registerExporter(exporter);
 ```
 
 Similarly for Typescript (Since the source is written in TypeScript):
 ```typescript
 import { PrometheusStatsExporter } from '@opencensus/exporter-prometheus';
-import { Stats } from '@opencensus/core';
+import { globalStats } from '@opencensus/core';
 
 // Add your port and startServer to the Prometheus options
-const options = {port: 9464, startServer: false};
+const options = {port: 9464, startServer: true};
 const exporter = new PrometheusStatsExporter(options);
 
-// Our Stats manager
-const stats = new Stats();
-
 // Pass the created exporter to Stats
-stats.registerExporter(exporter);
+globalStats.registerExporter(exporter);
 ```
 
 Viewing your metrics:
@@ -80,6 +69,6 @@ With the above you should now be able to navigate to the Prometheus UI at: <http
 [devdependencies-status]:
 https://david-dm.org/census-instrumentation/opencensus-node/dev-status.svg?path=packages/opencensus-exporter-prometheus
 
-## LICENSE 
+## LICENSE
 
 Apache License 2.0

--- a/packages/opencensus-exporter-stackdriver/README.md
+++ b/packages/opencensus-exporter-stackdriver/README.md
@@ -1,7 +1,7 @@
 # OpenCensus Stackdriver Exporter for Node.js
 [![Gitter chat][gitter-image]][gitter-url]
 
-OpenCensus Stackdriver Exporter allows the user to send collected traces with [OpenCensus Node.js](https://github.com/census-instrumentation/opencensus-node) to Stackdriver.
+OpenCensus Stackdriver Exporter allows the user to send collected traces with [OpenCensus Node.js](https://github.com/census-instrumentation/opencensus-node) and stats with [OpenCensus Core](https://github.com/census-instrumentation/opencensus-core) to Stackdriver Cloud Tracing and Stackdriver Monitoring.
 
 This project is still at an early stage of development. It's subject to change.
 
@@ -35,7 +35,7 @@ var exporter = new StackdriverTraceExporter({projectId: "your-project-id"});
 tracing.registerExporter(exporter).start();
 ```
 
-Similarly for Typescript:
+Similarly for TypeScript:
 
 ```typescript
 import * as tracing from '@opencensus/nodejs';
@@ -92,7 +92,7 @@ const exporter = new StackdriverStatsExporter({ projectId: "your-project-id" });
 globalStats.registerExporter(exporter);
 ```
 
-Similarly for Typescript:
+Similarly for TypeScript:
 ```typescript
 import { globalStats } from '@opencensus/core';
 import { StackdriverStatsExporter } from '@opencensus/exporter-stackdriver';

--- a/packages/opencensus-exporter-stackdriver/README.md
+++ b/packages/opencensus-exporter-stackdriver/README.md
@@ -5,6 +5,7 @@ OpenCensus Stackdriver Exporter allows the user to send collected traces with [O
 
 This project is still at an early stage of development. It's subject to change.
 
+# OpenCensus Stackdriver Trace Exporter
 ## Installation
 
 Install OpenCensus Stackdriver Exporter with:
@@ -24,11 +25,11 @@ export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credential.json
 Instance the exporter on your application and pass your Project ID. For javascript:
 
 ```javascript
-var tracing = require('@opencensus/nodejs');
-var stackdriver = require('@opencensus/exporter-stackdriver');
+const tracing = require('@opencensus/nodejs');
+const { StackdriverTraceExporter } = require('@opencensus/exporter-stackdriver');
 
 // Add your project id to the Stackdriver options
-var exporter = new stackdriver.StackdriverTraceExporter({projectId: "your-project-id"});
+var exporter = new StackdriverTraceExporter({projectId: "your-project-id"});
 
 tracing.registerExporter(exporter).start();
 ```
@@ -54,6 +55,58 @@ or
 ```javascript
 tracing.registerExporter(exporter).start();
 ```
+
+Viewing your traces:
+
+With the above you should now be able to navigate to the Stackdriver UI at: <https://console.cloud.google.com/traces/traces>
+
+# OpenCensus Stackdriver Stats/Metrics Exporter
+## Installation
+
+Install OpenCensus Stackdriver Exporter with:
+```bash
+npm install @opencensus/core
+npm install @opencensus/exporter-stackdriver
+```
+
+## Usage
+
+To use Stackdriver as your exporter, make sure you have enabled [Stackdriver Monitoring](https://cloud.google.com/monitoring/docs/quickstart) on Google Cloud Platform. Enable your [Application Default Credentials](https://cloud.google.com/docs/authentication/getting-started) for authentication with:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credential.json
+```
+
+Instance the exporter on your application.
+
+For javascript:
+```javascript
+const { globalStats } = require('@opencensus/core');
+const { StackdriverStatsExporter } = require('@opencensus/exporter-stackdriver');
+
+// Add your project id to the Stackdriver options
+const exporter = new StackdriverStatsExporter({ projectId: "your-project-id" });
+
+// Pass the created exporter to Stats
+globalStats.registerExporter(exporter);
+```
+
+Similarly for Typescript (Since the source is written in TypeScript):
+```typescript
+import { globalStats } from '@opencensus/core';
+import { StackdriverStatsExporter } from '@opencensus/exporter-stackdriver';
+
+// Add your project id to the Stackdriver options
+const exporter = new StackdriverStatsExporter({ projectId: "your-project-id" });
+
+// Pass the created exporter to Stats
+globalStats.registerExporter(exporter);
+```
+
+Viewing your metrics:
+
+With the above you should now be able to navigate to the Stackdriver UI at: <https://console.cloud.google.com/monitoring>
+
 
 ## Useful links
 - To know more about Stackdriver, visit: <https://cloud.google.com/docs/authentication/getting-started>

--- a/packages/opencensus-exporter-stackdriver/README.md
+++ b/packages/opencensus-exporter-stackdriver/README.md
@@ -22,8 +22,9 @@ To use Stackdriver as your exporter, make sure you have enabled [Stackdriver Tra
 export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credential.json
 ```
 
-Instance the exporter on your application and pass your Project ID. For javascript:
+Create and register the exporter on your application and pass your Project ID.
 
+For Javascript:
 ```javascript
 const tracing = require('@opencensus/nodejs');
 const { StackdriverTraceExporter } = require('@opencensus/exporter-stackdriver');
@@ -60,7 +61,7 @@ Viewing your traces:
 
 With the above you should now be able to navigate to the Stackdriver UI at: <https://console.cloud.google.com/traces/traces>
 
-# OpenCensus Stackdriver Stats/Metrics Exporter
+# OpenCensus Stackdriver Stats(Metrics) Exporter
 ## Installation
 
 Install OpenCensus Stackdriver Exporter with:
@@ -77,9 +78,9 @@ To use Stackdriver as your exporter, make sure you have enabled [Stackdriver Mon
 export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credential.json
 ```
 
-Instance the exporter on your application.
+Create and register the exporter on your application.
 
-For javascript:
+For Javascript:
 ```javascript
 const { globalStats } = require('@opencensus/core');
 const { StackdriverStatsExporter } = require('@opencensus/exporter-stackdriver');
@@ -91,7 +92,7 @@ const exporter = new StackdriverStatsExporter({ projectId: "your-project-id" });
 globalStats.registerExporter(exporter);
 ```
 
-Similarly for Typescript (Since the source is written in TypeScript):
+Similarly for Typescript:
 ```typescript
 import { globalStats } from '@opencensus/core';
 import { StackdriverStatsExporter } from '@opencensus/exporter-stackdriver';

--- a/packages/opencensus-exporter-stackdriver/package.json
+++ b/packages/opencensus-exporter-stackdriver/package.json
@@ -20,7 +20,9 @@
     "opencensus",
     "nodejs",
     "tracing",
-    "profiling"
+    "profiling",
+    "metrics",
+    "stats"
   ],
   "author": "Google Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR contains updated examples based on CHAGELOG -> https://github.com/census-instrumentation/opencensus-node/blob/master/CHANGELOG.md#new-code

Also, added ReadMe for the Stackdriver Stats(Metrics) exporter.