### PR TITLE
Add support for recording HTTP stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to this project will be documented in this file.
 - Add support for ```tags```, ```status``` and ```annotation``` in Zipkin exporter.
 - Add support for Binary propagation format.
 - Add support for object(```SpanOptions```) as an argument for ```startChildSpan``` function, similar to ```startRootSpan```.
-- Add proto files to exporter-ocagent package. Fixes issue [#174](https://github.com/census-instrumentation/opencensus-node/issues/174). 
+- Add proto files to exporter-ocagent package. Fixes issue [#174](https://github.com/census-instrumentation/opencensus-node/issues/174).
 - Remove `ConfigStream` behavior from exporter-ocagent. This was unstable and is not currently supported by any other language instrumentation.
 - Change default exporter-ocagent port to `55678` to match the default OC Agent port.
+- Add support for recording HTTP stats.
 
 ## 0.0.9 - 2019-02-12
 - Add Metrics API.

--- a/packages/opencensus-instrumentation-grpc/src/index.ts
+++ b/packages/opencensus-instrumentation-grpc/src/index.ts
@@ -15,11 +15,4 @@
  */
 
 export * from './grpc';
-
-import {registerAllGrpcViews, registerClientGrpcBasicViews, registerServerGrpcBasicViews} from './grpc-stats/stats-common';
-
-export {
-  registerAllGrpcViews,
-  registerClientGrpcBasicViews,
-  registerServerGrpcBasicViews
-};
+export {registerAllGrpcViews, registerClientGrpcBasicViews, registerServerGrpcBasicViews} from './grpc-stats/stats-common';

--- a/packages/opencensus-instrumentation-http/src/http-stats.ts
+++ b/packages/opencensus-instrumentation-http/src/http-stats.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {AggregationType, globalStats, MeasureUnit, Stats, View} from '@opencensus/core';
+import {AggregationType, globalStats, Measure, MeasureUnit, Stats, View} from '@opencensus/core';
 
 /**
  * {@link Measure} for the client-side total bytes sent in request body (not
  * including headers). This is uncompressed bytes.
  */
-export const HTTP_CLIENT_SENT_BYTES = globalStats.createMeasureInt64(
+export const HTTP_CLIENT_SENT_BYTES: Measure = globalStats.createMeasureInt64(
     'opencensus.io/http/client/sent_bytes', MeasureUnit.BYTE,
     'Client-side total bytes sent in request body (uncompressed)');
 
@@ -31,15 +31,16 @@ export const HTTP_CLIENT_SENT_BYTES = globalStats.createMeasureInt64(
  * the Content-Length header. This is uncompressed bytes. Responses with no
  * body should record 0 for this value.
  */
-export const HTTP_CLIENT_RECEIVED_BYTES = globalStats.createMeasureInt64(
-    'opencensus.io/http/client/received_bytes', MeasureUnit.BYTE,
-    'Client-side total bytes received in response bodies (uncompressed)');
+export const HTTP_CLIENT_RECEIVED_BYTES: Measure =
+    globalStats.createMeasureInt64(
+        'opencensus.io/http/client/received_bytes', MeasureUnit.BYTE,
+        'Client-side total bytes received in response bodies (uncompressed)');
 
 /**
  * {@link Measure} for the client-side time between first byte of request
  * headers sent to last byte of response received, or terminal error.
  */
-export const HTTP_CLIENT_ROUNDTRIP_LATENCY = globalStats.createMeasureDouble(
+export const HTTP_CLIENT_ROUNDTRIP_LATENCY: Measure = globalStats.createMeasureDouble(
     'opencensus.io/http/client/roundtrip_latency', MeasureUnit.MS,
     'Client-side time between first byte of request headers sent to last byte of response received, or terminal error');
 
@@ -47,9 +48,10 @@ export const HTTP_CLIENT_ROUNDTRIP_LATENCY = globalStats.createMeasureDouble(
  * {@link Measure} for the server-side total bytes received in request body
  * (not including headers). This is uncompressed bytes.
  */
-export const HTTP_SERVER_RECEIVED_BYTES = globalStats.createMeasureInt64(
-    'opencensus.io/http/server/received_bytes', MeasureUnit.BYTE,
-    'Server-side total bytes received in request body (uncompressed)');
+export const HTTP_SERVER_RECEIVED_BYTES: Measure =
+    globalStats.createMeasureInt64(
+        'opencensus.io/http/server/received_bytes', MeasureUnit.BYTE,
+        'Server-side total bytes received in request body (uncompressed)');
 
 /**
  * {@link Measure} for the server-side total bytes sent in response bodies
@@ -58,7 +60,7 @@ export const HTTP_SERVER_RECEIVED_BYTES = globalStats.createMeasureInt64(
  * Content-Length header. This is uncompressed bytes. Responses with no
  * body should record 0 for this value.
  */
-export const HTTP_SERVER_SENT_BYTES = globalStats.createMeasureInt64(
+export const HTTP_SERVER_SENT_BYTES: Measure = globalStats.createMeasureInt64(
     'opencensus.io/http/server/sent_bytes', MeasureUnit.BYTE,
     'Server-side total bytes sent in response bodies (uncompressed)');
 
@@ -66,7 +68,7 @@ export const HTTP_SERVER_SENT_BYTES = globalStats.createMeasureInt64(
  * {@link Measure} for the server-side time between first byte of request
  * headers received to last byte of response sent, or terminal error.
  */
-export const HTTP_SERVER_LATENCY = globalStats.createMeasureDouble(
+export const HTTP_SERVER_LATENCY: Measure = globalStats.createMeasureDouble(
     'opencensus.io/http/server/server_latency', MeasureUnit.MS,
     'Server-side time between first byte of request headers received to last byte of response sent, or terminal error');
 

--- a/packages/opencensus-instrumentation-http/src/index.ts
+++ b/packages/opencensus-instrumentation-http/src/index.ts
@@ -15,6 +15,4 @@
  */
 
 export * from './http';
-import {registerAllClientViews, registerAllServerViews, registerAllViews} from './http-stats';
-
-export {registerAllClientViews, registerAllServerViews, registerAllViews};
+export {registerAllClientViews, registerAllServerViews, registerAllViews} from './http-stats';

--- a/packages/opencensus-instrumentation-http/src/index.ts
+++ b/packages/opencensus-instrumentation-http/src/index.ts
@@ -15,3 +15,6 @@
  */
 
 export * from './http';
+import {registerAllClientViews, registerAllServerViews, registerAllViews} from './http-stats';
+
+export {registerAllClientViews, registerAllServerViews, registerAllViews};

--- a/packages/opencensus-instrumentation-http/tsconfig.json
+++ b/packages/opencensus-instrumentation-http/tsconfig.json
@@ -9,7 +9,7 @@
     "module": "commonjs",
     "target": "es6",
     "strictNullChecks": true,
-    "noUnusedLocals": false
+    "noUnusedLocals": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This PR provides instrumentation for HTTP Client and Server to record HTTP stats. Part of https://github.com/census-instrumentation/opencensus-node/issues/269

These changes have all been tested locally against prometheus exporter and been confirmed to be working.

<img width="1021" alt="screen shot 2019-02-27 at 11 11 41 pm" src="https://user-images.githubusercontent.com/6525361/53547929-2a1d5d00-3ae5-11e9-9e73-bf13f3dd6a7f.png">

I will work on recording stats for send/received bytes in seperate PR.