### PR TITLE
Add message sizes to `addMessageEvent` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add `compressedSize` and `uncompressedSize` params to `Span.addMessageEvent`
 
 ## 0.0.9 - 2019-02-12
 - Add Metrics API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Add `compressedSize` and `uncompressedSize` params to `Span.addMessageEvent`
+- Add optional `compressedSize` and `uncompressedSize` params to `Span.addMessageEvent`
 
 ## 0.0.9 - 2019-02-12
 - Add Metrics API.

--- a/packages/opencensus-core/src/trace/model/span-base.ts
+++ b/packages/opencensus-core/src/trace/model/span-base.ts
@@ -209,8 +209,8 @@ export abstract class SpanBase implements types.Span {
    * @param type The type of message event.
    * @param id An identifier for the message event.
    * @param timestamp A time in milliseconds. Defaults to Date.now()
-   * @param compressedSize The number of uncompressed bytes sent or received
-   * @param uncompressedSize The number of compressed bytes sent or received. If
+   * @param uncompressedSize The number of uncompressed bytes sent or received
+   * @param compressedSize The number of compressed bytes sent or received. If
    *     zero or undefined, assumed to be the same size as uncompressed.
    */
   addMessageEvent(

--- a/packages/opencensus-core/src/trace/model/span-base.ts
+++ b/packages/opencensus-core/src/trace/model/span-base.ts
@@ -209,8 +209,13 @@ export abstract class SpanBase implements types.Span {
    * @param type The type of message event.
    * @param id An identifier for the message event.
    * @param timestamp A time in milliseconds. Defaults to Date.now()
+   * @param compressedSize The number of uncompressed bytes sent or received
+   * @param uncompressedSize The number of compressed bytes sent or received. If
+   *     zero or undefined, assumed to be the same size as uncompressed.
    */
-  addMessageEvent(type: types.MessageEventType, id: string, timestamp = 0) {
+  addMessageEvent(
+      type: types.MessageEventType, id: string, timestamp = 0,
+      uncompressedSize?: number, compressedSize?: number) {
     if (this.messageEvents.length >=
         this.activeTraceParams.numberOfMessageEventsPerSpan) {
       this.messageEvents.shift();
@@ -218,9 +223,11 @@ export abstract class SpanBase implements types.Span {
     }
 
     this.messageEvents.push({
-      'type': type,
-      'id': id,
-      'timestamp': timestamp ? timestamp : Date.now(),
+      type,
+      id,
+      timestamp: timestamp ? timestamp : Date.now(),
+      uncompressedSize,
+      compressedSize,
     } as types.MessageEvent);
   }
 

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -192,7 +192,13 @@ export interface MessageEvent {
   timestamp: number;
   /** Indicates whether the message was sent or received. */
   type: MessageEventType;
-  /** An identifier for the MessageEvent's message. */
+  /**
+   * An identifier for the MessageEvent's message. This should be a hexadecimal
+   * value that fits within 64-bits. Message event ids should start with 1 for
+   * both sent and received messages and increment by 1 for each message
+   * sent/received. See:
+   * https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/gRPC.md#message-events
+   */
   id: string;
   /** The number of uncompressed bytes sent or received. */
   uncompressedSize?: number;

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -21,7 +21,6 @@ import {CoreTracer} from '../src/trace/model/tracer';
 import * as types from '../src/trace/model/types';
 import {Annotation, Attributes, Link} from '../src/trace/model/types';
 
-
 // TODO: we should evaluate a way to merge similar test cases between span and
 // rootspan
 
@@ -304,9 +303,18 @@ describe('Span', () => {
       span.start();
 
       span.addMessageEvent(
-          types.MessageEventType.UNSPECIFIED, 'message_event_test_id');
+          types.MessageEventType.UNSPECIFIED, /* id */ '1',
+          /* timestamp */ 1550000000000, /* uncompressedSize */ 55,
+          /** compressedSize */ 40);
 
       assert.ok(span.messageEvents.length > 0);
+      assert.deepEqual(span.messageEvents, [{
+                         type: types.MessageEventType.UNSPECIFIED,
+                         id: '1',
+                         timestamp: 1550000000000,
+                         uncompressedSize: 55,
+                         compressedSize: 40,
+                       }]);
       assert.equal(span.droppedMessageEventsCount, 0);
       assert.ok(instanceOfLink(span.messageEvents[0]));
     });


### PR DESCRIPTION
Message size parameters were added in https://github.com/census-instrumentation/opencensus-node/pull/323 and this now adds them to the `addMessageEvent` function on span as optional parameters.

This also adds a comment to the `id` field of the `MessageEvent` interface to explain that it is a hexadecimal string that should increment as new messages are sent.

cc/ @odeke-em 