### PR TITLE
Add support for nested spans

### DIFF
--- a/packages/opencensus-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-core/src/trace/model/root-span.ts
@@ -138,11 +138,17 @@ export class RootSpan extends SpanBase implements types.RootSpan {
         typeof nameOrOptions === 'object' ? nameOrOptions.name : nameOrOptions;
     const spanKind =
         typeof nameOrOptions === 'object' ? nameOrOptions.kind : kind;
+    const spanParentId = typeof nameOrOptions === 'object' ?
+        nameOrOptions.parentSpanId :
+        undefined;
     if (spanName) {
       child.name = spanName;
     }
     if (spanKind) {
       child.kind = spanKind;
+    }
+    if (spanParentId) {
+      child.parentSpanId = spanParentId;
     }
 
     child.start();

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -77,6 +77,28 @@ describe('RootSpan', () => {
     });
   });
 
+  describe('nested spans', () => {
+    it('should get nested spans from rootspan instance', () => {
+      const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
+      root.start();
+      assert.equal(root.numberOfChildren, 0);
+      const child =
+          root.startChildSpan('childName', types.SpanKind.UNSPECIFIED);
+      assert.equal(root.numberOfChildren, 1);
+      const grandchild = root.startChildSpan({
+        name: 'grandchildName',
+        kind: types.SpanKind.UNSPECIFIED,
+        parentSpanId: child.id
+      });
+      assert.equal(root.numberOfChildren, 2);
+      assert.equal(grandchild.parentSpanId, child.id);
+
+      assert.equal(root.spans.length, 2);
+      assert.equal(child, root.spans[0]);
+      assert.equal(grandchild, root.spans[1]);
+    });
+  });
+
   /**
    * Should get trace id from rootspan instance
    */

--- a/packages/opencensus-exporter-zipkin/src/zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/src/zipkin.ts
@@ -166,7 +166,7 @@ export class ZipkinTraceExporter implements Exporter {
       timestamp: span.startTime.getTime() * MICROS_PER_MILLI,
       duration: Math.round(span.duration * MICROS_PER_MILLI),
       debug: true,
-      shared: true,
+      shared: span.isRootSpan, // Only the root span could be shared.
       localEndpoint: {serviceName: this.serviceName},
       tags: this.createTags(span.attributes, span.status),
       annotations: this.createAnnotations(span.annotations, span.messageEvents)
@@ -178,7 +178,7 @@ export class ZipkinTraceExporter implements Exporter {
     return spanTraslated;
   }
 
-  /** Converts OpenCensus Attributes ans Status to Zipkin Tags format. */
+  /** Converts OpenCensus Attributes and Status to Zipkin Tags format. */
   private createTags(
       attributes: coreTypes.Attributes, status: coreTypes.Status) {
     const tags: {[key: string]: string} = {};

--- a/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
@@ -122,7 +122,11 @@ describe('Zipkin Exporter', function() {
         child.addMessageEvent(MessageEventType.UNSPECIFIED, '3', 1550213104708);
         child.addAnnotation('done', {}, 1550213104708);
 
-        const grandchild = rootSpan.startChildSpan({name: 'grandchildTest', kind: SpanKind.CLIENT, parentSpanId: child.id});
+        const grandchild = rootSpan.startChildSpan({
+          name: 'grandchildTest',
+          kind: SpanKind.CLIENT,
+          parentSpanId: child.id
+        });
         grandchild.addAttribute('grandchild-attribute', 200);
 
         grandchild.end();
@@ -183,14 +187,10 @@ describe('Zipkin Exporter', function() {
           'name': 'grandchildTest',
           'parentId': child.id,
           'shared': true,
-          'tags': {
-            'census.status_code': '0',
-            'grandchild-attribute': '200'
-          },
+          'tags': {'census.status_code': '0', 'grandchild-attribute': '200'},
           'timestamp': grandchild.startTime.getTime() * MICROS_PER_MILLI,
           'traceId': rootSpan.traceId
         });
-
       });
     });
   });

--- a/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
@@ -109,19 +109,24 @@ describe('Zipkin Exporter', function() {
       tracer.start(defaultConfig);
 
       return tracer.startRootSpan({name: 'root-test'}, (rootSpan: RootSpan) => {
-        const span =
+        const child =
             rootSpan.startChildSpan({name: 'spanTest', kind: SpanKind.CLIENT});
-        span.addAttribute('my-int-attribute', 100);
-        span.addAttribute('my-str-attribute', 'value');
-        span.addAttribute('my-bool-attribute', true);
-        span.setStatus(CanonicalCode.RESOURCE_EXHAUSTED, 'RESOURCE_EXHAUSTED');
+        child.addAttribute('my-int-attribute', 100);
+        child.addAttribute('my-str-attribute', 'value');
+        child.addAttribute('my-bool-attribute', true);
+        child.setStatus(CanonicalCode.RESOURCE_EXHAUSTED, 'RESOURCE_EXHAUSTED');
 
-        span.addAnnotation('processing', {}, 1550213104708);
-        span.addMessageEvent(MessageEventType.SENT, '1', 1550213104708);
-        span.addMessageEvent(MessageEventType.RECEIVED, '2', 1550213104708);
-        span.addMessageEvent(MessageEventType.UNSPECIFIED, '3', 1550213104708);
-        span.addAnnotation('done', {}, 1550213104708);
-        span.end();
+        child.addAnnotation('processing', {}, 1550213104708);
+        child.addMessageEvent(MessageEventType.SENT, '1', 1550213104708);
+        child.addMessageEvent(MessageEventType.RECEIVED, '2', 1550213104708);
+        child.addMessageEvent(MessageEventType.UNSPECIFIED, '3', 1550213104708);
+        child.addAnnotation('done', {}, 1550213104708);
+
+        const grandchild = rootSpan.startChildSpan({name: 'grandchildTest', kind: SpanKind.CLIENT, parentSpanId: child.id});
+        grandchild.addAttribute('grandchild-attribute', 200);
+
+        grandchild.end();
+        child.end();
         rootSpan.end();
 
         const rootSpanTranslated = exporter.translateSpan(rootSpan);
@@ -139,8 +144,8 @@ describe('Zipkin Exporter', function() {
           'traceId': rootSpan.traceId
         });
 
-        const chilsSpanTranslated = exporter.translateSpan(span);
-        assert.deepEqual(chilsSpanTranslated, {
+        const childSpanTranslated = exporter.translateSpan(child);
+        assert.deepEqual(childSpanTranslated, {
           'annotations': [
             {'timestamp': 1550213104708000, 'value': 'processing'},
             {'timestamp': 1550213104708000, 'value': 'done'},
@@ -149,8 +154,8 @@ describe('Zipkin Exporter', function() {
             {'timestamp': 1550213104708000, 'value': 'UNSPECIFIED'}
           ],
           'debug': true,
-          'duration': Math.round(span.duration * MICROS_PER_MILLI),
-          'id': span.id,
+          'duration': Math.round(child.duration * MICROS_PER_MILLI),
+          'id': child.id,
           'kind': 'CLIENT',
           'localEndpoint': {'serviceName': 'opencensus-tests'},
           'name': 'spanTest',
@@ -163,9 +168,29 @@ describe('Zipkin Exporter', function() {
             'my-str-attribute': 'value',
             'my-bool-attribute': 'true'
           },
-          'timestamp': span.startTime.getTime() * MICROS_PER_MILLI,
-          'traceId': span.traceId
+          'timestamp': child.startTime.getTime() * MICROS_PER_MILLI,
+          'traceId': rootSpan.traceId
         });
+
+        const grandchildSpanTranslated = exporter.translateSpan(grandchild);
+        assert.deepEqual(grandchildSpanTranslated, {
+          'annotations': [],
+          'debug': true,
+          'duration': Math.round(grandchild.duration * MICROS_PER_MILLI),
+          'id': grandchild.id,
+          'kind': 'CLIENT',
+          'localEndpoint': {'serviceName': 'opencensus-tests'},
+          'name': 'grandchildTest',
+          'parentId': child.id,
+          'shared': true,
+          'tags': {
+            'census.status_code': '0',
+            'grandchild-attribute': '200'
+          },
+          'timestamp': grandchild.startTime.getTime() * MICROS_PER_MILLI,
+          'traceId': rootSpan.traceId
+        });
+
       });
     });
   });


### PR DESCRIPTION
`rootSpan.startChildSpan()` takes an options object as input where one of the fields is `parentSpanId`.  However, `parentSpanId` isn't wired up.  This PR does that wiring and adds tests for both the core library as well as the Zipkin exporter.

Fixes #105 