### PR TITLE
Instrumentation/HTTP2/HTTPS: Enforce strictNullChecks and noUnusedLocals

### DIFF
--- a/packages/opencensus-instrumentation-http2/test/test-http2.ts
+++ b/packages/opencensus-instrumentation-http2/test/test-http2.ts
@@ -104,8 +104,8 @@ describe('Http2Plugin', () => {
     server.on('stream', (stream, requestHeaders) => {
       const path = requestHeaders[':path'];
       let statusCode = 200;
-      if (path) {
-        statusCode = path.length > 1 ? +path.slice(1) : 200;
+      if (path && path.length > 1) {
+        statusCode = isNaN(Number(path.slice(1))) ? 200 : Number(path.slice(1));
       }
       stream.respond({':status': statusCode, 'content-type': 'text/plain'});
       stream.end(`${statusCode}`);

--- a/packages/opencensus-instrumentation-http2/tsconfig.json
+++ b/packages/opencensus-instrumentation-http2/tsconfig.json
@@ -6,7 +6,8 @@
     "pretty": true,
     "module": "commonjs",
     "target": "es6",
-    "strictNullChecks": false,
+    "strictNullChecks": true,
+    "noUnusedLocals": true
   },
   "include": [
     "src/**/*.ts",
@@ -16,4 +17,3 @@
     "node_modules"
   ]
 }
-

--- a/packages/opencensus-instrumentation-https/src/https.ts
+++ b/packages/opencensus-instrumentation-https/src/https.ts
@@ -20,7 +20,6 @@ import * as http from 'http';
 import * as https from 'https';
 import * as semver from 'semver';
 import * as shimmer from 'shimmer';
-import * as url from 'url';
 
 /** Https instrumentation plugin for Opencensus */
 export class HttpsPlugin extends HttpPlugin {

--- a/packages/opencensus-instrumentation-https/tsconfig.json
+++ b/packages/opencensus-instrumentation-https/tsconfig.json
@@ -6,7 +6,8 @@
     "pretty": true,
     "module": "commonjs",
     "target": "es6",
-    "strictNullChecks": false
+    "strictNullChecks": true,
+    "noUnusedLocals": true
   },
   "include": [
     "src/**/*.ts",
@@ -16,4 +17,3 @@
     "node_modules"
   ]
 }
-


### PR DESCRIPTION
```strictNullChecks``` will help us to make the code safer (referencing nulls or undefined values), more robust and reduce some boilerplate.

This is part of #348 