### PR TITLE
Add support for custom attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 **This release has a breaking change. Please test your code accordingly after upgrading.**
 
+- http-instrumentation: add support for the addition of custom attributes to spans
 - Remove Span's `startChildSpan(nameOrOptions?: string|SpanOptions, kind?: SpanKind)` interface, now only `SpanOptions` object interface is supported.
 
 ## 0.0.12 - 2019-05-13

--- a/packages/opencensus-core/src/trace/instrumentation/types.ts
+++ b/packages/opencensus-core/src/trace/instrumentation/types.ts
@@ -15,7 +15,7 @@
  */
 
 import {Stats} from '../../stats/types';
-import {TracerBase} from '../model/types';
+import {Span, TracerBase} from '../model/types';
 
 /** Interface Plugin to apply patch. */
 export interface Plugin {
@@ -36,9 +36,19 @@ export interface Plugin {
   disable(): void;
 }
 
+/**
+ * Function that can be provided to plugin in order to add custom
+ * attributes to spans
+ */
+export interface CustomAttributeFunction {
+  // tslint:disable-next-line:no-any
+  (span: Span, ...rest: any[]): void;
+}
+
 export type PluginConfig = {
   // tslint:disable-next-line:no-any
   [key: string]: any;
+  applyCustomAttributesOnSpan?: CustomAttributeFunction;
 };
 
 export type NamedPluginConfig = {

--- a/packages/opencensus-instrumentation-http/src/types.ts
+++ b/packages/opencensus-instrumentation-http/src/types.ts
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-import {ClientRequest, IncomingMessage} from 'http';
+import {CustomAttributeFunction, Span} from '@opencensus/core';
+import {ClientRequest, IncomingMessage, ServerResponse} from 'http';
 
 export type IgnoreMatcher<T> =
     string|RegExp|((url: string, request: T) => boolean);
 
+export interface HttpCustomAttributeFunction extends CustomAttributeFunction {
+  (span: Span, request: ClientRequest|IncomingMessage,
+   response: IncomingMessage|ServerResponse): void;
+}
+
 export type HttpPluginConfig = {
   ignoreIncomingPaths?: Array<IgnoreMatcher<IncomingMessage>>;
   ignoreOutgoingUrls?: Array<IgnoreMatcher<ClientRequest>>;
+  applyCustomAttributesOnSpan?: HttpCustomAttributeFunction;
 };


### PR DESCRIPTION
Add support for custom attributes for http and https spans
Fixes: https://github.com/census-instrumentation/opencensus-node/issues/490

I've marked as Work in progress WIP as I've not looked at the updates needed to add any required documentation and to add tests.

I'm away until May 8th so I won't get back to the docs and tests until then but I wanted to get this out so that people could review provide additional feedback.

I think it is in line with the recommendations in https://github.com/census-instrumentation/opencensus-node/issues/490 and it seems to work based on my test app.