### PR TITLE
fix(tracer): report every span to exporters

### DIFF
--- a/packages/opencensus-core/src/exporters/console-exporter.ts
+++ b/packages/opencensus-core/src/exporters/console-exporter.ts
@@ -48,14 +48,14 @@ export class ConsoleExporter implements Exporter {
     this.logger = config.logger;
   }
 
-  onStartSpan(root: modelTypes.Span) {}
+  onStartSpan(span: modelTypes.Span) {}
 
   /**
    * Event called when a span is ended.
-   * @param root Ended span.
+   * @param span Ended span.
    */
-  onEndSpan(root: modelTypes.Span) {
-    this.buffer.addToBuffer(root);
+  onEndSpan(span: modelTypes.Span) {
+    this.buffer.addToBuffer(span);
   }
 
   /**

--- a/packages/opencensus-core/src/exporters/exporter-buffer.ts
+++ b/packages/opencensus-core/src/exporters/exporter-buffer.ts
@@ -80,7 +80,7 @@ export class ExporterBuffer {
    */
   addToBuffer(root: modelTypes.Span) {
     this.queue.push(root);
-    this.logger.debug('ExporterBuffer: added new rootspan');
+    this.logger.debug('ExporterBuffer: added new span');
 
     if (this.queue.length > this.bufferSize) {
       this.flush();

--- a/packages/opencensus-core/src/exporters/exporter-buffer.ts
+++ b/packages/opencensus-core/src/exporters/exporter-buffer.ts
@@ -75,11 +75,11 @@ export class ExporterBuffer {
   }
 
   /**
-   * Add a rootSpan in the buffer.
-   * @param root RootSpan to be added in the buffer.
+   * Add a span in the buffer.
+   * @param span Span to be added in the buffer.
    */
-  addToBuffer(root: modelTypes.Span) {
-    this.queue.push(root);
+  addToBuffer(span: modelTypes.Span) {
+    this.queue.push(span);
     this.logger.debug('ExporterBuffer: added new span');
 
     if (this.queue.length > this.bufferSize) {

--- a/packages/opencensus-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-core/src/trace/model/root-span.ts
@@ -20,8 +20,6 @@ import * as types from './types';
 
 /** Defines a root span */
 export class RootSpan extends Span {
-  /** A tracer object */
-  private tracer: types.TracerBase;
   /** Its trace ID. */
   private traceIdLocal: string;
   /** Its trace state. */
@@ -45,8 +43,7 @@ export class RootSpan extends Span {
   constructor(
       tracer: types.TracerBase, name: string, kind: types.SpanKind,
       traceId: string, parentSpanId: string, traceState?: types.TraceState) {
-    super();
-    this.tracer = tracer;
+    super(tracer);
     this.traceIdLocal = traceId;
     this.name = name;
     this.kind = kind;
@@ -70,18 +67,5 @@ export class RootSpan extends Span {
 
   get parentSpanId(): string {
     return this.parentSpanIdLocal;
-  }
-
-  /** Starts a rootspan instance. */
-  start() {
-    super.start();
-
-    this.tracer.onStartSpan(this);
-  }
-
-  /** Ends a rootspan instance. */
-  end() {
-    super.end();
-    this.tracer.onEndSpan(this);
   }
 }

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -29,6 +29,8 @@ const STATUS_OK = {
 /** Defines a base model for spans. */
 export class Span implements types.Span {
   protected className: string;
+  /** A tracer object */
+  private tracer: types.TracerBase;
   /** The clock used to mesure the beginning and ending of a span */
   private clock!: Clock;
   /** Indicates if this span was started */
@@ -77,7 +79,8 @@ export class Span implements types.Span {
   droppedMessageEventsCount = 0;
 
   /** Constructs a new Span instance. */
-  constructor(parent?: Span) {
+  constructor(tracer: types.TracerBase, parent?: Span) {
+    this.tracer = tracer;
     this.className = this.constructor.name;
     this.id = randomSpanId();
     this.spansLocal = [];
@@ -307,6 +310,8 @@ export class Span implements types.Span {
       parentSpanId: this.parentSpanId,
       traceState: this.traceState
     });
+
+    this.tracer.onStartSpan(this);
   }
 
   /** Ends the span and all of its children, recursively. */
@@ -332,6 +337,8 @@ export class Span implements types.Span {
         span.truncate();
       }
     }
+
+    this.tracer.onEndSpan(this);
   }
 
   /** Forces the span to end. */
@@ -363,7 +370,7 @@ export class Span implements types.Span {
       return new NoRecordSpan();
     }
 
-    const child = new Span(this);
+    const child = new Span(this.tracer, this);
     const spanName =
         typeof nameOrOptions === 'object' ? nameOrOptions.name : nameOrOptions;
     const spanKind =

--- a/packages/opencensus-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-core/src/trace/model/tracer-base.ts
@@ -180,20 +180,20 @@ export class CoreTracerBase implements types.TracerBase {
     }
   }
 
-  private notifyStartSpan(root: types.Span) {
-    this.logger.debug('starting to notify listeners the start of rootspans');
+  private notifyStartSpan(span: types.Span) {
+    this.logger.debug('starting to notify listeners the start of spans');
     if (this.eventListenersLocal && this.eventListenersLocal.length > 0) {
       for (const listener of this.eventListenersLocal) {
-        listener.onStartSpan(root);
+        listener.onStartSpan(span);
       }
     }
   }
 
-  private notifyEndSpan(root: types.Span) {
-    this.logger.debug('starting to notify listeners the end of rootspans');
+  private notifyEndSpan(span: types.Span) {
+    this.logger.debug('starting to notify listeners the end of spans');
     if (this.eventListenersLocal && this.eventListenersLocal.length > 0) {
       for (const listener of this.eventListenersLocal) {
-        listener.onEndSpan(root);
+        listener.onEndSpan(span);
       }
     }
   }

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -293,7 +293,7 @@ describe('RootSpan', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       rootSpan.addLink(

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -41,10 +41,10 @@ describe('Span', () => {
   /**
    * Should create a span
    */
-  describe('new Span()', () => {
+  describe('new Span(tracer, )', () => {
     it('should create a Span instance', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       assert.ok(span instanceof Span);
     });
   });
@@ -56,7 +56,7 @@ describe('Span', () => {
     it('should return the trace id', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       assert.equal(span.traceId, rootSpan.traceId);
     });
   });
@@ -69,7 +69,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       const context = span.spanContext;
 
       assert.equal(context.traceId, rootSpan.traceId);
@@ -87,7 +87,7 @@ describe('Span', () => {
     before(() => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      span = new Span(rootSpan);
+      span = new Span(tracer, rootSpan);
     });
     it('should get startTime()', () => {
       assert.ok(span.startTime);
@@ -108,7 +108,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       assert.ok(span.started);
@@ -122,7 +122,7 @@ describe('Span', () => {
     it('should not change the initial startTime', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
       const initialStartTime = span.startTime;
       span.start();
@@ -139,7 +139,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
       span.end();
 
@@ -155,7 +155,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.end();
 
       assert.ok(!span.ended);
@@ -169,7 +169,7 @@ describe('Span', () => {
     it('should not change the endTime', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
       span.end();
       const initialEndTime = span.endTime;
@@ -187,7 +187,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       ['String', 'Number', 'Boolean'].map(attType => {
@@ -201,7 +201,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
       for (let i = 0; i < 40; i++) {
         span.addAttribute('attr' + i, 100);
@@ -226,7 +226,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       span.addAnnotation('description test', {} as Attributes, Date.now());
@@ -240,7 +240,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
       for (let i = 0; i < 40; i++) {
         span.addAnnotation('description test', {} as Attributes, Date.now());
@@ -264,7 +264,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       span.addLink(
@@ -278,7 +278,7 @@ describe('Span', () => {
     it('should drop extra links', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       for (let i = 0; i < 35; i++) {
@@ -304,7 +304,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       span.addMessageEvent(
@@ -328,7 +328,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
       for (let i = 0; i < 35; i++) {
         span.addMessageEvent(types.MessageEventType.UNSPECIFIED, 1);
@@ -344,7 +344,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
 
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
 
       assert.equal(rootSpan.status.code, 0);
@@ -356,7 +356,7 @@ describe('Span', () => {
     it('should set an error status', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      const span = new Span(rootSpan);
+      const span = new Span(tracer, rootSpan);
       span.start();
       span.setStatus(types.CanonicalCode.PERMISSION_DENIED, 'This is an error');
 

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -41,7 +41,7 @@ describe('Span', () => {
   /**
    * Should create a span
    */
-  describe('new Span(tracer, )', () => {
+  describe('new Span()', () => {
     it('should create a Span instance', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       const span = new Span(tracer, rootSpan);

--- a/packages/opencensus-exporter-instana/src/instana.ts
+++ b/packages/opencensus-exporter-instana/src/instana.ts
@@ -60,10 +60,10 @@ export class InstanaTraceExporter implements Exporter {
     this.exporterBuffer = new ExporterBuffer(this, options);
   }
 
-  onStartSpan(root: Span) {}
+  onStartSpan(span: Span) {}
 
-  onEndSpan(root: Span) {
-    this.exporterBuffer.addToBuffer(root);
+  onEndSpan(span: Span) {
+    this.exporterBuffer.addToBuffer(span);
   }
 
   /**

--- a/packages/opencensus-exporter-jaeger/src/jaeger.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger.ts
@@ -98,24 +98,24 @@ export class JaegerTraceExporter implements Exporter {
 
   /**
    * Is called whenever a span is ended.
-   * @param root the ended span
+   * @param span the ended span
    */
-  onEndSpan(root: Span) {
+  onEndSpan(span: Span) {
     // Add spans of a trace together when root is ended, skip non root spans.
-    if (root.constructor.name !== 'RootSpan') {
+    if (span.constructor.name !== 'RootSpan') {
       return;
     }
 
-    this.logger.debug('onEndSpan: adding rootSpan: %s', root.name);
+    this.logger.debug('onEndSpan: adding rootSpan: %s', span.name);
 
     // UDPSender buffer is limited by maxPacketSize
-    this.addSpanToSenderBuffer(root)
+    this.addSpanToSenderBuffer(span)
         .then(result => {
-          this.addToBuffer(root, result as number);
-          for (const span of root.spans) {
-            this.addSpanToSenderBuffer(span)
+          this.addToBuffer(span, result as number);
+          for (const localSpan of span.spans) {
+            this.addSpanToSenderBuffer(localSpan)
                 .then(result => {
-                  this.addToBuffer(span, result as number);
+                  this.addToBuffer(localSpan, result as number);
                 })
                 .catch(err => {
                   return;

--- a/packages/opencensus-exporter-jaeger/src/jaeger.ts
+++ b/packages/opencensus-exporter-jaeger/src/jaeger.ts
@@ -101,6 +101,11 @@ export class JaegerTraceExporter implements Exporter {
    * @param root the ended span
    */
   onEndSpan(root: Span) {
+    // Add spans of a trace together when root is ended, skip non root spans.
+    if (root.constructor.name !== 'RootSpan') {
+      return;
+    }
+
     this.logger.debug('onEndSpan: adding rootSpan: %s', root.name);
 
     // UDPSender buffer is limited by maxPacketSize

--- a/packages/opencensus-exporter-ocagent/src/ocagent.ts
+++ b/packages/opencensus-exporter-ocagent/src/ocagent.ts
@@ -204,10 +204,15 @@ export class OCAgentExporter implements Exporter {
     }
   }
 
-  onStartSpan(root: Span) {}
+  onStartSpan(span: Span) {}
 
-  onEndSpan(root: Span) {
-    this.buffer.addToBuffer(root);
+  onEndSpan(span: Span) {
+    // Add spans of a trace together when root is ended, skip non root spans.
+    // adaptRootSpan() will extract child spans from root.
+    if (span.constructor.name !== 'RootSpan') {
+      return;
+    }
+    this.buffer.addToBuffer(span);
   }
 
   publish(rootSpans: Span[]): Promise<number|string|void> {

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
@@ -43,14 +43,14 @@ export class StackdriverTraceExporter implements Exporter {
 
   /**
    * Is called whenever a span is ended.
-   * @param root the ended span
+   * @param span the ended span
    */
-  onEndSpan(root: OCSpan) {
-    this.exporterBuffer.addToBuffer(root);
+  onEndSpan(span: OCSpan) {
+    this.exporterBuffer.addToBuffer(span);
   }
 
   /** Not used for this exporter */
-  onStartSpan(root: OCSpan) {}
+  onStartSpan(span: OCSpan) {}
 
   /**
    * Publishes a list of root spans to Stackdriver.

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace.ts
@@ -61,13 +61,15 @@ describe('Stackdriver Trace Exporter', function() {
         span.end();
         rootSpan.end();
 
-        assert.strictEqual(exporter.exporterBuffer.getQueue().length, 1);
+        assert.strictEqual(exporter.exporterBuffer.getQueue().length, 2);
         assert.strictEqual(
-            exporter.exporterBuffer.getQueue()[0].name, rootSpanOptions.name);
+            exporter.exporterBuffer.getQueue()[0].name, spanName);
         assert.strictEqual(
-            exporter.exporterBuffer.getQueue()[0].spans.length, 1);
+            exporter.exporterBuffer.getQueue()[1].name, rootSpanOptions.name);
         assert.strictEqual(
-            exporter.exporterBuffer.getQueue()[0].spans[0].name, spanName);
+            exporter.exporterBuffer.getQueue()[1].spans.length, 1);
+        assert.strictEqual(
+            exporter.exporterBuffer.getQueue()[1].spans[0].name, spanName);
       });
     });
   });

--- a/packages/opencensus-exporter-zipkin/src/zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/src/zipkin.ts
@@ -73,14 +73,14 @@ export class ZipkinTraceExporter implements Exporter {
 
   /**
    * Is called whenever a span is ended.
-   * @param root the ended span
+   * @param span the ended span
    */
-  onEndSpan(root: Span) {
-    this.buffer.addToBuffer(root);
+  onEndSpan(span: Span) {
+    this.buffer.addToBuffer(span);
   }
 
   /** Not used for this exporter */
-  onStartSpan(root: Span) {}
+  onStartSpan(span: Span) {}
 
   /**
    * Send a trace to zipkin service
@@ -155,7 +155,7 @@ export class ZipkinTraceExporter implements Exporter {
    * @param span Span to be translated
    */
   translateSpan(span: Span): TranslatedSpan {
-    const spanTraslated = {
+    const spanTranslated = {
       traceId: span.traceId,
       name: span.name,
       id: span.id,
@@ -165,16 +165,16 @@ export class ZipkinTraceExporter implements Exporter {
       timestamp: span.startTime.getTime() * MICROS_PER_MILLI,
       duration: Math.round(span.duration * MICROS_PER_MILLI),
       debug: true,
-      shared: true,
+      shared: !span.parentSpanId,
       localEndpoint: {serviceName: this.serviceName},
       tags: this.createTags(span.attributes, span.status),
       annotations: this.createAnnotations(span.annotations, span.messageEvents)
     } as TranslatedSpan;
 
     if (span.parentSpanId) {
-      spanTraslated.parentId = span.parentSpanId;
+      spanTranslated.parentId = span.parentSpanId;
     }
-    return spanTraslated;
+    return spanTranslated;
   }
 
   /** Converts OpenCensus Attributes and Status to Zipkin Tags format. */

--- a/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
@@ -155,7 +155,7 @@ describe('Zipkin Exporter', function() {
           'localEndpoint': {'serviceName': 'opencensus-tests'},
           'name': 'spanTest',
           'parentId': rootSpan.id,
-          'shared': true,
+          'shared': false,
           'tags': {
             'census.status_code': '8',
             'census.status_description': 'RESOURCE_EXHAUSTED',

--- a/packages/opencensus-exporter-zpages/src/zpages.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages.ts
@@ -77,18 +77,18 @@ export class ZpagesExporter implements Exporter, StatsEventListener {
 
   /**
    * Called whenever a span is started.
-   * @param root the started span
+   * @param span the started span
    */
-  onStartSpan(root: Span) {
-    this.sendTrace(root);
+  onStartSpan(span: Span) {
+    this.sendTrace(span);
   }
 
   /**
    * Called whenever a span is ended.
-   * @param root the ended span
+   * @param span the ended span
    */
-  onEndSpan(root: Span) {
-    this.sendTrace(root);
+  onEndSpan(span: Span) {
+    this.sendTrace(span);
   }
 
   /**

--- a/packages/opencensus-instrumentation-grpc/test/test-grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/test/test-grpc.ts
@@ -254,8 +254,12 @@ class RootSpanVerifier implements SpanEventListener {
   endedRootSpans: Span[] = [];
 
   onStartSpan(span: Span): void {}
-  onEndSpan(root: Span) {
-    this.endedRootSpans.push(root);
+  onEndSpan(span: Span) {
+    // TODO(hekike): Tests depends on the order of recorded spans.
+    // Capturing child spand breaks this order.
+    if (span.constructor.name === 'RootSpan') {
+      this.endedRootSpans.push(span);
+    }
   }
 }
 

--- a/packages/opencensus-instrumentation-grpc/test/test-grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/test/test-grpc.ts
@@ -256,7 +256,8 @@ class RootSpanVerifier implements SpanEventListener {
   onStartSpan(span: Span): void {}
   onEndSpan(span: Span) {
     // TODO(hekike): Tests depends on the order of recorded spans.
-    // Capturing child spand breaks this order.
+    // Capturing child spans breaks this order.
+    // https://github.com/census-instrumentation/opencensus-node/issues/501
     if (span.constructor.name === 'RootSpan') {
       this.endedRootSpans.push(span);
     }

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -320,7 +320,7 @@ describe('HttpPlugin', () => {
         // 5 child spans ended
         assert.strictEqual(spanVerifier.endedSpans.length, 5);
         root.end();
-        // 5 child spand + root span ended
+        // 5 child spans + root span ended
         assert.strictEqual(spanVerifier.endedSpans.length, 6);
       });
     });

--- a/packages/opencensus-instrumentation-https/test/test-https.ts
+++ b/packages/opencensus-instrumentation-https/test/test-https.ts
@@ -252,7 +252,7 @@ describe('HttpsPlugin', () => {
             // 5 child spans ended
             assert.strictEqual(spanVerifier.endedSpans.length, 5);
             root.end();
-            // 5 child spand + root span ended
+            // 5 child spans + root span ended
             assert.strictEqual(spanVerifier.endedSpans.length, 6);
           });
         });

--- a/packages/opencensus-instrumentation-https/test/test-https.ts
+++ b/packages/opencensus-instrumentation-https/test/test-https.ts
@@ -63,12 +63,12 @@ const httpRequest = {
 
 const VERSION = process.versions.node;
 
-class RootSpanVerifier implements SpanEventListener {
-  endedRootSpans: Span[] = [];
+class SpanVerifier implements SpanEventListener {
+  endedSpans: Span[] = [];
 
   onStartSpan(span: Span): void {}
-  onEndSpan(root: Span) {
-    this.endedRootSpans.push(root);
+  onEndSpan(span: Span) {
+    this.endedSpans.push(span);
   }
 }
 
@@ -105,7 +105,7 @@ describe('HttpsPlugin', () => {
   let server: https.Server;
   const log = logger.logger();
   const tracer = new CoreTracer();
-  const rootSpanVerifier = new RootSpanVerifier();
+  const spanVerifier = new SpanVerifier();
   tracer.start({samplingRate: 1, logger: log});
 
   it('should return a plugin', () => {
@@ -126,7 +126,7 @@ describe('HttpsPlugin', () => {
           ]
         },
         '');
-    tracer.registerSpanEventListener(rootSpanVerifier);
+    tracer.registerSpanEventListener(spanVerifier);
     server = https.createServer(httpsOptions, (request, response) => {
       response.end('Test Server Response');
     });
@@ -141,7 +141,7 @@ describe('HttpsPlugin', () => {
   });
 
   beforeEach(() => {
-    rootSpanVerifier.endedRootSpans = [];
+    spanVerifier.endedSpans = [];
     nock.cleanAll();
   });
 
@@ -159,15 +159,14 @@ describe('HttpsPlugin', () => {
            async () => {
              const testPath = '/outgoing/rootSpan/1';
              doNock(urlHost, testPath, 200, 'Ok');
-             assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+             assert.strictEqual(spanVerifier.endedSpans.length, 0);
              await requestMethod(`${urlHost}${testPath}`).then((result) => {
                assert.strictEqual(result, 'Ok');
                assert.ok(
-                   rootSpanVerifier.endedRootSpans[0].name.indexOf(testPath) >=
-                   0);
-               assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
+                   spanVerifier.endedSpans[0].name.indexOf(testPath) >= 0);
+               assert.strictEqual(spanVerifier.endedSpans.length, 1);
 
-               const span = rootSpanVerifier.endedRootSpans[0];
+               const span = spanVerifier.endedSpans[0];
                assertSpanAttributes(span, 200, 'GET', hostName, testPath);
              });
            });
@@ -182,14 +181,13 @@ describe('HttpsPlugin', () => {
                doNock(
                    urlHost, testPath, httpErrorCodes[i],
                    httpErrorCodes[i].toString());
-               assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+               assert.strictEqual(spanVerifier.endedSpans.length, 0);
                await requestMethod(`${urlHost}${testPath}`).then((result) => {
                  assert.strictEqual(result, httpErrorCodes[i].toString());
                  assert.ok(
-                     rootSpanVerifier.endedRootSpans[0].name.indexOf(
-                         testPath) >= 0);
-                 assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
-                 const span = rootSpanVerifier.endedRootSpans[0];
+                     spanVerifier.endedSpans[0].name.indexOf(testPath) >= 0);
+                 assert.strictEqual(spanVerifier.endedSpans.length, 1);
+                 const span = spanVerifier.endedSpans[0];
                  assertSpanAttributes(
                      span, httpErrorCodes[i], 'GET', hostName, testPath);
                });
@@ -251,9 +249,11 @@ describe('HttpsPlugin', () => {
                 assert.strictEqual(root.traceId, root.spans[i].traceId);
               });
             }
-            assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+            // 5 child spans ended
+            assert.strictEqual(spanVerifier.endedSpans.length, 5);
             root.end();
-            assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
+            // 5 child spand + root span ended
+            assert.strictEqual(spanVerifier.endedSpans.length, 6);
           });
         });
 
@@ -268,10 +268,10 @@ describe('HttpsPlugin', () => {
                headers: {'x-opencensus-outgoing-request': 1}
              };
 
-             assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+             assert.strictEqual(spanVerifier.endedSpans.length, 0);
              await requestMethod(options).then((result) => {
                assert.equal(result, 'Ok');
-               assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+               assert.strictEqual(spanVerifier.endedSpans.length, 0);
              });
            });
 
@@ -286,9 +286,9 @@ describe('HttpsPlugin', () => {
                  path: testPath,
                };
 
-               assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+               assert.strictEqual(spanVerifier.endedSpans.length, 0);
                await httpRequest.get(options);
-               assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+               assert.strictEqual(spanVerifier.endedSpans.length, 0);
              });
         }
       });
@@ -309,13 +309,12 @@ describe('HttpsPlugin', () => {
       };
       nock.enableNetConnect();
 
-      assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+      assert.strictEqual(spanVerifier.endedSpans.length, 0);
 
       await httpRequest.request(options).then((result) => {
-        assert.ok(
-            rootSpanVerifier.endedRootSpans[0].name.indexOf(testPath) >= 0);
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 2);
-        const span = rootSpanVerifier.endedRootSpans[0];
+        assert.ok(spanVerifier.endedSpans[0].name.indexOf(testPath) >= 0);
+        assert.strictEqual(spanVerifier.endedSpans.length, 2);
+        const span = spanVerifier.endedSpans[0];
         assertSpanAttributes(
             span, 200, 'GET', 'localhost', testPath, 'Android');
       });
@@ -335,9 +334,9 @@ describe('HttpsPlugin', () => {
         shimmer.unwrap(https, 'request');
         nock.enableNetConnect();
 
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+        assert.strictEqual(spanVerifier.endedSpans.length, 0);
         await httpRequest.get(options);
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+        assert.strictEqual(spanVerifier.endedSpans.length, 0);
       });
     }
   });
@@ -350,9 +349,9 @@ describe('HttpsPlugin', () => {
 
       const options = {host: 'localhost', path: testPath, port: serverPort};
 
-      assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+      assert.strictEqual(spanVerifier.endedSpans.length, 0);
       await httpRequest.request(options).then((result) => {
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+        assert.strictEqual(spanVerifier.endedSpans.length, 0);
       });
     });
   });

--- a/packages/opencensus-instrumentation-ioredis/test/test-ioredis.ts
+++ b/packages/opencensus-instrumentation-ioredis/test/test-ioredis.ts
@@ -27,8 +27,11 @@ class RootSpanVerifier implements SpanEventListener {
   onStartSpan(span: Span): void {
     return;
   }
-  onEndSpan(root: Span) {
-    this.endedRootSpans.push(root);
+  onEndSpan(span: Span) {
+    if (span.parentSpanId) {
+      return;
+    }
+    this.endedRootSpans.push(span);
   }
 }
 

--- a/packages/opencensus-instrumentation-mongodb/test/test-mongodb.ts
+++ b/packages/opencensus-instrumentation-mongodb/test/test-mongodb.ts
@@ -29,8 +29,10 @@ class RootSpanVerifier implements SpanEventListener {
   endedRootSpans: Span[] = [];
 
   onStartSpan(span: Span): void {}
-  onEndSpan(root: Span) {
-    this.endedRootSpans.push(root);
+  onEndSpan(span: Span) {
+    if (span.constructor.name === 'RootSpan') {
+      this.endedRootSpans.push(span);
+    }
   }
 }
 

--- a/packages/opencensus-instrumentation-mongodb/test/test-mongodb.ts
+++ b/packages/opencensus-instrumentation-mongodb/test/test-mongodb.ts
@@ -25,14 +25,12 @@ export type MongoDBAccess = {
 };
 
 /** Collects ended root spans to allow for later analysis. */
-class RootSpanVerifier implements SpanEventListener {
-  endedRootSpans: Span[] = [];
+class SpanVerifier implements SpanEventListener {
+  endedSpans: Span[] = [];
 
   onStartSpan(span: Span): void {}
   onEndSpan(span: Span) {
-    if (span.constructor.name === 'RootSpan') {
-      this.endedRootSpans.push(span);
-    }
+    this.endedSpans.push(span);
   }
 }
 
@@ -65,20 +63,20 @@ function accessCollection(url: string, dbName: string, collectionName: string):
  * @param expectedKind The expected kind of the first root span.
  */
 function assertSpan(
-    rootSpanVerifier: RootSpanVerifier, expectedName: string,
+    rootSpanVerifier: SpanVerifier, expectedName: string,
     expectedKind: SpanKind) {
-  assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
-  assert.strictEqual(rootSpanVerifier.endedRootSpans[0].spans.length, 1);
+  assert.strictEqual(rootSpanVerifier.endedSpans.length, 2);
+  assert.strictEqual(rootSpanVerifier.endedSpans[1].spans.length, 1);
   // we are forced to ignore the error because 'truncated' is a private
   // field but needed to verify that the span are correctly ended.
   // @ts-ignore
-  const isTruncated = rootSpanVerifier.endedRootSpans[0].spans[0].truncated;
+  const isTruncated = rootSpanVerifier.endedSpans[1].spans[0].truncated;
   assert.strictEqual(
       isTruncated, false, 'the span should not have been truncated');
   assert.strictEqual(
-      rootSpanVerifier.endedRootSpans[0].spans[0].name, expectedName);
+      rootSpanVerifier.endedSpans[1].spans[0].name, expectedName);
   assert.strictEqual(
-      rootSpanVerifier.endedRootSpans[0].spans[0].kind, expectedKind);
+      rootSpanVerifier.endedSpans[1].spans[0].kind, expectedKind);
 }
 
 describe('MongoDBPlugin', () => {
@@ -98,7 +96,7 @@ describe('MongoDBPlugin', () => {
   const VERSION = process.versions.node;
 
   const tracer = new CoreTracer();
-  const rootSpanVerifier = new RootSpanVerifier();
+  const rootSpanVerifier = new SpanVerifier();
   let client: mongodb.MongoClient;
   let collection: mongodb.Collection;
 
@@ -127,7 +125,7 @@ describe('MongoDBPlugin', () => {
     if (!shouldTest) {
       this.skip();
     }
-    rootSpanVerifier.endedRootSpans = [];
+    rootSpanVerifier.endedSpans = [];
     // Non traced insertion of basic data to perform tests
     const insertData = [{a: 1}, {a: 2}, {a: 3}];
     collection.insertMany(insertData, (err, result) => {
@@ -152,7 +150,7 @@ describe('MongoDBPlugin', () => {
 
       tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         collection.insertMany(insertData, (err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
           rootSpan.end();
           assert.ifError(err);
           assertSpan(
@@ -166,7 +164,7 @@ describe('MongoDBPlugin', () => {
     it('should create a child span for update', (done) => {
       tracer.startRootSpan({name: 'updateRootSpan'}, (rootSpan: Span) => {
         collection.updateOne({a: 2}, {$set: {b: 1}}, (err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
           rootSpan.end();
           assert.ifError(err);
           assertSpan(
@@ -180,7 +178,7 @@ describe('MongoDBPlugin', () => {
     it('should create a child span for remove', (done) => {
       tracer.startRootSpan({name: 'removeRootSpan'}, (rootSpan: Span) => {
         collection.deleteOne({a: 3}, (err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
           rootSpan.end();
           assert.ifError(err);
           assertSpan(
@@ -197,7 +195,7 @@ describe('MongoDBPlugin', () => {
     it('should create a child span for find', (done) => {
       tracer.startRootSpan({name: 'findRootSpan'}, (rootSpan: Span) => {
         collection.find({}).toArray((err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
           rootSpan.end();
           assert.ifError(err);
           assertSpan(
@@ -214,7 +212,7 @@ describe('MongoDBPlugin', () => {
     it('should create a child span for create index', (done) => {
       tracer.startRootSpan({name: 'indexRootSpan'}, (rootSpan: Span) => {
         collection.createIndex({a: 1}, (err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
           rootSpan.end();
           assert.ifError(err);
           assertSpan(
@@ -228,7 +226,7 @@ describe('MongoDBPlugin', () => {
     it('should create a child span for count', (done) => {
       tracer.startRootSpan({name: 'countRootSpan'}, (rootSpan: Span) => {
         collection.count({a: 1}, (err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
           rootSpan.end();
           assert.ifError(err);
           assertSpan(
@@ -250,12 +248,11 @@ describe('MongoDBPlugin', () => {
 
       tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         collection.insertMany(insertData, (err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 0);
           rootSpan.end();
           assert.ifError(err);
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
-          assert.strictEqual(
-              rootSpanVerifier.endedRootSpans[0].spans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
+          assert.strictEqual(rootSpanVerifier.endedSpans[0].spans.length, 0);
           done();
         });
       });
@@ -264,12 +261,11 @@ describe('MongoDBPlugin', () => {
     it('should not create a child span for cursor', (done) => {
       tracer.startRootSpan({name: 'findRootSpan'}, (rootSpan: Span) => {
         collection.find({}).toArray((err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 0);
           rootSpan.end();
           assert.ifError(err);
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
-          assert.strictEqual(
-              rootSpanVerifier.endedRootSpans[0].spans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
+          assert.strictEqual(rootSpanVerifier.endedSpans[0].spans.length, 0);
           done();
         });
       });
@@ -278,12 +274,11 @@ describe('MongoDBPlugin', () => {
     it('should not create a child span for command', (done) => {
       tracer.startRootSpan({name: 'indexRootSpan'}, (rootSpan: Span) => {
         collection.createIndex({a: 1}, (err, result) => {
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 0);
           rootSpan.end();
           assert.ifError(err);
-          assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
-          assert.strictEqual(
-              rootSpanVerifier.endedRootSpans[0].spans.length, 0);
+          assert.strictEqual(rootSpanVerifier.endedSpans.length, 1);
+          assert.strictEqual(rootSpanVerifier.endedSpans[0].spans.length, 0);
           done();
         });
       });


### PR DESCRIPTION
Today Tracer only reports root spans to exporters.
After this change every span will be reported to exporters, letting exporters filter on what they want to handle.
*Today some exporters (`opencensus-exporter-jaeger`) walk through `rootSpan.spans`, while others (`opencensus-exporter-ocagent`) use `adaptRootSpan()` to flatten spans, while other exporters completely skip child spans.*

This PR doesn't change Jaeger and ocagent exporters behaviour.

Changes:

- report all spans to exporters
- filter to RootSpan only in `opencensus-exporter-jaeger` to match the previous behaviour
- filter to RootSpan only in `opencensus-exporter-ocagent` to match the previous behaviour
- fix Zipkin reporting `shared` property for child spans
- upgrade handlebar to avoid security vulnerability (unrelated change, to pass PR checks)

I learned yesterday from @bogdandrutu that Java reports all the spans to exporters.