### PR TITLE
Stats: Record against implicit (current) tag context

### DIFF
--- a/examples/tags/tag-context-example.js
+++ b/examples/tags/tag-context-example.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const core = require('@opencensus/core');
+
+const K1 = { name: 'k1' };
+const K2 = { name: 'k2' };
+const V1 = { value: 'v1' };
+const V2 = { value: 'v2' };
+
+const mLatencyMs = core.globalStats.createMeasureDouble(
+  'm1', core.MeasureUnit.MS, '1st test metric'
+);
+
+/** Main method. */
+function main () {
+  const tags1 = new core.TagMap();
+  tags1.set(K1, V1);
+
+  core.withTagContext(tags1, () => {
+    console.log('Enter Scope 1');
+    printMap('Add Tags', tags1.tags);
+    printMap('Current Tags == Default + tags1:', core.getCurrentTagContext().tags);
+
+    const tags2 = new core.TagMap();
+    tags2.set(K2, V2);
+    core.withTagContext(tags2, () => {
+      console.log('Enter Scope 2');
+      printMap('Add Tags', tags2.tags);
+      printMap('Current Tags == Default + tags1 + tags2:', core.getCurrentTagContext().tags);
+
+      const measurement = { measure: mLatencyMs, value: 10 };
+      core.globalStats.record([measurement]);
+      console.log('Close Scope 2');
+    });
+    printMap('Current Tags == Default + tags1:', core.getCurrentTagContext().tags);
+    console.log('Close Scope 1');
+  });
+}
+
+function printMap (message, myMap) {
+  var tags = `    ${message}`;
+  for (var [key, value] of myMap) {
+    tags += ` ${key.name} = ${value.value}`;
+  }
+  console.log(tags);
+}
+
+main();

--- a/packages/opencensus-core/src/index.ts
+++ b/packages/opencensus-core/src/index.ts
@@ -71,6 +71,7 @@ export * from './stats/recorder';
 export * from './stats/bucket-boundaries';
 export * from './stats/metric-utils';
 export * from './tags/tag-map';
+export * from './tags/tagger';
 export * from './resource/resource';
 
 // interfaces

--- a/packages/opencensus-core/src/stats/stats.ts
+++ b/packages/opencensus-core/src/stats/stats.ts
@@ -20,7 +20,7 @@ import {StatsEventListener} from '../exporters/types';
 import {Metric} from '../metrics/export/types';
 import {Metrics} from '../metrics/metrics';
 import {TagMap} from '../tags/tag-map';
-import {getCurrentTagMap} from '../tags/tagger';
+import {getCurrentTagContext} from '../tags/tagger';
 import {TagKey} from '../tags/types';
 import {MetricProducerForStats} from './metric-producer';
 import {AggregationType, Measure, Measurement, MeasureType, MeasureUnit, Stats, View} from './types';
@@ -189,7 +189,7 @@ export class BaseStats implements Stats {
 
     if (!tags) {
       // Record against implicit (current) context
-      tags = getCurrentTagMap();
+      tags = getCurrentTagContext();
     }
 
     for (const measurement of measurements) {

--- a/packages/opencensus-core/src/stats/stats.ts
+++ b/packages/opencensus-core/src/stats/stats.ts
@@ -20,8 +20,8 @@ import {StatsEventListener} from '../exporters/types';
 import {Metric} from '../metrics/export/types';
 import {Metrics} from '../metrics/metrics';
 import {TagMap} from '../tags/tag-map';
+import {getCurrentTagMap} from '../tags/tagger';
 import {TagKey} from '../tags/types';
-
 import {MetricProducerForStats} from './metric-producer';
 import {AggregationType, Measure, Measurement, MeasureType, MeasureUnit, Stats, View} from './types';
 import {BaseView} from './view';
@@ -80,8 +80,8 @@ export class BaseStats implements Stats {
    * @param aggregation The view aggregation type
    * @param tagKeys The view columns (tag keys)
    * @param description The view description
-   * @param bucketBoundaries The view bucket boundaries for a distribution
-   * aggregation type
+   * @param bucketBoundaries optional The view bucket boundaries for a
+   *     distribution aggregation type
    */
   createView(
       name: string, measure: Measure, aggregation: AggregationType,
@@ -188,8 +188,8 @@ export class BaseStats implements Stats {
     }
 
     if (!tags) {
-      // TODO(mayurkale): read tags current execution context
-      tags = new TagMap();
+      // Record against implicit (current) context
+      tags = getCurrentTagMap();
     }
 
     for (const measurement of measurements) {

--- a/packages/opencensus-core/src/tags/tag-map.ts
+++ b/packages/opencensus-core/src/tags/tag-map.ts
@@ -31,6 +31,14 @@ export class TagMap {
     if (!isValidTagValue(tagValue)) {
       throw new Error(`Invalid TagValue: ${tagValue.value}`);
     }
+    let existingKey;
+    for (const key of this.registeredTags.keys()) {
+      if (key.name === tagKey.name) {
+        existingKey = key;
+        break;
+      }
+    }
+    if (existingKey) this.registeredTags.delete(existingKey);
     this.registeredTags.set(tagKey, tagValue);
   }
 

--- a/packages/opencensus-core/src/tags/tagger.ts
+++ b/packages/opencensus-core/src/tags/tagger.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as cls from '../internal/cls';
+import {TagMap} from './tag-map';
+
+const contextManager = cls.createNamespace();
+export const EMPTY_TAG_MAP = new TagMap();
+const CURRENT_TAG_MAP_KEY = 'current_tag_map';
+
+/** Gets the current tag context. */
+export function getCurrentTagMap(): TagMap {
+  const tagsFromContext = contextManager.get(CURRENT_TAG_MAP_KEY);
+  if (tagsFromContext) {
+    return tagsFromContext as TagMap;
+  }
+  return EMPTY_TAG_MAP;
+}
+
+/**
+ * Sets the current tag context.
+ * @param tags The TagMap.
+ */
+export function setCurrentTagMap(tags: TagMap) {
+  if (tags) {
+    contextManager.set(CURRENT_TAG_MAP_KEY, tags);
+  }
+}
+
+/** Clear the current tag context. */
+export function clear() {
+  contextManager.set(CURRENT_TAG_MAP_KEY, EMPTY_TAG_MAP);
+}

--- a/packages/opencensus-core/src/tags/tagger.ts
+++ b/packages/opencensus-core/src/tags/tagger.ts
@@ -22,7 +22,7 @@ export const EMPTY_TAG_MAP = new TagMap();
 const CURRENT_TAG_MAP_KEY = 'current_tag_map';
 
 /** Gets the current tag context. */
-export function getCurrentTagMap(): TagMap {
+export function getCurrentTagContext(): TagMap {
   const tagsFromContext = contextManager.get(CURRENT_TAG_MAP_KEY);
   if (tagsFromContext) {
     return tagsFromContext as TagMap;
@@ -34,10 +34,30 @@ export function getCurrentTagMap(): TagMap {
  * Sets the current tag context.
  * @param tags The TagMap.
  */
-export function setCurrentTagMap(tags: TagMap) {
-  if (tags) {
-    contextManager.set(CURRENT_TAG_MAP_KEY, tags);
-  }
+export function setCurrentTagContext(tags: TagMap) {
+  contextManager.set(CURRENT_TAG_MAP_KEY, tags);
+}
+
+/**
+ * Enters the scope of code where the given `TagMap` is in the current context
+ * (replacing the previous `TagMap`).
+ * @param tags The TagMap to be set to the current context.
+ * @param fn Callback function.
+ * @returns The callback return.
+ */
+export function withTagContext<T>(tags: TagMap, fn: cls.Func<T>): T {
+  const oldContext = getCurrentTagContext();
+  return contextManager.runAndReturn(() => {
+    const newContext = new TagMap();
+    for (const [tagKey, tagValue] of oldContext.tags) {
+      newContext.set(tagKey, tagValue);
+    }
+    for (const [tagKey, tagValue] of tags.tags) {
+      newContext.set(tagKey, tagValue);
+    }
+    setCurrentTagContext(newContext);
+    return fn();
+  });
 }
 
 /** Clear the current tag context. */

--- a/packages/opencensus-core/test/test-tagger.ts
+++ b/packages/opencensus-core/test/test-tagger.ts
@@ -97,4 +97,14 @@ describe('tagger()', () => {
     });
     assert.deepStrictEqual(tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
   });
+
+  it('should clear current tag context', () => {
+    tagger.withTagContext(tags1, () => {
+      assert.deepStrictEqual(tagger.getCurrentTagContext(), tags1);
+      tagger.clear();
+      assert.deepStrictEqual(
+          tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+    });
+    assert.deepStrictEqual(tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+  });
 });

--- a/packages/opencensus-core/test/test-tagger.ts
+++ b/packages/opencensus-core/test/test-tagger.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {TagMap} from '../src';
+import * as tagger from '../src/tags/tagger';
+
+describe('tagger()', () => {
+  const tags = new TagMap();
+  tags.set({name: 'key1'}, {value: 'value1'});
+  tags.set({name: 'key2'}, {value: 'value2'});
+
+  it('should return empty current tag context', () => {
+    const tags = tagger.getCurrentTagMap();
+    assert.equal(tags, tagger.EMPTY_TAG_MAP);
+  });
+
+  it('should return assigned current tag context', () => {
+    tagger.setCurrentTagMap(tags);
+    const currentTagMap = tagger.getCurrentTagMap();
+    assert.deepStrictEqual(currentTagMap, tags);
+  });
+
+  it('should clear assigned current tag context', () => {
+    tagger.setCurrentTagMap(tags);
+    tagger.clear();
+
+    const currentTagMap = tagger.getCurrentTagMap();
+    assert.equal(currentTagMap, tagger.EMPTY_TAG_MAP);
+  });
+});


### PR DESCRIPTION
Specs are available here: https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/Record.md#recording-stats

This will allow users to set and get the current tag context, which can be used when recoding the stats if explicit tags are not provided.