### PR TITLE
add default value when `attributes` are not specified

### DIFF
--- a/packages/opencensus-core/src/trace/model/span-base.ts
+++ b/packages/opencensus-core/src/trace/model/span-base.ts
@@ -176,7 +176,7 @@ export abstract class SpanBase implements types.Span {
     }
     this.annotations.push({
       'description': description,
-      'attributes': attributes,
+      'attributes': attributes || {},
       'timestamp': timestamp ? timestamp : Date.now(),
     } as types.Annotation);
   }
@@ -200,7 +200,7 @@ export abstract class SpanBase implements types.Span {
       'traceId': traceId,
       'spanId': spanId,
       'type': type,
-      'attributes': attributes
+      'attributes': attributes || {}
     } as types.Link);
   }
 

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -210,6 +210,19 @@ describe('RootSpan', () => {
       assert.equal(rootSpan.droppedAnnotationsCount, 0);
       assert.ok(instanceOfAnnotation(rootSpan.annotations[0]));
     });
+
+    it('should add an annotation without attributes and timestamp', () => {
+      const rootSpan = new RootSpan(tracer);
+      rootSpan.start();
+
+      rootSpan.addAnnotation('description test');
+
+      assert.ok(rootSpan.annotations.length > 0);
+      assert.equal(rootSpan.droppedAnnotationsCount, 0);
+      assert.equal(rootSpan.annotations[0].description, 'description test');
+      assert.deepEqual(rootSpan.annotations[0].attributes, {});
+      assert.ok(rootSpan.annotations[0].timestamp > 0);
+    });
   });
 
   /**

--- a/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
+++ b/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
@@ -535,13 +535,15 @@ describe('OpenCensus Agent Exporter', () => {
                   type: 'PARENT_LINKED_SPAN',
                   traceId: buff,
                   spanId: buff,
-                  attributes: null
+                  attributes:
+                      {'attributeMap': {}, 'droppedAttributesCount': 0}
                 },
                 {
                   type: 'TYPE_UNSPECIFIED',
                   traceId: buff,
                   spanId: buff,
-                  attributes: null
+                  attributes:
+                      {'attributeMap': {}, 'droppedAttributesCount': 0}
                 }
               ]
             });
@@ -712,7 +714,8 @@ describe('OpenCensus Agent Exporter', () => {
                      type: 'PARENT_LINKED_SPAN',
                      traceId: buff,
                      spanId: buff,
-                     attributes: null
+                     attributes:
+                         {'attributeMap': {}, 'droppedAttributesCount': 0}
                    }
                  ]
                });


### PR DESCRIPTION
This will fix the issue when we export data to Stackdriver backend https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace-utils.ts#L120, otherwise the program will crash when optional ```attributes``` is missing. 

I have open an issue #348 to enable ```strictNullChecks ``` on this repo.