### PR TITLE
Remove deprecated @types/pkg-dir and pkg-dir 

### DIFF
--- a/packages/opencensus-exporter-zpages/package-lock.json
+++ b/packages/opencensus-exporter-zpages/package-lock.json
@@ -194,11 +194,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
       "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
     },
-    "@types/pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha512-0R+NtmRVZiw+icBZVipQC3DOKGCag3zyRNjAtdpIMR+M+rM/fHE6fPJFpMroTcvqmQuh6lH68NL0Rh0tR+PDdA=="
-    },
     "@types/serve-static": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
@@ -3661,9 +3656,9 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.0.0.tgz",
+      "integrity": "sha512-1S63UXE5ujsNUTFEgI001K06PkKqNceY07OBdRw24KYs3xvtoG3bkkunIG1p3glRKUjrZYc43opq2Y70R+/Rbw==",
       "requires": {
         "find-up": "^3.0.0"
       },
@@ -3686,9 +3681,9 @@
           }
         },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -3702,9 +3697,9 @@
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+          "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
         }
       }
     },

--- a/packages/opencensus-exporter-zpages/package.json
+++ b/packages/opencensus-exporter-zpages/package.json
@@ -46,7 +46,6 @@
     "@types/extend": "^3.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.12",
-    "@types/pkg-dir": "^2.0.0",
     "axios": "^0.18.0",
     "codecov": "^3.1.0",
     "gts": "^0.9.0",
@@ -60,6 +59,6 @@
     "@opencensus/core": "^0.0.9",
     "ejs": "^2.5.8",
     "express": "^4.16.3",
-    "pkg-dir": "^3.0.0"
+    "pkg-dir": "^4.0.0"
   }
 }

--- a/packages/opencensus-exporter-zpages/package.json
+++ b/packages/opencensus-exporter-zpages/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "@opencensus/core": "^0.0.9",
     "ejs": "^2.5.8",
-    "express": "^4.16.3",
-    "pkg-dir": "^4.0.0"
+    "express": "^4.16.3"
   }
 }

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/rpcz.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/rpcz.page-handler.ts
@@ -15,13 +15,11 @@
  */
 
 import {AggregationType} from '@opencensus/core';
+import * as ejs from 'ejs';
+import * as path from 'path';
 import {StatsParams} from '../../zpages';
 
-const ejs = require('ejs');
-
-import pkgDir from 'pkg-dir';
-const templatesDir = `${pkgDir.sync(__dirname)}/templates`;
-
+const templatesDir = path.join(__dirname, '../../../../templates');
 const FIXED_SIZE = 3;
 
 export interface ZMeasureOrders {
@@ -71,8 +69,7 @@ export class RpczPageHandler {
    */
   emitHtml(json: boolean): string {
     /** template HTML */
-    const rpczFile =
-        ejs.fileLoader(`${templatesDir}/rpcz.ejs`, 'utf8').toString();
+    const rpczFile = ejs.fileLoader(`${templatesDir}/rpcz.ejs`).toString();
     /** CSS styles file */
     const stylesFile =
         ejs.fileLoader(`${templatesDir}/styles.min.css`).toString();

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/rpcz.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/rpcz.page-handler.ts
@@ -19,7 +19,7 @@ import {StatsParams} from '../../zpages';
 
 const ejs = require('ejs');
 
-import * as pkgDir from 'pkg-dir';
+import pkgDir from 'pkg-dir';
 const templatesDir = `${pkgDir.sync(__dirname)}/templates`;
 
 const FIXED_SIZE = 3;

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/statsz.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/statsz.page-handler.ts
@@ -16,10 +16,9 @@
 
 import {AggregationData, AggregationType, TagKey, TagValue, View} from '@opencensus/core';
 import {StatsParams} from '../../zpages';
-
 const ejs = require('ejs');
 
-import pkgDir from 'pkg-dir';
+import * as path from 'path';
 
 export interface StatszParams {
   path: string;
@@ -202,7 +201,7 @@ export class StatszPageHandler {
    * file
    */
   private loaderFile(fileName: string): string {
-    const rootDir = `${pkgDir.sync(__dirname)}`;
-    return ejs.fileLoader(`${rootDir}/templates/${fileName}`, 'utf8');
+    const fileDir = path.join(__dirname, '../../../../templates', fileName);
+    return ejs.fileLoader(fileDir, 'utf8');
   }
 }

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/statsz.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/statsz.page-handler.ts
@@ -19,7 +19,7 @@ import {StatsParams} from '../../zpages';
 
 const ejs = require('ejs');
 
-import * as pkgDir from 'pkg-dir';
+import pkgDir from 'pkg-dir';
 
 export interface StatszParams {
   path: string;

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/traceconfigz.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/traceconfigz.page-handler.ts
@@ -17,10 +17,10 @@
 import {SamplerBuilder} from '@opencensus/core';
 import * as tracing from '@opencensus/nodejs';
 import * as ejs from 'ejs';
-import pkgDir from 'pkg-dir';
+import * as path from 'path';
 
 // The directory to search for templates.
-const templatesDir = `${pkgDir.sync(__dirname)}/templates`;
+const templatesDir = path.join(__dirname, '../../../../templates');
 
 export interface TraceConfigzParams {
   change: string;

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/traceconfigz.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/traceconfigz.page-handler.ts
@@ -17,7 +17,7 @@
 import {SamplerBuilder} from '@opencensus/core';
 import * as tracing from '@opencensus/nodejs';
 import * as ejs from 'ejs';
-import * as pkgDir from 'pkg-dir';
+import pkgDir from 'pkg-dir';
 
 // The directory to search for templates.
 const templatesDir = `${pkgDir.sync(__dirname)}/templates`;

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
@@ -16,12 +16,12 @@
 
 import {RootSpan, Span} from '@opencensus/core';
 import * as ejs from 'ejs';
-import pkgDir from 'pkg-dir';
+import * as path from 'path';
 
 import {LatencyBucketBoundaries} from '../latency-bucket-boundaries';
 
 // The directory to search for templates.
-const templatesDir = `${pkgDir.sync(__dirname)}/templates`;
+const templatesDir = path.join(__dirname, '../../../../templates');
 
 export type TracezParams = {
   tracename: string; type: string;

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
@@ -16,7 +16,7 @@
 
 import {RootSpan, Span} from '@opencensus/core';
 import * as ejs from 'ejs';
-import * as pkgDir from 'pkg-dir';
+import pkgDir from 'pkg-dir';
 
 import {LatencyBucketBoundaries} from '../latency-bucket-boundaries';
 


### PR DESCRIPTION
The `@types/pkg-dir` package has been deprecated. https://www.npmjs.com/package/@types/pkg-dir 