### PR TITLE
pass stats instance to plugin loader

### DIFF
--- a/examples/http/client.js
+++ b/examples/http/client.js
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-const path = require('path');
-const http = require('http');
 const tracing = require('@opencensus/nodejs');
-const { plugin } = require('@opencensus/instrumentation-http');
 const { ZipkinTraceExporter } = require('@opencensus/exporter-zipkin');
 const { TraceContextFormat } = require('@opencensus/propagation-tracecontext');
 
+/**
+ * The trace instance needs to be initialized first, if you want to enable
+ * automatic tracing for built-in plugins (HTTP in this case).
+ * https://github.com/census-instrumentation/opencensus-node#plugins
+ */
 const tracer = setupTracerAndExporters();
+
+const http = require('http');
 
 /** A function which makes requests and handles response. */
 function makeRequest () {
@@ -38,7 +42,7 @@ function makeRequest () {
       let body = [];
       response.on('data', chunk => body.push(chunk));
       response.on('end', () => {
-        console.log(body);
+        console.log(body.toString());
         rootSpan.end();
       });
     });
@@ -54,18 +58,13 @@ function setupTracerAndExporters () {
   // Creates Zipkin exporter
   const exporter = new ZipkinTraceExporter(zipkinOptions);
 
-  // Starts tracing and set sampling rate
-  const tracer = tracing.registerExporter(exporter).start({
+  // Starts tracing and set sampling rate, exporter and propagation
+  const tracer = tracing.start({
+    exporter,
     samplingRate: 1, // For demo purposes, always sample
-    propagation: new TraceContextFormat()
+    propagation: new TraceContextFormat(),
+    logLevel: 1 // show errors, if any
   }).tracer;
-
-  // Defines basedir and version
-  const basedir = path.dirname(require.resolve('http'));
-  const version = process.versions.node;
-
-  // Enables HTTP plugin: Method that enables the instrumentation patch.
-  plugin.enable(http, tracer, version, /** plugin options */{}, basedir);
 
   return tracer;
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@opencensus/exporter-zipkin": "^0.0.9",
-    "@opencensus/instrumentation-http": "^0.0.9",
     "@opencensus/nodejs": "^0.0.9",
     "@opencensus/propagation-tracecontext": "^0.0.9",
     "http": "*"

--- a/packages/opencensus-core/src/trace/config/types.ts
+++ b/packages/opencensus-core/src/trace/config/types.ts
@@ -16,6 +16,7 @@
 
 import {Logger} from '../../common/types';
 import {Exporter} from '../../exporters/types';
+import {Stats} from '../../stats/types';
 import {PluginNames} from '../instrumentation/types';
 import {Propagation} from '../propagation/types';
 
@@ -70,6 +71,8 @@ export interface TracingConfig {
   exporter?: Exporter;
   /** An instance of a logger  */
   logger?: Logger;
+  /** An instance of a stats  */
+  stats?: Stats;
 }
 
 /** Global configuration of trace service */

--- a/packages/opencensus-nodejs/src/trace/tracing.ts
+++ b/packages/opencensus-nodejs/src/trace/tracing.ts
@@ -74,7 +74,8 @@ export class Tracing implements core.Tracing {
         this.configLocal.logger || logger.logger(this.configLocal.logLevel);
     this.configLocal.logger = this.logger;
     this.logger.debug('config: %o', this.configLocal);
-    this.pluginLoader = new PluginLoader(this.logger, this.tracer);
+    this.pluginLoader =
+        new PluginLoader(this.logger, this.tracer, this.configLocal.stats);
     this.pluginLoader.loadPlugins(this.configLocal.plugins as core.PluginNames);
 
     if (!this.configLocal.exporter) {


### PR DESCRIPTION
Allow a way to pass ```stats``` instance to ```PluginLoader``` class, this will help users to collect stats for HTTP and GRPC plugin with automatic tracing. 

Also, I have updated the HTTP instrumentation example to capture traces without manually enabling the plugin.  I think this is the recommended and straightforward way for users to enable tracing on supported plugins/frameworks.