### PR TITLE
Message events: use counters instead of hexdecimal value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Add `TagMetadata` that defines the properties associated with a `Tag`.
 - Add HTTP text format serializer to Tag propagation component.
 - Enforce `--strictNullChecks` and `--noUnusedLocals` Compiler Options on [opencensus-core] package.
+- Please note that there is an API breaking change in methods `addMessageEvent()`. The field `id` is now number instead of string.
 
 ## 0.0.9 - 2019-02-12
 - Add Metrics API.

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-span-base.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-span-base.ts
@@ -129,7 +129,7 @@ export abstract class NoRecordSpanBase implements types.Span {
 
   /** No-op implementation of this method. */
   addMessageEvent(
-      type: types.MessageEventType, id: string, timestamp = 0,
+      type: types.MessageEventType, id: number, timestamp = 0,
       uncompressedSize?: number, compressedSize?: number) {}
 
   /** No-op implementation of this method. */

--- a/packages/opencensus-core/src/trace/model/span-base.ts
+++ b/packages/opencensus-core/src/trace/model/span-base.ts
@@ -218,7 +218,7 @@ export abstract class SpanBase implements types.Span {
    *     zero or undefined, assumed to be the same size as uncompressed.
    */
   addMessageEvent(
-      type: types.MessageEventType, id: string, timestamp = 0,
+      type: types.MessageEventType, id: number, timestamp = 0,
       uncompressedSize?: number, compressedSize?: number) {
     if (this.messageEvents.length >=
         this.activeTraceParams.numberOfMessageEventsPerSpan!) {

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -191,11 +191,10 @@ export interface MessageEvent {
   /** Indicates whether the message was sent or received. */
   type: MessageEventType;
   /**
-   * An identifier for the MessageEvent's message. This should be a hexadecimal
-   * value that fits within 64-bits. Message event ids should start with 1 for
+   * An identifier for the MessageEvent's message that can be used to match
+   * SENT and RECEIVED MessageEvents. Message event ids should start with 1 for
    * both sent and received messages and increment by 1 for each message
-   * sent/received. See:
-   * https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/gRPC.md#message-events
+   * sent/received.
    */
   id: string;
   /** The number of uncompressed bytes sent or received. */

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -196,7 +196,7 @@ export interface MessageEvent {
    * both sent and received messages and increment by 1 for each message
    * sent/received.
    */
-  id: string;
+  id: number;
   /** The number of uncompressed bytes sent or received. */
   uncompressedSize?: number;
   /**
@@ -432,7 +432,7 @@ export interface Span {
    *     zero or undefined, assumed to be the same size as uncompressed.
    */
   addMessageEvent(
-      type: MessageEventType, id: string, timestamp?: number,
+      type: MessageEventType, id: number, timestamp?: number,
       uncompressedSize?: number, compressedSize?: number): void;
 
   /**

--- a/packages/opencensus-core/test/test-no-record-root-span.ts
+++ b/packages/opencensus-core/test/test-no-record-root-span.ts
@@ -28,8 +28,7 @@ describe('NoRecordRootSpan()', () => {
     noRecordRootSpan.addAnnotation(
         'MyAnnotation', {myString: 'bar', myNumber: 123, myBoolean: true});
     noRecordRootSpan.addLink('aaaaa', 'aaa', LinkType.CHILD_LINKED_SPAN);
-    noRecordRootSpan.addMessageEvent(
-        MessageEventType.RECEIVED, 'aaaa', 123456789);
+    noRecordRootSpan.addMessageEvent(MessageEventType.RECEIVED, '1', 123456789);
     noRecordRootSpan.addAttribute('my_first_attribute', 'foo');
     noRecordRootSpan.setStatus(CanonicalCode.OK);
     noRecordRootSpan.startChildSpan();

--- a/packages/opencensus-core/test/test-no-record-root-span.ts
+++ b/packages/opencensus-core/test/test-no-record-root-span.ts
@@ -28,7 +28,7 @@ describe('NoRecordRootSpan()', () => {
     noRecordRootSpan.addAnnotation(
         'MyAnnotation', {myString: 'bar', myNumber: 123, myBoolean: true});
     noRecordRootSpan.addLink('aaaaa', 'aaa', LinkType.CHILD_LINKED_SPAN);
-    noRecordRootSpan.addMessageEvent(MessageEventType.RECEIVED, '1', 123456789);
+    noRecordRootSpan.addMessageEvent(MessageEventType.RECEIVED, 1, 123456789);
     noRecordRootSpan.addAttribute('my_first_attribute', 'foo');
     noRecordRootSpan.setStatus(CanonicalCode.OK);
     noRecordRootSpan.startChildSpan();

--- a/packages/opencensus-core/test/test-no-record-span.ts
+++ b/packages/opencensus-core/test/test-no-record-span.ts
@@ -25,7 +25,7 @@ describe('NoRecordSpan()', () => {
     noRecordSpan.addAnnotation(
         'MyAnnotation', {myString: 'bar', myNumber: 123, myBoolean: true});
     noRecordSpan.addLink('aaaaa', 'aaa', LinkType.CHILD_LINKED_SPAN);
-    noRecordSpan.addMessageEvent(MessageEventType.RECEIVED, 'aaaa', 123456789);
+    noRecordSpan.addMessageEvent(MessageEventType.RECEIVED, 1, 123456789);
     noRecordSpan.addAttribute('my_first_attribute', 'foo');
     noRecordSpan.setStatus(CanonicalCode.OK);
   });

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -271,7 +271,7 @@ describe('RootSpan', () => {
 
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      rootSpan.addMessageEvent(types.MessageEventType.UNSPECIFIED, '1');
+      rootSpan.addMessageEvent(types.MessageEventType.UNSPECIFIED, 1);
 
       assert.ok(rootSpan.messageEvents.length > 0);
       assert.equal(rootSpan.droppedMessageEventsCount, 0);

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -271,9 +271,7 @@ describe('RootSpan', () => {
 
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-
-      rootSpan.addMessageEvent(
-          types.MessageEventType.UNSPECIFIED, 'message_event_test_id');
+      rootSpan.addMessageEvent(types.MessageEventType.UNSPECIFIED, '1');
 
       assert.ok(rootSpan.messageEvents.length > 0);
       assert.equal(rootSpan.droppedMessageEventsCount, 0);

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -331,8 +331,7 @@ describe('Span', () => {
       const span = new Span(rootSpan);
       span.start();
       for (let i = 0; i < 35; i++) {
-        span.addMessageEvent(
-            types.MessageEventType.UNSPECIFIED, 'message_event_test_id');
+        span.addMessageEvent(types.MessageEventType.UNSPECIFIED, '1');
       }
 
       assert.equal(span.messageEvents.length, 32);

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -308,14 +308,14 @@ describe('Span', () => {
       span.start();
 
       span.addMessageEvent(
-          types.MessageEventType.UNSPECIFIED, /* id */ '1',
+          types.MessageEventType.UNSPECIFIED, /* id */ 1,
           /* timestamp */ 1550000000000, /* uncompressedSize */ 55,
           /** compressedSize */ 40);
 
       assert.ok(span.messageEvents.length > 0);
       assert.deepEqual(span.messageEvents, [{
                          type: types.MessageEventType.UNSPECIFIED,
-                         id: '1',
+                         id: 1,
                          timestamp: 1550000000000,
                          uncompressedSize: 55,
                          compressedSize: 40,
@@ -331,7 +331,7 @@ describe('Span', () => {
       const span = new Span(rootSpan);
       span.start();
       for (let i = 0; i < 35; i++) {
-        span.addMessageEvent(types.MessageEventType.UNSPECIFIED, '1');
+        span.addMessageEvent(types.MessageEventType.UNSPECIFIED, 1);
       }
 
       assert.equal(span.messageEvents.length, 32);

--- a/packages/opencensus-exporter-ocagent/src/adapters.ts
+++ b/packages/opencensus-exporter-ocagent/src/adapters.ts
@@ -179,8 +179,7 @@ const adaptTimeEvents =
           timeEvents.push({
             time: millisToTimestamp(messageEvent.timestamp),
             messageEvent: {
-              // tslint:disable-next-line:ban Needed to parse hexadecimal.
-              id: parseInt(messageEvent.id, 16),
+              id: messageEvent.id,
               type: adaptMessageEventType(messageEvent.type),
               uncompressedSize: messageEvent.uncompressedSize || 0,
               compressedSize: messageEvent.compressedSize || 0

--- a/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
+++ b/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
@@ -269,13 +269,12 @@ describe('OpenCensus Agent Exporter', () => {
 
       // Message Event
       const timeStamp = 123456789;
-      rootSpan.addMessageEvent(MessageEventType.SENT, 'aaaa', timeStamp);
-      rootSpan.addMessageEvent(
-          MessageEventType.SENT, 'ffff', timeStamp, 100, 12);
-      rootSpan.addMessageEvent(MessageEventType.RECEIVED, 'ffff', timeStamp);
+      rootSpan.addMessageEvent(MessageEventType.SENT, '1', timeStamp);
+      rootSpan.addMessageEvent(MessageEventType.SENT, '2', timeStamp, 100, 12);
+      rootSpan.addMessageEvent(MessageEventType.RECEIVED, '1', timeStamp);
       // Use of `null` is to force a `TYPE_UNSPECIFIED` value
       // tslint:disable-next-line:no-any
-      rootSpan.addMessageEvent(null as any, 'ffff', timeStamp);
+      rootSpan.addMessageEvent(null as any, '2', timeStamp);
 
       // Links
       rootSpan.addLink('aaaaa', 'aaa', LinkType.CHILD_LINKED_SPAN);
@@ -493,8 +492,8 @@ describe('OpenCensus Agent Exporter', () => {
 
          // Message Event
          const timeStamp = 123456789;
-         rootSpan.addMessageEvent(MessageEventType.SENT, 'ffff', timeStamp);
-         rootSpan.addMessageEvent(MessageEventType.RECEIVED, 'ffff', timeStamp);
+         rootSpan.addMessageEvent(MessageEventType.SENT, '1', timeStamp);
+         rootSpan.addMessageEvent(MessageEventType.RECEIVED, '1', timeStamp);
 
          // Links
          rootSpan.addLink('ffff', 'ffff', LinkType.CHILD_LINKED_SPAN, {

--- a/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
+++ b/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
@@ -269,12 +269,12 @@ describe('OpenCensus Agent Exporter', () => {
 
       // Message Event
       const timeStamp = 123456789;
-      rootSpan.addMessageEvent(MessageEventType.SENT, '1', timeStamp);
-      rootSpan.addMessageEvent(MessageEventType.SENT, '2', timeStamp, 100, 12);
-      rootSpan.addMessageEvent(MessageEventType.RECEIVED, '1', timeStamp);
+      rootSpan.addMessageEvent(MessageEventType.SENT, 1, timeStamp);
+      rootSpan.addMessageEvent(MessageEventType.SENT, 2, timeStamp, 100, 12);
+      rootSpan.addMessageEvent(MessageEventType.RECEIVED, 1, timeStamp);
       // Use of `null` is to force a `TYPE_UNSPECIFIED` value
       // tslint:disable-next-line:no-any
-      rootSpan.addMessageEvent(null as any, '2', timeStamp);
+      rootSpan.addMessageEvent(null as any, 2, timeStamp);
 
       // Links
       rootSpan.addLink('aaaaa', 'aaa', LinkType.CHILD_LINKED_SPAN);
@@ -387,7 +387,7 @@ describe('OpenCensus Agent Exporter', () => {
                 {
                   messageEvent: {
                     compressedSize: '12',
-                    id: '65535',
+                    id: 2,
                     type: 'SENT',
                     uncompressedSize: '100'
                   },
@@ -398,7 +398,7 @@ describe('OpenCensus Agent Exporter', () => {
                   value: 'messageEvent',
                   messageEvent: {
                     compressedSize: '0',
-                    id: '65535',
+                    id: 1,
                     type: 'RECEIVED',
                     uncompressedSize: '0'
                   },
@@ -408,7 +408,7 @@ describe('OpenCensus Agent Exporter', () => {
                   value: 'messageEvent',
                   messageEvent: {
                     compressedSize: '0',
-                    id: '65535',
+                    id: 2,
                     type: 'TYPE_UNSPECIFIED',
                     uncompressedSize: '0'
                   },
@@ -492,8 +492,8 @@ describe('OpenCensus Agent Exporter', () => {
 
          // Message Event
          const timeStamp = 123456789;
-         rootSpan.addMessageEvent(MessageEventType.SENT, '1', timeStamp);
-         rootSpan.addMessageEvent(MessageEventType.RECEIVED, '1', timeStamp);
+         rootSpan.addMessageEvent(MessageEventType.SENT, 1, timeStamp);
+         rootSpan.addMessageEvent(MessageEventType.RECEIVED, 1, timeStamp);
 
          // Links
          rootSpan.addLink('ffff', 'ffff', LinkType.CHILD_LINKED_SPAN, {
@@ -576,7 +576,7 @@ describe('OpenCensus Agent Exporter', () => {
                    {
                      messageEvent: {
                        compressedSize: '0',
-                       id: '65535',
+                       id: 1,
                        type: 'SENT',
                        uncompressedSize: '0'
                      },
@@ -587,7 +587,7 @@ describe('OpenCensus Agent Exporter', () => {
                      value: 'messageEvent',
                      messageEvent: {
                        compressedSize: '0',
-                       id: '65535',
+                       id: 1,
                        type: 'RECEIVED',
                        uncompressedSize: '0'
                      },

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace-utils.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace-utils.ts
@@ -82,7 +82,7 @@ export function createTimeEvents(
         (messageEvent) => ({
           time: new Date(messageEvent.timestamp).toISOString(),
           messageEvent: {
-            id: messageEvent.id,
+            id: String(messageEvent.id),
             type: createMessageEventType(messageEvent.type),
             uncompressedSize: String(messageEvent.uncompressedSize || 0),
             compressedSize: String(messageEvent.compressedSize || 0)

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace-utils.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace-utils.ts
@@ -98,17 +98,14 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
     ];
     const messageEvents: coreTypes.MessageEvent[] = [
       {
-        id: 'aaaa',
+        id: 1,
         timestamp: ts,
         type: coreTypes.MessageEventType.SENT,
         compressedSize: 100,
         uncompressedSize: 12
       },
-      {id: 'ffff', timestamp: ts, type: coreTypes.MessageEventType.RECEIVED}, {
-        id: 'eeee',
-        timestamp: ts,
-        type: coreTypes.MessageEventType.UNSPECIFIED
-      }
+      {id: 1, timestamp: ts, type: coreTypes.MessageEventType.RECEIVED},
+      {id: 1, timestamp: ts, type: coreTypes.MessageEventType.UNSPECIFIED}
     ];
 
     const expectedTimeEvent = [
@@ -147,22 +144,18 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
         }
       },
       {
-        messageEvent: {
-          compressedSize: '100',
-          id: 'aaaa',
-          type: 1,
-          uncompressedSize: '12'
-        },
+        messageEvent:
+            {compressedSize: '100', id: '1', type: 1, uncompressedSize: '12'},
         time: '1970-01-02T10:17:36.789Z',
       },
       {
         messageEvent:
-            {compressedSize: '0', id: 'ffff', type: 2, uncompressedSize: '0'},
+            {compressedSize: '0', id: '1', type: 2, uncompressedSize: '0'},
         time: '1970-01-02T10:17:36.789Z',
       },
       {
         messageEvent:
-            {compressedSize: '0', id: 'eeee', type: 0, uncompressedSize: '0'},
+            {compressedSize: '0', id: '1', type: 0, uncompressedSize: '0'},
         time: '1970-01-02T10:17:36.789Z',
       }
     ];

--- a/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
@@ -117,9 +117,9 @@ describe('Zipkin Exporter', function() {
         span.setStatus(CanonicalCode.RESOURCE_EXHAUSTED, 'RESOURCE_EXHAUSTED');
 
         span.addAnnotation('processing', {}, 1550213104708);
-        span.addMessageEvent(MessageEventType.SENT, '1', 1550213104708);
-        span.addMessageEvent(MessageEventType.RECEIVED, '2', 1550213104708);
-        span.addMessageEvent(MessageEventType.UNSPECIFIED, '3', 1550213104708);
+        span.addMessageEvent(MessageEventType.SENT, 1, 1550213104708);
+        span.addMessageEvent(MessageEventType.RECEIVED, 2, 1550213104708);
+        span.addMessageEvent(MessageEventType.UNSPECIFIED, 3, 1550213104708);
         span.addAnnotation('done', {}, 1550213104708);
         span.end();
         rootSpan.end();

--- a/packages/opencensus-instrumentation-grpc/src/grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/src/grpc.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import {BasePlugin, CanonicalCode, deserializeBinary, PluginInternalFiles, RootSpan, serializeBinary, Span, SpanContext, SpanKind, TagMap, TagTtl, TraceOptions} from '@opencensus/core';
+import {BasePlugin, CanonicalCode, deserializeBinary, MessageEventType, PluginInternalFiles, RootSpan, serializeBinary, Span, SpanContext, SpanKind, TagMap, TagTtl, TraceOptions} from '@opencensus/core';
 import {deserializeSpanContext, serializeSpanContext} from '@opencensus/propagation-binaryformat';
 import {EventEmitter} from 'events';
 import * as grpcTypes from 'grpc';
 import * as lodash from 'lodash';
 import * as shimmer from 'shimmer';
+
 import * as clientStats from './grpc-stats/client-stats';
 import * as serverStats from './grpc-stats/server-stats';
 
@@ -87,8 +88,6 @@ export class GrpcPlugin extends BasePlugin {
   static readonly ATTRIBUTE_GRPC_STATUS_CODE = 'grpc.status_code';
   static readonly ATTRIBUTE_GRPC_ERROR_NAME = 'grpc.error_name';
   static readonly ATTRIBUTE_GRPC_ERROR_MESSAGE = 'grpc.error_message';
-  private sentSeqId = 1;
-  private receviedSeqId = 1;
 
   protected readonly internalFileList: PluginInternalFiles = {
     '0.13 - 1.6': {
@@ -230,8 +229,7 @@ export class GrpcPlugin extends BasePlugin {
             GrpcPlugin.ATTRIBUTE_GRPC_STATUS_CODE,
             grpcTypes.status.OK.toString());
       }
-      rootSpan.addMessageEvent(
-          MessageEventType.RECEIVED, `${plugin.receviedSeqId++}`);
+      rootSpan.addMessageEvent(MessageEventType.RECEIVED, 1);
 
       // record stats
       const parentTagCtx =
@@ -382,7 +380,7 @@ export class GrpcPlugin extends BasePlugin {
               GrpcPlugin.ATTRIBUTE_GRPC_STATUS_CODE,
               grpcTypes.status.OK.toString());
         }
-        span.addMessageEvent(MessageEventType.SENT, `${plugin.sentSeqId++}`);
+        span.addMessageEvent(MessageEventType.SENT, 1);
 
         // record stats: new RPCs on client-side inherit the tag context from
         // the current Context.

--- a/packages/opencensus-instrumentation-grpc/src/grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/src/grpc.ts
@@ -87,6 +87,8 @@ export class GrpcPlugin extends BasePlugin {
   static readonly ATTRIBUTE_GRPC_STATUS_CODE = 'grpc.status_code';
   static readonly ATTRIBUTE_GRPC_ERROR_NAME = 'grpc.error_name';
   static readonly ATTRIBUTE_GRPC_ERROR_MESSAGE = 'grpc.error_message';
+  private sentSeqId = 1;
+  private receviedSeqId = 1;
 
   protected readonly internalFileList: PluginInternalFiles = {
     '0.13 - 1.6': {
@@ -228,6 +230,8 @@ export class GrpcPlugin extends BasePlugin {
             GrpcPlugin.ATTRIBUTE_GRPC_STATUS_CODE,
             grpcTypes.status.OK.toString());
       }
+      rootSpan.addMessageEvent(
+          MessageEventType.RECEIVED, `${plugin.receviedSeqId++}`);
 
       // record stats
       const parentTagCtx =
@@ -378,6 +382,7 @@ export class GrpcPlugin extends BasePlugin {
               GrpcPlugin.ATTRIBUTE_GRPC_STATUS_CODE,
               grpcTypes.status.OK.toString());
         }
+        span.addMessageEvent(MessageEventType.SENT, `${plugin.sentSeqId++}`);
 
         // record stats: new RPCs on client-side inherit the tag context from
         // the current Context.

--- a/packages/opencensus-instrumentation-http/package-lock.json
+++ b/packages/opencensus-instrumentation-http/package-lock.json
@@ -179,14 +179,6 @@
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.1.tgz",
       "integrity": "sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ=="
     },
-    "@types/uuid": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
-      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "ajv": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
@@ -4567,11 +4559,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
-    },
-    "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/packages/opencensus-instrumentation-http/package-lock.json
+++ b/packages/opencensus-instrumentation-http/package-lock.json
@@ -2361,7 +2361,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2641,8 +2640,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2714,7 +2712,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2755,8 +2752,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2985,8 +2981,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-instrumentation-http/package.json
+++ b/packages/opencensus-instrumentation-http/package.json
@@ -54,7 +54,6 @@
     "@types/node": "^9.4.7",
     "@types/semver": "^6.0.0",
     "@types/shimmer": "^1.0.1",
-    "@types/uuid": "^3.4.3",
     "codecov": "^3.1.0",
     "gts": "^0.9.0",
     "mocha": "^6.0.0",
@@ -67,8 +66,7 @@
   },
   "dependencies": {
     "@opencensus/core": "^0.0.9",
-    "semver": "^6.0.0",
-    "shimmer": "^1.2.0",
-    "uuid": "^3.2.1"
+    "semver": "^5.5.0",
+    "shimmer": "^1.2.0"
   }
 }

--- a/packages/opencensus-instrumentation-http/package.json
+++ b/packages/opencensus-instrumentation-http/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@opencensus/core": "^0.0.9",
-    "semver": "^5.5.0",
+    "semver": "^6.0.0",
     "shimmer": "^1.2.0"
   }
 }

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -49,8 +49,6 @@ export class HttpPlugin extends BasePlugin {
   // NOT ON OFFICIAL SPEC
   static ATTRIBUTE_HTTP_ERROR_NAME = 'http.error_name';
   static ATTRIBUTE_HTTP_ERROR_MESSAGE = 'http.error_message';
-  private sentSeqId = 1;
-  private receviedSeqId = 1;
 
   /** Constructs a new HttpPlugin instance. */
   constructor(moduleName: string) {
@@ -243,8 +241,7 @@ export class HttpPlugin extends BasePlugin {
 
             rootSpan.setStatus(
                 HttpPlugin.parseResponseStatus(response.statusCode));
-            rootSpan.addMessageEvent(
-                MessageEventType.RECEIVED, `${plugin.receviedSeqId++}`);
+            rootSpan.addMessageEvent(MessageEventType.RECEIVED, 1);
 
             tags.set(
                 stats.HTTP_SERVER_METHOD, {value: method},
@@ -406,7 +403,7 @@ export class HttpPlugin extends BasePlugin {
                 stats.HTTP_CLIENT_STATUS,
                 {value: response.statusCode.toString()});
           }
-          span.addMessageEvent(MessageEventType.SENT, `${plugin.sentSeqId++}`);
+          span.addMessageEvent(MessageEventType.SENT, 1);
 
           HttpPlugin.recordStats(span.kind, tags, Date.now() - startTime);
           span.end();

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -19,7 +19,6 @@ import {ClientRequest, ClientResponse, IncomingMessage, request, RequestOptions,
 import * as semver from 'semver';
 import * as shimmer from 'shimmer';
 import * as url from 'url';
-import * as uuid from 'uuid';
 import * as stats from './http-stats';
 import {IgnoreMatcher} from './types';
 
@@ -50,6 +49,8 @@ export class HttpPlugin extends BasePlugin {
   // NOT ON OFFICIAL SPEC
   static ATTRIBUTE_HTTP_ERROR_NAME = 'http.error_name';
   static ATTRIBUTE_HTTP_ERROR_MESSAGE = 'http.error_message';
+  private sentSeqId = 1;
+  private receviedSeqId = 1;
 
   /** Constructs a new HttpPlugin instance. */
   constructor(moduleName: string) {
@@ -242,10 +243,8 @@ export class HttpPlugin extends BasePlugin {
 
             rootSpan.setStatus(
                 HttpPlugin.parseResponseStatus(response.statusCode));
-
-            // Message Event ID is not defined
             rootSpan.addMessageEvent(
-                MessageEventType.RECEIVED, uuid.v4().split('-').join(''));
+                MessageEventType.RECEIVED, `${plugin.receviedSeqId++}`);
 
             tags.set(
                 stats.HTTP_SERVER_METHOD, {value: method},
@@ -407,10 +406,7 @@ export class HttpPlugin extends BasePlugin {
                 stats.HTTP_CLIENT_STATUS,
                 {value: response.statusCode.toString()});
           }
-
-          // Message Event ID is not defined
-          span.addMessageEvent(
-              MessageEventType.SENT, uuid.v4().split('-').join(''));
+          span.addMessageEvent(MessageEventType.SENT, `${plugin.sentSeqId++}`);
 
           HttpPlugin.recordStats(span.kind, tags, Date.now() - startTime);
           span.end();

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -271,7 +271,7 @@ describe('HttpPlugin', () => {
           assertSpanAttributes(span, 200, 'GET', hostName, testPath);
           assert.equal(span.messageEvents.length, 1);
           assert.equal(span.messageEvents[0].type, MessageEventType.SENT);
-          assert.equal(span.messageEvents[0].id, '11');
+          assert.equal(span.messageEvents[0].id, '1');
           assertClientStats(testExporter, 200, 'GET');
         });
       });
@@ -305,7 +305,6 @@ describe('HttpPlugin', () => {
     it('should create multiple child spans for GET requests', () => {
       const testPath = '/outgoing/rootSpan/childs';
       const num = 5;
-      const currentSeqNo = 21;
       doNock(urlHost, testPath, 200, 'Ok', num);
       const options = {name: 'TestRootSpan'};
       return tracer.startRootSpan(options, async (root: RootSpan) => {
@@ -315,8 +314,7 @@ describe('HttpPlugin', () => {
             assert.strictEqual(root.spans.length, i + 1);
             assert.ok(root.spans[i].name.indexOf(testPath) >= 0);
             assert.strictEqual(root.traceId, root.spans[i].traceId);
-            assert.equal(
-                root.spans[i].messageEvents[0].id, `${currentSeqNo + i}`);
+            assert.equal(root.spans[i].messageEvents[0].id, 1);
             assert.equal(
                 root.spans[i].messageEvents[0].type, MessageEventType.SENT);
           });

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import {CoreTracer, globalStats, HeaderGetter, HeaderSetter, logger, Measurement, Propagation, RootSpan, Span, SpanContext, SpanEventListener, StatsEventListener, TagKey, TagMap, TagValue, View} from '@opencensus/core';
+import {CoreTracer, globalStats, HeaderGetter, HeaderSetter, logger, Measurement, MessageEventType, Propagation, RootSpan, Span, SpanContext, SpanEventListener, StatsEventListener, TagKey, TagMap, TagValue, View} from '@opencensus/core';
 import * as assert from 'assert';
 import * as http from 'http';
 import * as nock from 'nock';
 import * as shimmer from 'shimmer';
+
 import {HttpPlugin, plugin} from '../src/';
 import * as stats from '../src/http-stats';
 
@@ -223,6 +224,9 @@ describe('HttpPlugin', () => {
 
         const span = rootSpanVerifier.endedRootSpans[0];
         assertSpanAttributes(span, 200, 'GET', hostName, testPath);
+        assert.equal(span.messageEvents.length, 1);
+        assert.equal(span.messageEvents[0].type, MessageEventType.SENT);
+        assert.equal(span.messageEvents[0].id, '1');
         assertClientStats(testExporter, 200, 'GET');
       });
     });
@@ -265,6 +269,9 @@ describe('HttpPlugin', () => {
           assert.strictEqual(root.traceId, root.spans[0].traceId);
           const span = root.spans[0];
           assertSpanAttributes(span, 200, 'GET', hostName, testPath);
+          assert.equal(span.messageEvents.length, 1);
+          assert.equal(span.messageEvents[0].type, MessageEventType.SENT);
+          assert.equal(span.messageEvents[0].id, '11');
           assertClientStats(testExporter, 200, 'GET');
         });
       });
@@ -298,6 +305,7 @@ describe('HttpPlugin', () => {
     it('should create multiple child spans for GET requests', () => {
       const testPath = '/outgoing/rootSpan/childs';
       const num = 5;
+      const currentSeqNo = 21;
       doNock(urlHost, testPath, 200, 'Ok', num);
       const options = {name: 'TestRootSpan'};
       return tracer.startRootSpan(options, async (root: RootSpan) => {
@@ -307,6 +315,10 @@ describe('HttpPlugin', () => {
             assert.strictEqual(root.spans.length, i + 1);
             assert.ok(root.spans[i].name.indexOf(testPath) >= 0);
             assert.strictEqual(root.traceId, root.spans[i].traceId);
+            assert.equal(
+                root.spans[i].messageEvents[0].id, `${currentSeqNo + i}`);
+            assert.equal(
+                root.spans[i].messageEvents[0].type, MessageEventType.SENT);
           });
         }
         assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);

--- a/packages/opencensus-instrumentation-http2/package-lock.json
+++ b/packages/opencensus-instrumentation-http2/package-lock.json
@@ -171,14 +171,6 @@
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.1.tgz",
       "integrity": "sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ=="
     },
-    "@types/uuid": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
-      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "ajv": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",

--- a/packages/opencensus-instrumentation-http2/package.json
+++ b/packages/opencensus-instrumentation-http2/package.json
@@ -53,7 +53,6 @@
     "@types/node": "^10.12.12",
     "@types/semver": "^6.0.0",
     "@types/shimmer": "^1.0.1",
-    "@types/uuid": "^3.4.3",
     "codecov": "^3.1.0",
     "gts": "^0.9.0",
     "mocha": "^6.0.0",

--- a/packages/opencensus-instrumentation-http2/src/http2.ts
+++ b/packages/opencensus-instrumentation-http2/src/http2.ts
@@ -19,7 +19,6 @@ import {HttpPlugin} from '@opencensus/instrumentation-http';
 import * as http2 from 'http2';
 import * as shimmer from 'shimmer';
 import * as url from 'url';
-import * as uuid from 'uuid';
 
 export type Http2Module = typeof http2;
 export type ConnectFunction = typeof http2.connect;
@@ -30,6 +29,9 @@ export type CreateServerFunction = typeof http2.createServer;
 
 /** Http2 instrumentation plugin for Opencensus */
 export class Http2Plugin extends HttpPlugin {
+  private http2SentSeqId = 1;
+  private http2ReceviedSeqId = 1;
+
   /** Constructs a new Http2Plugin instance. */
   constructor() {
     super('http2');
@@ -159,10 +161,8 @@ export class Http2Plugin extends HttpPlugin {
           span.addAttribute(
               Http2Plugin.ATTRIBUTE_HTTP_USER_AGENT, `${userAgent}`);
         }
-
         span.addMessageEvent(
-            MessageEventType.SENT, uuid.v4().split('-').join(''));
-
+            MessageEventType.SENT, `${plugin.http2SentSeqId++}`);
         span.end();
       });
 
@@ -262,9 +262,8 @@ export class Http2Plugin extends HttpPlugin {
             rootSpan.addAttribute(
                 Http2Plugin.ATTRIBUTE_HTTP_STATUS_CODE, `${statusCode}`);
             rootSpan.setStatus(Http2Plugin.parseResponseStatus(statusCode));
-
             rootSpan.addMessageEvent(
-                MessageEventType.RECEIVED, uuid.v4().split('-').join(''));
+                MessageEventType.RECEIVED, `${plugin.http2ReceviedSeqId++}`);
 
             rootSpan.end();
             return returned;

--- a/packages/opencensus-instrumentation-http2/src/http2.ts
+++ b/packages/opencensus-instrumentation-http2/src/http2.ts
@@ -29,9 +29,6 @@ export type CreateServerFunction = typeof http2.createServer;
 
 /** Http2 instrumentation plugin for Opencensus */
 export class Http2Plugin extends HttpPlugin {
-  private http2SentSeqId = 1;
-  private http2ReceviedSeqId = 1;
-
   /** Constructs a new Http2Plugin instance. */
   constructor() {
     super('http2');
@@ -161,8 +158,7 @@ export class Http2Plugin extends HttpPlugin {
           span.addAttribute(
               Http2Plugin.ATTRIBUTE_HTTP_USER_AGENT, `${userAgent}`);
         }
-        span.addMessageEvent(
-            MessageEventType.SENT, `${plugin.http2SentSeqId++}`);
+        span.addMessageEvent(MessageEventType.SENT, 1);
         span.end();
       });
 
@@ -262,8 +258,7 @@ export class Http2Plugin extends HttpPlugin {
             rootSpan.addAttribute(
                 Http2Plugin.ATTRIBUTE_HTTP_STATUS_CODE, `${statusCode}`);
             rootSpan.setStatus(Http2Plugin.parseResponseStatus(statusCode));
-            rootSpan.addMessageEvent(
-                MessageEventType.RECEIVED, `${plugin.http2ReceviedSeqId++}`);
+            rootSpan.addMessageEvent(MessageEventType.RECEIVED, 1);
 
             rootSpan.end();
             return returned;

--- a/packages/opencensus-instrumentation-http2/test/test-http2.ts
+++ b/packages/opencensus-instrumentation-http2/test/test-http2.ts
@@ -15,7 +15,7 @@
  */
 
 
-import {CoreTracer, logger, RootSpan, Span, SpanEventListener} from '@opencensus/core';
+import {CoreTracer, logger, MessageEventType, RootSpan, Span, SpanEventListener} from '@opencensus/core';
 import * as assert from 'assert';
 import * as http2 from 'http2';
 import * as semver from 'semver';
@@ -141,6 +141,14 @@ describe('Http2Plugin', () => {
 
         const span = rootSpanVerifier.endedRootSpans[1];
         assertSpanAttributes(span, 200, 'GET', host, testPath);
+        assert.equal(span.messageEvents.length, 1);
+        assert.equal(span.messageEvents[0].type, MessageEventType.SENT);
+        assert.equal(span.messageEvents[0].id, '1');
+
+        const messageEvents =
+            rootSpanVerifier.endedRootSpans[0].messageEvents[0];
+        assert.equal(messageEvents.type, MessageEventType.RECEIVED);
+        assert.equal(messageEvents.id, '1');
       });
     });
 


### PR DESCRIPTION
Fixes #442 

As per the [Specs](https://github.com/census-instrumentation/opencensus-proto/blob/master/src/opencensus/proto/trace/v1/trace.proto#L202-L206), The `MessageId` must be calculated as two different counters starting from 1 one for sent messages and one for received message. This way we guarantee that the values will be consistent between different implementations.

~~To avoid breaking changes, I preferred to keep `string` type for id field. I am happy to change that or add support for both `string|number`.~~