### PR TITLE
only require userland CLS when needed

### DIFF
--- a/packages/opencensus-core/src/internal/cls.ts
+++ b/packages/opencensus-core/src/internal/cls.ts
@@ -27,7 +27,8 @@ const useAsyncHooks: boolean = semver.satisfies(
     process.version, '>=8');  //&&
                               // !!process.env.GCLOUD_TRACE_NEW_CONTEXT;
 
-const cls: typeof CLS = useAsyncHooks ? require('./cls-ah') : CLS;
+const cls: typeof CLS =
+    useAsyncHooks ? require('./cls-ah') : require('continuation-local-storage');
 
 
 const TRACE_NAMESPACE = 'opencensus.io';


### PR DESCRIPTION
We shipped our APM with the `@opencensus/core` package. We didn't enable the tracer by default but since when required, it will require the `continuation-local-storage` which will apply patches automatically. So even if you use `async_hooks`, you will have the patchs from the userland CLS.
I believe it's safe to change this behavior since it will work the same way.

I would like to raise also the fact that we could only require both CLS implementation when the tracing is enabled to decrease the performance impact when not enabled.

If you are interested, here are the different complaints from users: https://github.com/keymetrics/pm2-io-apm/issues/235