### PR TITLE
Add MetricOptions to simplify all addXGauge

### DIFF
--- a/packages/opencensus-core/src/metrics/gauges/types.ts
+++ b/packages/opencensus-core/src/metrics/gauges/types.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {Metric, TimeSeries, Timestamp} from '../export/types';
+import {MeasureUnit} from '../../stats/types';
+import {LabelKey, LabelValue, Metric, TimeSeries, Timestamp} from '../export/types';
 
 export interface Meter {
   /**
@@ -47,4 +48,18 @@ export interface Point {
    * @returns {TimeSeries} The TimeSeries.
    */
   getTimeSeries(timestamp: Timestamp): TimeSeries;
+}
+
+export interface MetricOptions {
+  /** The description of the metric. */
+  readonly description?: string;
+  /** The unit of the metric. */
+  readonly unit?: MeasureUnit;
+  /** The list of the label keys. */
+  readonly labelKeys?: LabelKey[];
+  /** The map of constant labels for the Metric. */
+  readonly constantLabels?: Map<LabelKey, LabelValue>;
+
+  // TODO(mayurkale): Add resource information.
+  // https://github.com/census-instrumentation/opencensus-specs/pull/248
 }

--- a/packages/opencensus-core/src/metrics/gauges/types.ts
+++ b/packages/opencensus-core/src/metrics/gauges/types.ts
@@ -50,6 +50,7 @@ export interface Point {
   getTimeSeries(timestamp: Timestamp): TimeSeries;
 }
 
+/** Options for every metric added to the MetricRegistry. */
 export interface MetricOptions {
   /** The description of the metric. */
   readonly description?: string;

--- a/packages/opencensus-core/src/metrics/metric-registry.ts
+++ b/packages/opencensus-core/src/metrics/metric-registry.ts
@@ -31,6 +31,9 @@ export class MetricRegistry {
 
   private static readonly NAME = 'name';
   private static readonly LABEL_KEY = 'labelKey';
+  private static readonly DEFAULT_DESCRIPTION = '';
+  private static readonly DEFAULT_UNIT = MeasureUnit.UNIT;
+  private static readonly DEFAULT_LABEL_KEYS = [];
 
   constructor() {
     this.metricProducer = new MetricProducerForRegistry(this.registeredMetrics);
@@ -46,9 +49,12 @@ export class MetricRegistry {
    * @returns {Gauge} A Int64 Gauge metric.
    */
   addInt64Gauge(name: string, options?: MetricOptions): Gauge {
-    const description = (options && options.description) || '';
-    const unit = (options && options.unit) || MeasureUnit.UNIT;
-    const labelKeys = (options && options.labelKeys) || [];
+    const description =
+        (options && options.description) || MetricRegistry.DEFAULT_DESCRIPTION;
+    const unit = (options && options.unit) || MetricRegistry.DEFAULT_UNIT;
+    const labelKeys =
+        (options && options.labelKeys) || MetricRegistry.DEFAULT_LABEL_KEYS;
+    // TODO (mayurkale): Add support for constantLabels
 
     validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);
@@ -69,9 +75,12 @@ export class MetricRegistry {
    * @returns {Gauge} A Double Gauge metric.
    */
   addDoubleGauge(name: string, options?: MetricOptions): Gauge {
-    const description = (options && options.description) || '';
-    const unit = (options && options.unit) || MeasureUnit.UNIT;
-    const labelKeys = (options && options.labelKeys) || [];
+    const description =
+        (options && options.description) || MetricRegistry.DEFAULT_DESCRIPTION;
+    const unit = (options && options.unit) || MetricRegistry.DEFAULT_UNIT;
+    const labelKeys =
+        (options && options.labelKeys) || MetricRegistry.DEFAULT_LABEL_KEYS;
+    // TODO (mayurkale): Add support for constantLabels
 
     validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);
@@ -92,9 +101,12 @@ export class MetricRegistry {
    * @returns {DerivedGauge} A Int64 DerivedGauge metric.
    */
   addDerivedInt64Gauge(name: string, options?: MetricOptions): DerivedGauge {
-    const description = (options && options.description) || '';
-    const unit = (options && options.unit) || MeasureUnit.UNIT;
-    const labelKeys = (options && options.labelKeys) || [];
+    const description =
+        (options && options.description) || MetricRegistry.DEFAULT_DESCRIPTION;
+    const unit = (options && options.unit) || MetricRegistry.DEFAULT_UNIT;
+    const labelKeys =
+        (options && options.labelKeys) || MetricRegistry.DEFAULT_LABEL_KEYS;
+    // TODO (mayurkale): Add support for constantLabels
 
     validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);
@@ -115,9 +127,12 @@ export class MetricRegistry {
    * @returns {DerivedGauge} A Double DerivedGauge metric.
    */
   addDerivedDoubleGauge(name: string, options?: MetricOptions): DerivedGauge {
-    const description = (options && options.description) || '';
-    const unit = (options && options.unit) || MeasureUnit.UNIT;
-    const labelKeys = (options && options.labelKeys) || [];
+    const description =
+        (options && options.description) || MetricRegistry.DEFAULT_DESCRIPTION;
+    const unit = (options && options.unit) || MetricRegistry.DEFAULT_UNIT;
+    const labelKeys =
+        (options && options.labelKeys) || MetricRegistry.DEFAULT_LABEL_KEYS;
+    // TODO (mayurkale): Add support for constantLabels
 
     validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);

--- a/packages/opencensus-core/src/metrics/metric-registry.ts
+++ b/packages/opencensus-core/src/metrics/metric-registry.ts
@@ -17,10 +17,10 @@
 import {validateArrayElementsNotNull, validateNotNull} from '../common/validations';
 import {MeasureUnit,} from '../stats/types';
 import {BaseMetricProducer} from './export/base-metric-producer';
-import {LabelKey, Metric, MetricDescriptorType, MetricProducer} from './export/types';
+import {Metric, MetricDescriptorType, MetricProducer} from './export/types';
 import {DerivedGauge} from './gauges/derived-gauge';
 import {Gauge} from './gauges/gauge';
-import {Meter} from './gauges/types';
+import {Meter, MetricOptions} from './gauges/types';
 
 /**
  * Creates and manages application's set of metrics.
@@ -30,10 +30,7 @@ export class MetricRegistry {
   private metricProducer: MetricProducer;
 
   private static readonly NAME = 'name';
-  private static readonly DESCRIPTION = 'description';
-  private static readonly UNIT = 'unit';
   private static readonly LABEL_KEY = 'labelKey';
-  private static readonly LABEL_KEYS = 'labelKeys';
 
   constructor() {
     this.metricProducer = new MetricProducerForRegistry(this.registeredMetrics);
@@ -45,23 +42,18 @@ export class MetricRegistry {
    * per your service requirements.
    *
    * @param {string} name The name of the metric.
-   * @param {string} description The description of the metric.
-   * @param {MeasureUnit} unit The unit of the metric.
-   * @param {LabelKey[]} labelKeys The list of the label keys.
+   * @param {MetricOptions} options The options for the metric.
    * @returns {Gauge} A Int64 Gauge metric.
    */
-  addInt64Gauge(
-      name: string, description: string, unit: MeasureUnit,
-      labelKeys: LabelKey[]): Gauge {
-    validateArrayElementsNotNull(
-        validateNotNull(labelKeys, MetricRegistry.LABEL_KEYS),
-        MetricRegistry.LABEL_KEY);
+  addInt64Gauge(name: string, options?: MetricOptions): Gauge {
+    const description = (options && options.description) || '';
+    const unit = (options && options.unit) || MeasureUnit.UNIT;
+    const labelKeys = (options && options.labelKeys) || [];
 
+    validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);
     const int64Gauge = new Gauge(
-        validateNotNull(name, MetricRegistry.NAME),
-        validateNotNull(description, MetricRegistry.DESCRIPTION),
-        validateNotNull(unit, MetricRegistry.UNIT),
+        validateNotNull(name, MetricRegistry.NAME), description, unit,
         MetricDescriptorType.GAUGE_INT64, labelKeysCopy);
     this.registerMetric(name, int64Gauge);
     return int64Gauge;
@@ -73,23 +65,18 @@ export class MetricRegistry {
    * per your service requirements.
    *
    * @param {string} name The name of the metric.
-   * @param {string} description The description of the metric.
-   * @param {MeasureUnit} unit The unit of the metric.
-   * @param {LabelKey[]} labelKeys The list of the label keys.
+   * @param {MetricOptions} options The options for the metric.
    * @returns {Gauge} A Double Gauge metric.
    */
-  addDoubleGauge(
-      name: string, description: string, unit: MeasureUnit,
-      labelKeys: LabelKey[]): Gauge {
-    validateArrayElementsNotNull(
-        validateNotNull(labelKeys, MetricRegistry.LABEL_KEYS),
-        MetricRegistry.LABEL_KEY);
+  addDoubleGauge(name: string, options?: MetricOptions): Gauge {
+    const description = (options && options.description) || '';
+    const unit = (options && options.unit) || MeasureUnit.UNIT;
+    const labelKeys = (options && options.labelKeys) || [];
 
+    validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);
     const doubleGauge = new Gauge(
-        validateNotNull(name, MetricRegistry.NAME),
-        validateNotNull(description, MetricRegistry.DESCRIPTION),
-        validateNotNull(unit, MetricRegistry.UNIT),
+        validateNotNull(name, MetricRegistry.NAME), description, unit,
         MetricDescriptorType.GAUGE_DOUBLE, labelKeysCopy);
     this.registerMetric(name, doubleGauge);
     return doubleGauge;
@@ -101,23 +88,18 @@ export class MetricRegistry {
    * per your service requirements.
    *
    * @param {string} name The name of the metric.
-   * @param {string} description The description of the metric.
-   * @param {MeasureUnit} unit The unit of the metric.
-   * @param {LabelKey[]} labelKeys The list of the label keys.
+   * @param {MetricOptions} options The options for the metric.
    * @returns {DerivedGauge} A Int64 DerivedGauge metric.
    */
-  addDerivedInt64Gauge(
-      name: string, description: string, unit: MeasureUnit,
-      labelKeys: LabelKey[]): DerivedGauge {
-    validateArrayElementsNotNull(
-        validateNotNull(labelKeys, MetricRegistry.LABEL_KEYS),
-        MetricRegistry.LABEL_KEY);
+  addDerivedInt64Gauge(name: string, options?: MetricOptions): DerivedGauge {
+    const description = (options && options.description) || '';
+    const unit = (options && options.unit) || MeasureUnit.UNIT;
+    const labelKeys = (options && options.labelKeys) || [];
 
+    validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);
     const derivedInt64Gauge = new DerivedGauge(
-        validateNotNull(name, MetricRegistry.NAME),
-        validateNotNull(description, MetricRegistry.DESCRIPTION),
-        validateNotNull(unit, MetricRegistry.UNIT),
+        validateNotNull(name, MetricRegistry.NAME), description, unit,
         MetricDescriptorType.GAUGE_INT64, labelKeysCopy);
     this.registerMetric(name, derivedInt64Gauge);
     return derivedInt64Gauge;
@@ -129,23 +111,18 @@ export class MetricRegistry {
    * per your service requirements.
    *
    * @param {string} name The name of the metric.
-   * @param {string} description The description of the metric.
-   * @param {MeasureUnit} unit The unit of the metric.
-   * @param {LabelKey[]} labelKeys The list of the label keys.
+   * @param {MetricOptions} options The options for the metric.
    * @returns {DerivedGauge} A Double DerivedGauge metric.
    */
-  addDerivedDoubleGauge(
-      name: string, description: string, unit: MeasureUnit,
-      labelKeys: LabelKey[]): DerivedGauge {
-    validateArrayElementsNotNull(
-        validateNotNull(labelKeys, MetricRegistry.LABEL_KEYS),
-        MetricRegistry.LABEL_KEY);
+  addDerivedDoubleGauge(name: string, options?: MetricOptions): DerivedGauge {
+    const description = (options && options.description) || '';
+    const unit = (options && options.unit) || MeasureUnit.UNIT;
+    const labelKeys = (options && options.labelKeys) || [];
 
+    validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
     const labelKeysCopy = Object.assign([], labelKeys);
     const derivedDoubleGauge = new DerivedGauge(
-        validateNotNull(name, MetricRegistry.NAME),
-        validateNotNull(description, MetricRegistry.DESCRIPTION),
-        validateNotNull(unit, MetricRegistry.UNIT),
+        validateNotNull(name, MetricRegistry.NAME), description, unit,
         MetricDescriptorType.GAUGE_DOUBLE, labelKeysCopy);
     this.registerMetric(name, derivedDoubleGauge);
     return derivedDoubleGauge;

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {globalStats, LabelKey, Logger, MeasureUnit, Metrics} from '@opencensus/core';
+import {globalStats, Logger, MeasureUnit, Metrics} from '@opencensus/core';
 import * as assert from 'assert';
 import {StackdriverStatsExporter} from '../src/stackdriver-monitoring';
 import {MetricKind, StackdriverExporterOptions, ValueType} from '../src/types';
@@ -83,12 +83,15 @@ describe('Stackdriver Stats Exporter', () => {
       const METRIC_NAME = 'metric-name';
       const METRIC_DESCRIPTION = 'metric-description';
       const UNIT = MeasureUnit.UNIT;
-      const LABEL_KEYS: LabelKey[] = [{key: 'code', description: 'desc'}];
+      const METRIC_OPTIONS = {
+        description: METRIC_DESCRIPTION,
+        unit: UNIT,
+        labelKeys: [{key: 'code', description: 'desc'}]
+      };
 
       const metricRegistry = Metrics.getMetricRegistry();
 
-      const gauge = metricRegistry.addInt64Gauge(
-          METRIC_NAME, METRIC_DESCRIPTION, UNIT, LABEL_KEYS);
+      const gauge = metricRegistry.addInt64Gauge(METRIC_NAME, METRIC_OPTIONS);
       gauge.getDefaultTimeSeries().add(100);
 
       nocks.metricDescriptors(PROJECT_ID);


### PR DESCRIPTION
The list of options are too long for `Gauges` (`Cumulative` metrics - in the future) metrics and most of them are optional. It makes sense to use `MetricOptions` type to maintain the options. Also, in the future will be adding `resource` information to the `MetricOptions` list. This way it is easier to shrink or expand the input options.

Although, this is a breaking change in existing `Gauge` API but we don't expect too many users using this (released in last version - `0.0.9`).

Specs: https://github.com/census-instrumentation/opencensus-specs/pull/248/files