### PR TITLE
chore(multiple): 0.0.11 release proposal

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/opencensus-core/package.json
+++ b/packages/opencensus-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/core",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus is a toolkit for collecting application performance and behavior data.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opencensus-example-automatic-tracing/package.json
+++ b/packages/opencensus-example-automatic-tracing/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@opencensus/example-automatic-tracing",
   "description": "These example show hot to trace a simple HTTP server and export the trace state.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "main": "zipkin.js",
   "dependencies": {
-    "@opencensus/exporter-instana": "^0.0.10",
-    "@opencensus/exporter-stackdriver": "^0.0.10",
-    "@opencensus/exporter-zipkin": "^0.0.10",
-    "@opencensus/nodejs": "^0.0.10"
+    "@opencensus/exporter-instana": "^0.0.11",
+    "@opencensus/exporter-stackdriver": "^0.0.11",
+    "@opencensus/exporter-zipkin": "^0.0.11",
+    "@opencensus/nodejs": "^0.0.11"
   }
 }

--- a/packages/opencensus-exporter-instana/package.json
+++ b/packages/opencensus-exporter-instana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/exporter-instana",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus Instana Exporter allows the user to send collected traces with OpenCensus Node.js to Instana.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -63,6 +63,6 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10"
+    "@opencensus/core": "^0.0.11"
   }
 }

--- a/packages/opencensus-exporter-jaeger/package-lock.json
+++ b/packages/opencensus-exporter-jaeger/package-lock.json
@@ -2338,7 +2338,6 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -2618,8 +2617,7 @@
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
@@ -2691,7 +2689,6 @@
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -2732,8 +2729,7 @@
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
@@ -2962,8 +2958,7 @@
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"require-directory": {
 					"version": "2.1.1",

--- a/packages/opencensus-exporter-jaeger/package.json
+++ b/packages/opencensus-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/exporter-jaeger",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus Exporter Jeager allows user to send collected traces to Jeager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -63,7 +63,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "jaeger-client": "~3.14.0"
   }
 }

--- a/packages/opencensus-exporter-ocagent/package-lock.json
+++ b/packages/opencensus-exporter-ocagent/package-lock.json
@@ -1367,8 +1367,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1386,13 +1385,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1405,18 +1402,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1519,8 +1513,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1530,7 +1523,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1543,20 +1535,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1573,7 +1562,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1646,8 +1634,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1657,7 +1644,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1733,8 +1719,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1764,7 +1749,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1782,7 +1766,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1821,13 +1804,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3580,7 +3561,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3860,8 +3840,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3933,7 +3912,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3974,8 +3952,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -4204,8 +4181,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-exporter-ocagent/package.json
+++ b/packages/opencensus-exporter-ocagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/exporter-ocagent",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus Agent Exporter allows user to send collected trace to the OpenCensus Agent",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -64,8 +64,8 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.4.0",
-    "@opencensus/core": "^0.0.10",
-    "@opencensus/nodejs": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
+    "@opencensus/nodejs": "^0.0.11",
     "grpc": "^1.18.0"
   }
 }

--- a/packages/opencensus-exporter-prometheus/package-lock.json
+++ b/packages/opencensus-exporter-prometheus/package-lock.json
@@ -2568,7 +2568,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2848,8 +2847,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2921,7 +2919,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2962,8 +2959,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3192,8 +3188,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-exporter-prometheus/package.json
+++ b/packages/opencensus-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/exporter-prometheus",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus Exporter Prometheus allows user to send collected stats to Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -63,7 +63,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "express": "^4.16.3",
     "prom-client": "^11.1.1"
   }

--- a/packages/opencensus-exporter-stackdriver/package-lock.json
+++ b/packages/opencensus-exporter-stackdriver/package-lock.json
@@ -2543,7 +2543,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2823,8 +2822,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2896,7 +2894,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2937,8 +2934,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3167,8 +3163,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-exporter-stackdriver/package.json
+++ b/packages/opencensus-exporter-stackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/exporter-stackdriver",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus Exporter Stackdriver allows user to send collected traces to Stackdriver",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -64,8 +64,8 @@
     "typescript": "~3.1.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
-    "@opencensus/resource-util": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
+    "@opencensus/resource-util": "^0.0.11",
     "google-auth-library": "^3.0.0",
     "googleapis": "39.2.0"
   }

--- a/packages/opencensus-exporter-zipkin/package.json
+++ b/packages/opencensus-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/exporter-zipkin",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus Zipkin Exporter allows the user to send collected traces with OpenCensus Node.js to Zipkin.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -62,6 +62,6 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10"
+    "@opencensus/core": "^0.0.11"
   }
 }

--- a/packages/opencensus-exporter-zpages/package.json
+++ b/packages/opencensus-exporter-zpages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/exporter-zpages",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A collection of HTML pages to display stats and trace data and allow library configuration control",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opencensus/nodejs": "^0.0.10",
+    "@opencensus/nodejs": "^0.0.11",
     "@types/ejs": "^2.6.0",
     "@types/express": "^4.11.1",
     "@types/extend": "^3.0.0",
@@ -67,7 +67,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "ejs": "^2.5.8",
     "express": "^4.16.3"
   }

--- a/packages/opencensus-instrumentation-all/package.json
+++ b/packages/opencensus-instrumentation-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-all",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "This package has dependencies to all default instrumentation packages.",
   "main": "src/index.js",
   "types": "src/index.d.ts",
@@ -38,12 +38,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@opencensus/instrumentation-grpc": "^0.0.10",
-    "@opencensus/instrumentation-http": "^0.0.10",
-    "@opencensus/instrumentation-http2": "^0.0.10",
-    "@opencensus/instrumentation-https": "^0.0.10",
-    "@opencensus/instrumentation-ioredis": "^0.0.10",
-    "@opencensus/instrumentation-mongodb": "^0.0.10",
-    "@opencensus/instrumentation-redis": "^0.0.10"
+    "@opencensus/instrumentation-grpc": "^0.0.11",
+    "@opencensus/instrumentation-http": "^0.0.11",
+    "@opencensus/instrumentation-http2": "^0.0.11",
+    "@opencensus/instrumentation-https": "^0.0.11",
+    "@opencensus/instrumentation-ioredis": "^0.0.11",
+    "@opencensus/instrumentation-mongodb": "^0.0.11",
+    "@opencensus/instrumentation-redis": "^0.0.11"
   }
 }

--- a/packages/opencensus-instrumentation-grpc/package-lock.json
+++ b/packages/opencensus-instrumentation-grpc/package-lock.json
@@ -3026,7 +3026,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3306,8 +3305,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3379,7 +3377,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3420,8 +3417,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3650,8 +3646,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-instrumentation-grpc/package.json
+++ b/packages/opencensus-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-grpc",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opencensus/propagation-binaryformat": "^0.0.10",
+    "@opencensus/propagation-binaryformat": "^0.0.11",
     "@types/lodash": "^4.14.109",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.12",
@@ -66,7 +66,7 @@
     "typescript": "~2.8.3"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "grpc": "~1.19.0",
     "lodash": "^4.17.11",
     "object-sizeof": "^1.3.0",

--- a/packages/opencensus-instrumentation-http/package-lock.json
+++ b/packages/opencensus-instrumentation-http/package-lock.json
@@ -2361,7 +2361,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2641,8 +2640,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2714,7 +2712,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2755,8 +2752,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2985,8 +2981,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-instrumentation-http/package.json
+++ b/packages/opencensus-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-http",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus http automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -65,7 +65,7 @@
     "typescript": "~2.9.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "semver": "^6.0.0",
     "shimmer": "^1.2.0"
   }

--- a/packages/opencensus-instrumentation-http2/package-lock.json
+++ b/packages/opencensus-instrumentation-http2/package-lock.json
@@ -2276,7 +2276,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2556,8 +2555,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2629,7 +2627,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2670,8 +2667,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2900,8 +2896,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-instrumentation-http2/package.json
+++ b/packages/opencensus-instrumentation-http2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-http2",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus http2 automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -63,8 +63,8 @@
     "typescript": "~2.9.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
-    "@opencensus/instrumentation-http": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
+    "@opencensus/instrumentation-http": "^0.0.11",
     "semver": "^6.0.0",
     "shimmer": "^1.2.0"
   }

--- a/packages/opencensus-instrumentation-https/package-lock.json
+++ b/packages/opencensus-instrumentation-https/package-lock.json
@@ -2361,7 +2361,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2641,8 +2640,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2714,7 +2712,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2755,8 +2752,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2985,8 +2981,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-instrumentation-https/package.json
+++ b/packages/opencensus-instrumentation-https/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-https",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -65,8 +65,8 @@
     "typescript": "~2.9.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
-    "@opencensus/instrumentation-http": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
+    "@opencensus/instrumentation-http": "^0.0.11",
     "semver": "^6.0.0",
     "shimmer": "^1.2.0"
   }

--- a/packages/opencensus-instrumentation-ioredis/package.json
+++ b/packages/opencensus-instrumentation-ioredis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-ioredis",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus IORedis automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -67,7 +67,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "semver": "^6.0.0",
     "shimmer": "^1.2.0"
   }

--- a/packages/opencensus-instrumentation-mongodb/package-lock.json
+++ b/packages/opencensus-instrumentation-mongodb/package-lock.json
@@ -2312,7 +2312,6 @@
           "version": "0.1.4",
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2637,8 +2636,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": false,
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "optional": true
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2722,7 +2720,6 @@
           "version": "3.2.2",
           "resolved": false,
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2769,8 +2766,7 @@
         "longest": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "optional": true
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3036,8 +3032,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "resolved": false,
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "optional": true
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-instrumentation-mongodb/package.json
+++ b/packages/opencensus-instrumentation-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-mongodb",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus MongoDB automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -64,7 +64,7 @@
     "typescript": "~2.9.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "shimmer": "^1.2.0"
   }
 }

--- a/packages/opencensus-instrumentation-redis/package.json
+++ b/packages/opencensus-instrumentation-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/instrumentation-redis",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus Redis automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -54,7 +54,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "semver": "^6.0.0",
     "shimmer": "^1.2.0"
   }

--- a/packages/opencensus-nodejs/package.json
+++ b/packages/opencensus-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/nodejs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus is a toolkit for collecting application performance and behavior data.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -54,8 +54,8 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
-    "@opencensus/instrumentation-all": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
+    "@opencensus/instrumentation-all": "^0.0.11",
     "extend": "^3.0.2",
     "require-in-the-middle": "^4.0.0"
   }

--- a/packages/opencensus-propagation-b3/package-lock.json
+++ b/packages/opencensus-propagation-b3/package-lock.json
@@ -2236,7 +2236,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2516,8 +2515,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2589,7 +2587,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2630,8 +2627,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2860,8 +2856,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-propagation-b3/package.json
+++ b/packages/opencensus-propagation-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/propagation-b3",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus propagation package for B3 format.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -62,7 +62,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "uuid": "^3.2.1"
   }
 }

--- a/packages/opencensus-propagation-binaryformat/package.json
+++ b/packages/opencensus-propagation-binaryformat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/propagation-binaryformat",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus propagation package for binary format.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -61,6 +61,6 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10"
+    "@opencensus/core": "^0.0.11"
   }
 }

--- a/packages/opencensus-propagation-jaeger/package-lock.json
+++ b/packages/opencensus-propagation-jaeger/package-lock.json
@@ -2236,7 +2236,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2516,8 +2515,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2589,7 +2587,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2630,8 +2627,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2860,8 +2856,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-propagation-jaeger/package.json
+++ b/packages/opencensus-propagation-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/propagation-jaeger",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus propagation package for jaeger's format.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -61,7 +61,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "uuid": "^3.2.1"
   }
 }

--- a/packages/opencensus-propagation-stackdriver/package.json
+++ b/packages/opencensus-propagation-stackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/propagation-stackdriver",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Opencensus propagation package for Stackdriver format.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -37,7 +37,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "hex2dec": "^1.0.1",
     "uuid": "^3.2.1"
   },

--- a/packages/opencensus-propagation-tracecontext/package-lock.json
+++ b/packages/opencensus-propagation-tracecontext/package-lock.json
@@ -2228,7 +2228,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2508,8 +2507,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2581,7 +2579,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2622,8 +2619,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2852,8 +2848,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-propagation-tracecontext/package.json
+++ b/packages/opencensus-propagation-tracecontext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/propagation-tracecontext",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenCensus propagation package for TraceContext format.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -61,6 +61,6 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10"
+    "@opencensus/core": "^0.0.11"
   }
 }

--- a/packages/opencensus-resource-util/package-lock.json
+++ b/packages/opencensus-resource-util/package-lock.json
@@ -2361,7 +2361,6 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2686,8 +2685,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "optional": true
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2771,7 +2769,6 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2818,8 +2815,7 @@
         "longest": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "optional": true
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3085,8 +3081,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "optional": true
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/opencensus-resource-util/package.json
+++ b/packages/opencensus-resource-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/resource-util",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "The OpenCensus Monitored Resource Util for Node.js is a collection of utilities for auto detecting monitored resource when exporting stats, based on the environment where the application is running.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -62,7 +62,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@opencensus/core": "^0.0.10",
+    "@opencensus/core": "^0.0.11",
     "gcp-metadata": "^1.0.0"
   }
 }


### PR DESCRIPTION
https://github.com/census-instrumentation/opencensus-node/releases/tag/untagged-662383a19e4f29ac5035

7609340 Add redis instrumentation plugins by default (#471)
b916ec9 Add support for Opencensus Span links to Thrift Span references (#473)
dff1e54 Fix(deps): update dependency googleapis to v39 (#452)
aa889b2 Fix error in opencensus to stackdriver translation (#474) (#475)
9632157 Remove createScopedRequired usage (#467)
6f5c6b3 Gauge: Add support for constant labels (#468)