### PR TITLE
chore: add node 11 ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,14 @@ workflows:
           filters: *release_tags
       - node10:
           filters: *release_tags
+      - node11:
+          filters: *release_tags
       - publish_npm:
           requires:
             - node6
             - node8
             - node10
+            - node11
           filters:
             branches:
               ignore: /.*/
@@ -63,6 +66,13 @@ jobs:
   node10:
     docker:
       - image: node:10
+        user: node
+        environment: *test_env
+      - *mongo_service
+    <<: *unit_tests
+  node11:
+    docker:
+      - image: node:11
         user: node
         environment: *test_env
       - *mongo_service


### PR DESCRIPTION
I am optimistic about tests and build, Let's see how much work required to add support for node 11.

![image](https://user-images.githubusercontent.com/6525361/53594131-068efc80-3b4f-11e9-87c4-7990a26fe326.png)

