### PR TITLE
Add support for overriding sampling per span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Add NoRecordRootSpan, NoRecordSpan and NoRecordSpanBase.
 - Enforce `--strictNullChecks` and `--noUnusedLocals` Compiler Options on [opencensus-exporter-instana] package.
 - Add an API `globalStats.unregisterExporter()`.
+- Add support for overriding sampling for a span.
 
 ## 0.0.9 - 2019-02-12
 - Add Metrics API.

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-root-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-root-span.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as uuid from 'uuid';
 import * as logger from '../../../common/console-logger';
 import * as types from '../types';
 import {NoRecordSpan} from './no-record-span';
@@ -35,22 +34,25 @@ export class NoRecordRootSpan extends NoRecordSpanBase implements
   /**
    * Constructs a new NoRecordRootSpanImpl instance.
    * @param tracer A tracer object.
-   * @param context A trace options object to build the no-record root span.
+   * @param name The displayed name for the new span.
+   * @param kind The kind of new span.
+   * @param traceId The trace Id.
+   * @param parentSpanId The id of the parent span, or empty if the new span is
+   *     a root span.
+   * @param traceState Optional traceState.
    */
-  constructor(tracer: types.Tracer, context?: types.TraceOptions) {
+  constructor(
+      tracer: types.Tracer, name: string, kind: types.SpanKind, traceId: string,
+      parentSpanId: string, traceState?: types.TraceState) {
     super();
     this.tracer = tracer;
-    this.traceIdLocal =
-        context && context.spanContext && context.spanContext.traceId ?
-        context.spanContext.traceId :
-        (uuid.v4().split('-').join(''));
-    this.name = context && context.name ? context.name : 'undefined';
-    if (context && context.spanContext) {
-      this.parentSpanId = context.spanContext.spanId || '';
-      this.traceStateLocal = context.spanContext.traceState;
+    this.traceIdLocal = traceId;
+    this.name = name;
+    this.kind = kind;
+    this.parentSpanId = parentSpanId;
+    if (traceState) {
+      this.traceStateLocal = traceState;
     }
-    this.kind =
-        context && context.kind ? context.kind : types.SpanKind.UNSPECIFIED;
     this.logger = this.tracer.logger || logger.logger();
   }
 

--- a/packages/opencensus-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-core/src/trace/model/root-span.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as uuid from 'uuid';
 import * as logger from '../../common/console-logger';
 import {Span} from './span';
 import {SpanBase} from './span-base';
@@ -39,23 +38,26 @@ export class RootSpan extends SpanBase implements types.RootSpan {
   /**
    * Constructs a new RootSpanImpl instance.
    * @param tracer A tracer object.
-   * @param context A trace options object to build the root span.
+   * @param name The displayed name for the new span.
+   * @param kind The kind of new span.
+   * @param traceId The trace Id.
+   * @param parentSpanId The id of the parent span, or empty if the new span is
+   *     a root span.
+   * @param traceState Optional traceState.
    */
-  constructor(tracer: types.Tracer, context?: types.TraceOptions) {
+  constructor(
+      tracer: types.Tracer, name: string, kind: types.SpanKind, traceId: string,
+      parentSpanId: string, traceState?: types.TraceState) {
     super();
     this.tracer = tracer;
-    this.traceIdLocal =
-        context && context.spanContext && context.spanContext.traceId ?
-        context.spanContext.traceId :
-        (uuid.v4().split('-').join(''));
-    this.name = context && context.name ? context.name : 'undefined';
-    if (context && context.spanContext) {
-      this.parentSpanId = context.spanContext.spanId || '';
-      this.traceStateLocal = context.spanContext.traceState;
+    this.traceIdLocal = traceId;
+    this.name = name;
+    this.kind = kind;
+    this.parentSpanId = parentSpanId;
+    if (traceState) {
+      this.traceStateLocal = traceState;
     }
     this.spansLocal = [];
-    this.kind =
-        context && context.kind ? context.kind : types.SpanKind.UNSPECIFIED;
     this.logger = tracer.logger || logger.logger();
     this.activeTraceParams = tracer.activeTraceParams;
     this.numberOfChildrenLocal = 0;

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -232,6 +232,8 @@ export interface TraceOptions {
   spanContext?: SpanContext;
   /** Span kind */
   kind?: SpanKind;
+  /** Determines the sampling rate. Ranges from 0.0 to 1.0 */
+  samplingRate?: number;
 }
 
 /** Defines the span options */

--- a/packages/opencensus-core/test/test-console-exporter.ts
+++ b/packages/opencensus-core/test/test-console-exporter.ts
@@ -25,13 +25,17 @@ const defaultBufferConfig = {
   bufferSize: 1,
   bufferTimeout: 20000  // time in milliseconds
 };
+const name = 'MySpanName';
+const kind = SpanKind.SERVER;
+const traceId = 'd4cda95b652f4a1592b449d5929fda1b';
+const parentSpanId = '';
 
 describe('NoopExporter', () => {
   /** Should do nothing when calling onEndSpan() */
   describe('onEndSpan()', () => {
     it('should do nothing', () => {
       const exporter = new NoopExporter();
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       exporter.onEndSpan(rootSpan);
       assert.ok(true);
     });
@@ -41,7 +45,7 @@ describe('NoopExporter', () => {
   describe('publish()', () => {
     it('should do nothing', () => {
       const exporter = new NoopExporter();
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const queue: RootSpan[] = [rootSpan];
 
       return exporter.publish(queue);
@@ -61,11 +65,11 @@ describe('ConsoleLogExporter', () => {
 
       const exporter = new ConsoleExporter(defaultBufferConfig);
 
-      const rootSpan1 = new RootSpan(tracer);
+      const rootSpan1 = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       exporter.onEndSpan(rootSpan1);
       assert.strictEqual(capturedText, '');
 
-      const rootSpan2 = new RootSpan(tracer);
+      const rootSpan2 = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       exporter.onEndSpan(rootSpan2);
       [rootSpan1, rootSpan2].map(rootSpan => {
         assert.ok(capturedText.indexOf(rootSpan.traceId) >= 0);
@@ -85,7 +89,7 @@ describe('ConsoleLogExporter', () => {
       });
 
       const exporter = new ConsoleExporter(defaultBufferConfig);
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       rootSpan.startChildSpan('name', SpanKind.UNSPECIFIED, rootSpan.traceId);
       const queue: RootSpan[] = [rootSpan];

--- a/packages/opencensus-core/test/test-exporter-buffer.ts
+++ b/packages/opencensus-core/test/test-exporter-buffer.ts
@@ -22,7 +22,6 @@ import {ExporterBuffer} from '../src/exporters/exporter-buffer';
 import {RootSpan} from '../src/trace/model/root-span';
 import {CoreTracer} from '../src/trace/model/tracer';
 
-
 const exporter = new NoopExporter();
 const DEFAULT_BUFFER_SIZE = 3;
 const DEFAULT_BUFFER_TIMEOUT = 2000;  // time in milliseconds
@@ -34,11 +33,16 @@ const defaultBufferConfig = {
   logger: logger.logger()
 };
 
+const name = 'MySpanName';
+const kind = SpanKind.SERVER;
+const traceId = 'd4cda95b652f4a1592b449d5929fda1b';
+const parentSpanId = '';
 
 const createRootSpans = (num: number): RootSpan[] => {
   const rootSpans = [];
   for (let i = 0; i < num; i++) {
-    const rootSpan = new RootSpan(tracer, {name: `rootSpan.${i}`});
+    const rootSpan =
+        new RootSpan(tracer, `rootSpan.${i}`, kind, traceId, parentSpanId);
     rootSpan.start();
     for (let j = 0; j < 10; j++) {
       rootSpan.startChildSpan(`childSpan.${i}.${j}`, SpanKind.CLIENT);
@@ -79,7 +83,8 @@ describe('ExporterBuffer', () => {
   describe('addToBuffer', () => {
     it('should add one item to the Buffer', () => {
       const buffer = new ExporterBuffer(exporter, defaultBufferConfig);
-      buffer.addToBuffer(new RootSpan(tracer));
+      buffer.addToBuffer(
+          new RootSpan(tracer, name, kind, traceId, parentSpanId));
       assert.strictEqual(buffer.getQueue().length, 1);
     });
   });
@@ -95,7 +100,8 @@ describe('ExporterBuffer', () => {
         buffer.addToBuffer(rootSpan);
       }
       assert.strictEqual(buffer.getQueue().length, buffer.getBufferSize());
-      buffer.addToBuffer(new RootSpan(tracer));
+      buffer.addToBuffer(
+          new RootSpan(tracer, name, kind, traceId, parentSpanId));
       assert.strictEqual(buffer.getQueue().length, 0);
     });
   });
@@ -106,7 +112,8 @@ describe('ExporterBuffer', () => {
   describe('addToBuffer force flush by timeout ', () => {
     it('should flush by timeout', (done) => {
       const buffer = new ExporterBuffer(exporter, defaultBufferConfig);
-      buffer.addToBuffer(new RootSpan(tracer));
+      buffer.addToBuffer(
+          new RootSpan(tracer, name, kind, traceId, parentSpanId));
       assert.strictEqual(buffer.getQueue().length, 1);
       setTimeout(() => {
         assert.strictEqual(buffer.getQueue().length, 0);

--- a/packages/opencensus-core/test/test-no-record-root-span.ts
+++ b/packages/opencensus-core/test/test-no-record-root-span.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import {CanonicalCode, CoreTracer, LinkType, MessageEventType} from '../src';
+import {CanonicalCode, CoreTracer, LinkType, MessageEventType, SpanKind} from '../src';
 import {NoRecordRootSpan} from '../src/trace/model/no-record/no-record-root-span';
 
 const tracer = new CoreTracer();
 
 describe('NoRecordRootSpan()', () => {
   it('do not crash', () => {
-    const noRecordRootSpan = new NoRecordRootSpan(tracer);
+    const noRecordRootSpan =
+        new NoRecordRootSpan(tracer, 'name', SpanKind.SERVER, 'traceid', '');
     noRecordRootSpan.addAnnotation('MyAnnotation');
     noRecordRootSpan.addAnnotation('MyAnnotation', {myString: 'bar'});
     noRecordRootSpan.addAnnotation(

--- a/packages/opencensus-core/test/test-no-record-span.ts
+++ b/packages/opencensus-core/test/test-no-record-span.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CanonicalCode, CoreTracer, LinkType, MessageEventType} from '../src';
+import {CanonicalCode, CoreTracer, LinkType, MessageEventType, SpanKind} from '../src';
 import {NoRecordRootSpan} from '../src/trace/model/no-record/no-record-root-span';
 import {NoRecordSpan} from '../src/trace/model/no-record/no-record-span';
 
@@ -22,8 +22,9 @@ const tracer = new CoreTracer();
 
 describe('NoRecordSpan()', () => {
   it('do not crash', () => {
-    const root = new NoRecordRootSpan(tracer);
-    const noRecordSpan = new NoRecordSpan(root);
+    const noRecordRootSpan =
+        new NoRecordRootSpan(tracer, 'name', SpanKind.SERVER, 'traceid', '');
+    const noRecordSpan = new NoRecordSpan(noRecordRootSpan);
     noRecordSpan.addAnnotation('MyAnnotation');
     noRecordSpan.addAnnotation('MyAnnotation', {myString: 'bar'});
     noRecordSpan.addAnnotation(

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -19,30 +19,22 @@ import {RootSpan} from '../src/trace/model/root-span';
 import {Span} from '../src/trace/model/span';
 import {CoreTracer} from '../src/trace/model/tracer';
 import * as types from '../src/trace/model/types';
-import {Annotation, Attributes, Link, TraceOptions} from '../src/trace/model/types';
+import {Annotation, Attributes, Link} from '../src/trace/model/types';
 
 const tracer = new CoreTracer();
 
 describe('RootSpan', () => {
+  const name = 'MySpanName';
+  const kind = types.SpanKind.SERVER;
+  const traceId = 'd4cda95b652f4a1592b449d5929fda1b';
+  const parentSpanId = '';
+
   /**
    * Should create a RootSpan instance
    */
   describe('new RootSpan()', () => {
     it('should create a RootSpan instance', () => {
-      const root = new RootSpan(tracer);
-      assert.ok(root instanceof RootSpan);
-    });
-  });
-
-  /**
-   * Should create a RootSpan instance with options
-   */
-  describe('new RootSpan() with options', () => {
-    it('should create a RootSpan instance with options', () => {
-      const trace = new RootSpan(tracer);
-      const options = {name: 'test', spanContext: trace.spanContext} as
-          TraceOptions;
-      const root = new RootSpan(tracer, options);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       assert.ok(root instanceof RootSpan);
     });
   });
@@ -52,7 +44,7 @@ describe('RootSpan', () => {
    */
   describe('get spans()', () => {
     it('should get span list from rootspan instance', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, null);
       // TODO: Suggetion: make sure that root.spans.length is 1,
       // and that it's the same as the earlier (shadowed) span object
       root.start();
@@ -72,7 +64,7 @@ describe('RootSpan', () => {
 
   describe('get numberOfChildren()', () => {
     it('should get numberOfChildren from rootspan instance', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
       assert.equal(root.numberOfChildren, 0);
       root.startChildSpan('spanName', types.SpanKind.UNSPECIFIED);
@@ -90,7 +82,7 @@ describe('RootSpan', () => {
    */
   describe('new traceId()', () => {
     it('should get trace id from rootspan instance', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       assert.equal(root.traceId, root.spanContext.traceId);
     });
   });
@@ -100,7 +92,7 @@ describe('RootSpan', () => {
    */
   describe('start()', () => {
     it('should start a RootSpan instance', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
       assert.ok(root.started);
     });
@@ -113,7 +105,7 @@ describe('RootSpan', () => {
     let root: types.RootSpan, span: types.Span;
 
     before(() => {
-      root = new RootSpan(tracer);
+      root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
       span = root.startChildSpan('spanName', types.SpanKind.UNSPECIFIED);
     });
@@ -132,7 +124,7 @@ describe('RootSpan', () => {
    */
   describe('startSpan() before start rootspan', () => {
     it('should not create span', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const span = root.startChildSpan('spanName', types.SpanKind.UNSPECIFIED);
       assert.strictEqual(span, null);
     });
@@ -143,7 +135,7 @@ describe('RootSpan', () => {
    */
   describe('startSpan() after rootspan ended', () => {
     it('should not create span', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
       root.end();
       const span = root.startChildSpan('spanName', types.SpanKind.UNSPECIFIED);
@@ -156,7 +148,7 @@ describe('RootSpan', () => {
    */
   describe('end()', () => {
     it('should end the rootspan instance', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
       root.end();
       assert.ok(root.ended);
@@ -168,7 +160,7 @@ describe('RootSpan', () => {
    */
   describe('end() before start rootspan', () => {
     it('should not end rootspan', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.end();
       assert.ok(!root.ended);
     });
@@ -179,7 +171,7 @@ describe('RootSpan', () => {
    */
   describe('end() before end all spans', () => {
     it('should end all spans inside rootspan', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
       root.startChildSpan('spanName', types.SpanKind.UNSPECIFIED);
       root.end();
@@ -196,7 +188,7 @@ describe('RootSpan', () => {
    */
   describe('addAtribute()', () => {
     it('should add an attribute', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       ['String', 'Number', 'Boolean'].map(attType => {
@@ -218,7 +210,7 @@ describe('RootSpan', () => {
             'attributes' in object;
       }
 
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       rootSpan.addAnnotation('description test', {} as Attributes, Date.now());
@@ -228,7 +220,7 @@ describe('RootSpan', () => {
     });
 
     it('should add an annotation without attributes and timestamp', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       rootSpan.addAnnotation('description test');
@@ -251,7 +243,7 @@ describe('RootSpan', () => {
         return 'traceId' in object && 'spanId' in object && 'type' in object;
       }
 
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -276,7 +268,7 @@ describe('RootSpan', () => {
         return 'type' in object && 'id' in object;
       }
 
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       rootSpan.addMessageEvent(

--- a/packages/opencensus-core/test/test-sampler.ts
+++ b/packages/opencensus-core/test/test-sampler.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-
+import {SpanKind} from '../src';
 import {TraceParams} from '../src/trace/config/types';
 import {RootSpan} from '../src/trace/model/root-span';
 import {CoreTracer} from '../src/trace/model/tracer';
@@ -31,19 +31,24 @@ const traceParameters: TraceParams = {
 };
 
 describe('Sampler', () => {
+  const name = 'MySpanName';
+  const kind = SpanKind.SERVER;
+  const traceId = 'd4cda95b652f4a1592b449d5929fda1b';
+  const parentSpanId = '';
+
   /**
    * Should return true
    */
   describe('shouldSample() always', () => {
     it('should return a always sampler for 1', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const sampler = SamplerBuilder.getSampler(1);
       const samplerShouldSample = sampler.shouldSample(root.traceId);
       assert.strictEqual(sampler.description, 'always');
       assert.ok(samplerShouldSample);
     });
     it('should return a always sampler for >1', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const sampler = SamplerBuilder.getSampler(100);
       const samplerShouldSample = sampler.shouldSample(root.traceId);
       assert.strictEqual(sampler.description, 'always');
@@ -55,14 +60,14 @@ describe('Sampler', () => {
    */
   describe('shouldSample() never', () => {
     it('should return a never sampler for 0', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const sampler = SamplerBuilder.getSampler(0);
       const samplerShouldSample = sampler.shouldSample(root.traceId);
       assert.strictEqual(sampler.description, 'never');
       assert.ok(!samplerShouldSample);
     });
     it('should return a never sampler for negative value', () => {
-      const root = new RootSpan(tracer);
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const sampler = SamplerBuilder.getSampler(-1);
       const samplerShouldSample = sampler.shouldSample(root.traceId);
       assert.strictEqual(sampler.description, 'never');

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -33,12 +33,17 @@ tracer.activeTraceParams = {
 };
 
 describe('Span', () => {
+  const name = 'MySpanName';
+  const kind = types.SpanKind.SERVER;
+  const traceId = 'd4cda95b652f4a1592b449d5929fda1b';
+  const parentSpanId = '';
+
   /**
    * Should create a span
    */
   describe('new Span()', () => {
     it('should create a Span instance', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const span = new Span(rootSpan);
       assert.ok(span instanceof Span);
     });
@@ -49,7 +54,7 @@ describe('Span', () => {
    */
   describe('get traceId()', () => {
     it('should return the trace id', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       const span = new Span(rootSpan);
       assert.equal(span.traceId, rootSpan.traceId);
@@ -61,7 +66,7 @@ describe('Span', () => {
    */
   describe('get spanContext', () => {
     it('should the span context of span', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -80,7 +85,7 @@ describe('Span', () => {
   describe('get time properties before start()', () => {
     let span: types.Span;
     before(() => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       span = new Span(rootSpan);
     });
@@ -100,7 +105,7 @@ describe('Span', () => {
    */
   describe('start()', () => {
     it('should start a span instance', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -115,7 +120,7 @@ describe('Span', () => {
    */
   describe('start() an already started span', () => {
     it('should not change the initial startTime', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       const span = new Span(rootSpan);
       span.start();
@@ -131,7 +136,7 @@ describe('Span', () => {
    */
   describe('end()', () => {
     it('should end a span instance', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -147,7 +152,7 @@ describe('Span', () => {
    */
   describe('end() before start()', () => {
     it('should not end a span instance', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -162,7 +167,7 @@ describe('Span', () => {
    */
   describe('end() an already ended span', () => {
     it('should not change the endTime', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       const span = new Span(rootSpan);
       span.start();
@@ -179,7 +184,7 @@ describe('Span', () => {
    */
   describe('addAtribute()', () => {
     it('should add an attribute', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -193,7 +198,7 @@ describe('Span', () => {
     });
 
     it('should drop extra attributes', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -218,7 +223,7 @@ describe('Span', () => {
             'attributes' in object;
       }
 
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -232,7 +237,7 @@ describe('Span', () => {
     });
 
     it('should drop extra annotations', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -256,7 +261,7 @@ describe('Span', () => {
         return 'traceId' in object && 'spanId' in object && 'type' in object;
       }
 
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -271,7 +276,7 @@ describe('Span', () => {
     });
 
     it('should drop extra links', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       const span = new Span(rootSpan);
       span.start();
@@ -296,7 +301,7 @@ describe('Span', () => {
         return 'type' in object && 'id' in object;
       }
 
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -320,7 +325,7 @@ describe('Span', () => {
     });
 
     it('should drop extra  Message Event', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -337,7 +342,7 @@ describe('Span', () => {
 
   describe('setStatus()', () => {
     it('should return default status', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
       const span = new Span(rootSpan);
@@ -350,7 +355,7 @@ describe('Span', () => {
     });
 
     it('should set an error status', () => {
-      const rootSpan = new RootSpan(tracer);
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       const span = new Span(rootSpan);
       span.start();

--- a/packages/opencensus-core/test/test-tracer.ts
+++ b/packages/opencensus-core/test/test-tracer.ts
@@ -171,14 +171,47 @@ describe('Tracer', () => {
   });
 
   describe('startRootSpan() with sampler never', () => {
+    const tracer = new CoreTracer();
+    const config = {samplingRate: 0} as TracerConfig;
+
     it('should start the new NoRecordRootSpan instance', () => {
-      const tracer = new CoreTracer();
-      const config = {samplingRate: 0} as TracerConfig;
       tracer.start(config);
       tracer.startRootSpan(options, (rootSpan) => {
         assert.ok(rootSpan instanceof NoRecordRootSpan);
       });
     });
+
+    it('should start the new RootSpan instance when always sampling provided at span level',
+       () => {
+         tracer.start(config);
+         tracer.startRootSpan({name: 'test', samplingRate: 1}, (rootSpan) => {
+           assert.ok(rootSpan);
+           assert.ok(tracer.currentRootSpan instanceof RootSpan);
+           assert.strictEqual(tracer.currentRootSpan, rootSpan);
+         });
+       });
+  });
+
+  describe('startRootSpan() with sampler always', () => {
+    const tracer = new CoreTracer();
+    const config = {samplingRate: 1} as TracerConfig;
+
+    it('should start the new RootSpan instance', () => {
+      tracer.start(config);
+      tracer.startRootSpan(options, (rootSpan) => {
+        assert.ok(rootSpan);
+        assert.ok(tracer.currentRootSpan instanceof RootSpan);
+        assert.strictEqual(tracer.currentRootSpan, rootSpan);
+      });
+    });
+
+    it('should start the new NoRecordRootSpan instance when never sampling provided at span level',
+       () => {
+         tracer.start(config);
+         tracer.startRootSpan({name: 'test', samplingRate: 0}, (rootSpan) => {
+           assert.ok(rootSpan instanceof NoRecordRootSpan);
+         });
+       });
   });
 
   describe('startRootSpan() before start()', () => {
@@ -226,18 +259,20 @@ describe('Tracer', () => {
       });
     });
 
-    it('should create the new RootSpan with no propagation', () => {
-      const tracer = new CoreTracer();
-      tracer.start(defaultConfig);
-      traceOptions.spanContext.options = 0x0;
-      tracer.startRootSpan(traceOptions, (rootSpan) => {
-        assert.ok(rootSpan);
-        assert.strictEqual(rootSpan.name, traceOptions.name);
-        assert.strictEqual(rootSpan.kind, traceOptions.kind);
-        assert.notEqual(rootSpan.traceId, spanContextPropagated.traceId);
-        assert.notEqual(rootSpan.parentSpanId, spanContextPropagated.spanId);
-      });
-    });
+    it('should create the new RootSpan with no propagation (options bit is not set)',
+       () => {
+         const tracer = new CoreTracer();
+         tracer.start(defaultConfig);
+         traceOptions.spanContext.options = 0x0;
+         tracer.startRootSpan(traceOptions, (rootSpan) => {
+           assert.ok(rootSpan);
+           assert.strictEqual(rootSpan.name, traceOptions.name);
+           assert.strictEqual(rootSpan.kind, traceOptions.kind);
+           assert.strictEqual(rootSpan.traceId, spanContextPropagated.traceId);
+           assert.strictEqual(
+               rootSpan.parentSpanId, spanContextPropagated.spanId);
+         });
+       });
 
     it('should create a tracer with default TraceParams when no parameters are specified upon initialisation',
        () => {


### PR DESCRIPTION
Specs: https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md#how-can-users-control-the-sampler-that-is-used-for-sampling

The logic for allocating ```traceId``` moved in ```tracer``` class. This helps to make sampling decision first and depending on decision we can then create either ```RecordRootSpan(RootSpan)``` or ```NoRecordRootSpan``` instead of always creating ```RootSpan```(just to get traceId for sampling decision) and discarding it later. 

This introduces signature changes to internal ```RootSpan``` class, But I think this won't be breaking change for users.

Fixes #391 