### PR TITLE
Add support for gRPC tags propagation

### DIFF
--- a/examples/tags/tag-context-example.js
+++ b/examples/tags/tag-context-example.js
@@ -14,39 +14,40 @@
  * limitations under the License.
  */
 
-const core = require('@opencensus/core');
+const {globalStats, MeasureUnit, TagMap} = require('@opencensus/core');
 
 const K1 = { name: 'k1' };
 const K2 = { name: 'k2' };
 const V1 = { value: 'v1' };
 const V2 = { value: 'v2' };
 
-const mLatencyMs = core.globalStats.createMeasureDouble(
-  'm1', core.MeasureUnit.MS, '1st test metric'
+const mLatencyMs = globalStats.createMeasureDouble(
+  'm1', MeasureUnit.MS, '1st test metric'
 );
 
 /** Main method. */
 function main () {
-  const tags1 = new core.TagMap();
+  const tags1 = new TagMap();
   tags1.set(K1, V1);
 
-  core.withTagContext(tags1, () => {
+  globalStats.withTagContext(tags1, () => {
     console.log('Enter Scope 1');
     printMap('Add Tags', tags1.tags);
-    printMap('Current Tags == Default + tags1:', core.getCurrentTagContext().tags);
+    printMap('Current Tags == Default + tags1:',
+    globalStats.getCurrentTagContext().tags);
 
-    const tags2 = new core.TagMap();
+    const tags2 = new TagMap();
     tags2.set(K2, V2);
-    core.withTagContext(tags2, () => {
+    globalStats.withTagContext(tags2, () => {
       console.log('Enter Scope 2');
       printMap('Add Tags', tags2.tags);
-      printMap('Current Tags == Default + tags1 + tags2:', core.getCurrentTagContext().tags);
+      printMap('Current Tags == Default + tags1 + tags2:', globalStats.getCurrentTagContext().tags);
 
       const measurement = { measure: mLatencyMs, value: 10 };
-      core.globalStats.record([measurement]);
+      globalStats.record([measurement]);
       console.log('Close Scope 2');
     });
-    printMap('Current Tags == Default + tags1:', core.getCurrentTagContext().tags);
+    printMap('Current Tags == Default + tags1:', globalStats.getCurrentTagContext().tags);
     console.log('Close Scope 1');
   });
 }

--- a/packages/opencensus-core/src/index.ts
+++ b/packages/opencensus-core/src/index.ts
@@ -72,6 +72,7 @@ export * from './stats/bucket-boundaries';
 export * from './stats/metric-utils';
 export * from './tags/tag-map';
 export * from './tags/tagger';
+export * from './tags/propagation/binary-serializer';
 export * from './tags/propagation/text-format';
 export * from './resource/resource';
 

--- a/packages/opencensus-core/src/internal/cls-ah.ts
+++ b/packages/opencensus-core/src/internal/cls-ah.ts
@@ -64,6 +64,9 @@ class AsyncHooksNamespace implements CLSNamespace {
   runAndReturn<T>(fn: Func<T>): T {
     const oldContext = current;
     current = {};
+    if (oldContext['current_tag_map']) {
+      current['current_tag_map'] = oldContext['current_tag_map'];
+    }
     const res = fn();
     current = oldContext;
     return res;

--- a/packages/opencensus-core/src/internal/cls.ts
+++ b/packages/opencensus-core/src/internal/cls.ts
@@ -52,3 +52,5 @@ export function destroyNamespace(): void {
 export function getNamespace(): CLS.Namespace {
   return cls.getNamespace(TRACE_NAMESPACE);
 }
+
+export const contextManager = createNamespace();

--- a/packages/opencensus-core/src/stats/types.ts
+++ b/packages/opencensus-core/src/stats/types.ts
@@ -15,6 +15,7 @@
  */
 
 import {StatsEventListener} from '../exporters/types';
+import * as cls from '../internal/cls';
 import {Metric} from '../metrics/export/types';
 import {TagMap} from '../tags/tag-map';
 import {TagKey, TagValue} from '../tags/types';
@@ -98,6 +99,18 @@ export interface Stats {
    * @param exporter An stats exporter
    */
   unregisterExporter(exporter: StatsEventListener): void;
+
+  /**
+   * Enters the scope of code where the given `TagMap` is in the current context
+   * (replacing the previous `TagMap`).
+   * @param tags The TagMap to be set to the current context.
+   * @param fn Callback function.
+   * @returns The callback return.
+   */
+  withTagContext<T>(tags: TagMap, fn: cls.Func<T>): T;
+
+  /** Gets the current tag context. */
+  getCurrentTagContext(): TagMap;
 }
 
 /**

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -51,7 +51,7 @@ export class CoreTracer implements types.Tracer {
   /** Constructs a new TraceImpl instance. */
   constructor() {
     this.activeLocal = false;
-    this.contextManager = cls.createNamespace();
+    this.contextManager = cls.getNamespace();
     this.clearCurrentTrace();
     this.activeTraceParams = {};
   }

--- a/packages/opencensus-core/test/test-stats.ts
+++ b/packages/opencensus-core/test/test-stats.ts
@@ -232,7 +232,7 @@ describe('Stats', () => {
       tags.set(tagKeys[0], {value: 'value1'});
       tags.set(tagKeys[1], {value: 'value2'});
       const measurement = {measure, value: 1};
-      tagger.withTagContext(tags, () => {
+      globalStats.withTagContext(tags, () => {
         globalStats.record([measurement]);
       });
 
@@ -250,7 +250,7 @@ describe('Stats', () => {
       const UNKNOWN_TAG_VALUE: TagValue = null;
       globalStats.registerExporter(testExporter);
       const measurement = {measure, value: 2211};
-      tagger.withTagContext(tagger.EMPTY_TAG_MAP, () => {
+      globalStats.withTagContext(tagger.EMPTY_TAG_MAP, () => {
         globalStats.record([measurement]);
       });
 

--- a/packages/opencensus-core/test/test-tagger.ts
+++ b/packages/opencensus-core/test/test-tagger.ts
@@ -16,7 +16,10 @@
 
 import * as assert from 'assert';
 import {TagMap} from '../src';
+import * as cls from '../src/internal/cls';
 import * as tagger from '../src/tags/tagger';
+
+const contextManager = cls.getNamespace();
 
 describe('tagger()', () => {
   const tags1 = new TagMap();
@@ -54,57 +57,68 @@ describe('tagger()', () => {
   expectedTagsFrom1n3n4.set({name: 'key6'}, {value: 'value6'});
 
   it('should return empty current tag context', () => {
-    tagger.withTagContext(tagger.EMPTY_TAG_MAP, () => {
+    tagger.withTagContext(contextManager, tagger.EMPTY_TAG_MAP, () => {
       assert.deepStrictEqual(
-          tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+          tagger.getCurrentTagContext(contextManager), tagger.EMPTY_TAG_MAP);
     });
   });
 
   it('should set current tag context', () => {
-    tagger.withTagContext(tags1, () => {
-      assert.deepStrictEqual(tagger.getCurrentTagContext(), tags1);
+    tagger.withTagContext(contextManager, tags1, () => {
+      assert.deepStrictEqual(
+          tagger.getCurrentTagContext(contextManager), tags1);
     });
-    assert.deepStrictEqual(tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+    assert.deepStrictEqual(
+        tagger.getCurrentTagContext(contextManager), tagger.EMPTY_TAG_MAP);
   });
 
   it('should set nested current tag context', () => {
-    tagger.withTagContext(tags1, () => {
-      assert.deepStrictEqual(tagger.getCurrentTagContext(), tags1);
+    tagger.withTagContext(contextManager, tags1, () => {
+      assert.deepStrictEqual(
+          tagger.getCurrentTagContext(contextManager), tags1);
 
-      tagger.withTagContext(tags2, () => {
+      tagger.withTagContext(contextManager, tags2, () => {
         assert.deepStrictEqual(
-            tagger.getCurrentTagContext(), expectedMergedTags);
+            tagger.getCurrentTagContext(contextManager), expectedMergedTags);
       });
-      assert.deepStrictEqual(tagger.getCurrentTagContext(), tags1);
+      assert.deepStrictEqual(
+          tagger.getCurrentTagContext(contextManager), tags1);
     });
-    assert.deepStrictEqual(tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+    assert.deepStrictEqual(
+        tagger.getCurrentTagContext(contextManager), tagger.EMPTY_TAG_MAP);
   });
 
   it('should resolve tag conflicts', () => {
-    tagger.withTagContext(tags1, () => {
-      assert.deepStrictEqual(tagger.getCurrentTagContext(), tags1);
+    tagger.withTagContext(contextManager, tags1, () => {
+      assert.deepStrictEqual(
+          tagger.getCurrentTagContext(contextManager), tags1);
 
-      tagger.withTagContext(tags3, () => {
+      tagger.withTagContext(contextManager, tags3, () => {
         assert.deepStrictEqual(
-            tagger.getCurrentTagContext(), expectedTagsFrom1n3);
+            tagger.getCurrentTagContext(contextManager), expectedTagsFrom1n3);
 
-        tagger.withTagContext(tags4, () => {
+        tagger.withTagContext(contextManager, tags4, () => {
           assert.deepStrictEqual(
-              tagger.getCurrentTagContext(), expectedTagsFrom1n3n4);
+              tagger.getCurrentTagContext(contextManager),
+              expectedTagsFrom1n3n4);
         });
       });
-      assert.deepStrictEqual(tagger.getCurrentTagContext(), tags1);
+      assert.deepStrictEqual(
+          tagger.getCurrentTagContext(contextManager), tags1);
     });
-    assert.deepStrictEqual(tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+    assert.deepStrictEqual(
+        tagger.getCurrentTagContext(contextManager), tagger.EMPTY_TAG_MAP);
   });
 
   it('should clear current tag context', () => {
-    tagger.withTagContext(tags1, () => {
-      assert.deepStrictEqual(tagger.getCurrentTagContext(), tags1);
-      tagger.clear();
+    tagger.withTagContext(contextManager, tags1, () => {
       assert.deepStrictEqual(
-          tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+          tagger.getCurrentTagContext(contextManager), tags1);
+      tagger.clear(contextManager);
+      assert.deepStrictEqual(
+          tagger.getCurrentTagContext(contextManager), tagger.EMPTY_TAG_MAP);
     });
-    assert.deepStrictEqual(tagger.getCurrentTagContext(), tagger.EMPTY_TAG_MAP);
+    assert.deepStrictEqual(
+        tagger.getCurrentTagContext(contextManager), tagger.EMPTY_TAG_MAP);
   });
 });

--- a/packages/opencensus-instrumentation-grpc/src/grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/src/grpc.ts
@@ -560,8 +560,8 @@ export class GrpcPlugin extends BasePlugin {
       if (!tags) return null;
       return tags;
     } catch (ignore) {
+      return null;
     }
-    return null;
   }
 
   /**

--- a/packages/opencensus-instrumentation-grpc/src/grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/src/grpc.ts
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-import {BasePlugin, CanonicalCode, PluginInternalFiles, RootSpan, Span, SpanContext, SpanKind, TagMap, TagTtl, TraceOptions} from '@opencensus/core';
+import {BasePlugin, CanonicalCode, deserializeBinary, PluginInternalFiles, RootSpan, serializeBinary, Span, SpanContext, SpanKind, TagMap, TagTtl, TraceOptions} from '@opencensus/core';
 import {deserializeSpanContext, serializeSpanContext} from '@opencensus/propagation-binaryformat';
 import {EventEmitter} from 'events';
 import * as grpcTypes from 'grpc';
 import * as lodash from 'lodash';
 import * as shimmer from 'shimmer';
+
 import * as clientStats from './grpc-stats/client-stats';
 import * as serverStats from './grpc-stats/server-stats';
+
 const sizeof = require('object-sizeof');
 
 /** The metadata key under which span context is stored as a binary value. */
 export const GRPC_TRACE_KEY = 'grpc-trace-bin';
+/** The metadata key under which TagMap is stored as a binary value. */
+export const GRPC_TAGS_KEY = 'grpc-tags-bin';
 const findIndex = lodash.findIndex;
 
 //
@@ -229,13 +233,14 @@ export class GrpcPlugin extends BasePlugin {
       }
 
       // record stats
-      const tags = new TagMap();
-      tags.set(
+      const parentTagCtx =
+          GrpcPlugin.getTagContext(call.metadata) || new TagMap();
+      parentTagCtx.set(
           serverStats.GRPC_SERVER_METHOD, {value: rootSpan.name},
           UNLIMITED_PROPAGATION_MD);
       const req = call.hasOwnProperty('request') ? call.request : {};
       GrpcPlugin.recordStats(
-          rootSpan.kind, tags, value, req, Date.now() - startTime);
+          rootSpan.kind, parentTagCtx, value, req, Date.now() - startTime);
 
       rootSpan.end();
       return callback(err, value, trailer, flags);
@@ -354,7 +359,9 @@ export class GrpcPlugin extends BasePlugin {
      * Patches a callback so that the current span for this trace is also ended
      * when the callback is invoked.
      */
-    function patchedCallback(span: Span, callback: SendUnaryDataCallback) {
+    function patchedCallback(
+        span: Span, callback: SendUnaryDataCallback,
+        metadata: grpcTypes.Metadata) {
       // tslint:disable-next-line:no-any
       const wrappedFn = (err: grpcTypes.ServiceError, res: any) => {
         if (err) {
@@ -375,13 +382,18 @@ export class GrpcPlugin extends BasePlugin {
               grpcTypes.status.OK.toString());
         }
 
-        // record stats
-        const tags = new TagMap();
-        tags.set(
+        // record stats: new RPCs on client-side inherit the tag context from
+        // the current Context.
+        const parentTagCtx =
+            plugin.stats ? plugin.stats.getCurrentTagContext() : new TagMap();
+        if (parentTagCtx.tags.size > 0) {
+          GrpcPlugin.setTagContext(metadata, parentTagCtx);
+        }
+        parentTagCtx.set(
             clientStats.GRPC_CLIENT_METHOD, {value: span.name},
             UNLIMITED_PROPAGATION_MD);
         GrpcPlugin.recordStats(
-            span.kind, tags, originalArgs, res, Date.now() - startTime);
+            span.kind, parentTagCtx, originalArgs, res, Date.now() - startTime);
 
         span.end();
         callback(err, res);
@@ -394,6 +406,7 @@ export class GrpcPlugin extends BasePlugin {
         return original.apply(self, args);
       }
 
+      const metadata = this.getMetadata(original, args);
       // if unary or clientStream
       if (!original.responseStream) {
         const callbackFuncIndex = findIndex(args, (arg) => {
@@ -401,11 +414,10 @@ export class GrpcPlugin extends BasePlugin {
         });
         if (callbackFuncIndex !== -1) {
           args[callbackFuncIndex] =
-              patchedCallback(span, args[callbackFuncIndex]);
+              patchedCallback(span, args[callbackFuncIndex], metadata);
         }
       }
 
-      const metadata = this.getMetadata(original, args);
       GrpcPlugin.setSpanContext(metadata, span.spanContext);
 
       span.addAttribute(GrpcPlugin.ATTRIBUTE_GRPC_METHOD, original.path);
@@ -520,7 +532,7 @@ export class GrpcPlugin extends BasePlugin {
   }
 
   /**
-   * Set span context on a Metadata object if it exists.
+   * Sets a span context on a Metadata object if it exists.
    * @param metadata The Metadata object to which a span context should be
    *     added.
    * @param spanContext The span context.
@@ -530,6 +542,37 @@ export class GrpcPlugin extends BasePlugin {
     const serializedSpanContext = serializeSpanContext(spanContext);
     if (serializedSpanContext) {
       metadata.set(GRPC_TRACE_KEY, serializedSpanContext);
+    }
+  }
+
+  /**
+   * Returns a TagMap on a Metadata object if it exists and is well-formed, or
+   * null otherwise.
+   * @param metadata The Metadata object from which TagMap should be retrieved.
+   */
+  static getTagContext(metadata: grpcTypes.Metadata): TagMap|null {
+    const metadataValue = metadata.getMap()[GRPC_TAGS_KEY] as Buffer;
+    // Entry doesn't exist.
+    if (!metadataValue) return null;
+    try {
+      const tags = deserializeBinary(metadataValue);
+      // Value is malformed.
+      if (!tags) return null;
+      return tags;
+    } catch (ignore) {
+    }
+    return null;
+  }
+
+  /**
+   * Sets a TagMap context on a Metadata object if it exists.
+   * @param metadata The Metadata object to which a TagMap should be added.
+   * @param TagMap The TagMap.
+   */
+  static setTagContext(metadata: grpcTypes.Metadata, tagMap: TagMap): void {
+    const serializedTagMap = serializeBinary(tagMap);
+    if (serializedTagMap) {
+      metadata.set(GRPC_TAGS_KEY, serializedTagMap);
     }
   }
 


### PR DESCRIPTION
Fixes #325

This PR contains the following changes
1. Share same `contextManager` across tracer and stats singleton instances.
2. Add `withTagContext` and `getCurrentTagContext ` API on stats, so that plugins can use these API to get current `TagContext/TagMap`.
3. Make a deep copy of `TagMap` during get/set into `contextManager`.
4. Insert/Get gRPC metadata with `grpc-tags-bin` header with serialized `TagMap`.
5. Update `tag-context-example.js` example.

