### PR TITLE
fix(exporter-zpages): zpages template scope

### DIFF
--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
@@ -242,9 +242,8 @@ export class TracezPageHandler {
       const renderedSummary =
           ejs.render(summaryFile, {latencyBucketNames}, options);
       /** HTML selected trace list */
-      const renderedSelectedTraces: string = selectedTraces ?
-          ejs.render(spansFile, selectedTraces, options) :
-          '';
+      const renderedSelectedTraces: string =
+          selectedTraces ? ejs.render(spansFile, selectedTraces, options) : '';
       /** RootSpan lines */
       const renderedSpanCells: string =
           spanCells.map(spanCell => ejs.render(spanCellFile, spanCell, options))

--- a/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
+++ b/packages/opencensus-exporter-zpages/src/zpages-frontend/page-handlers/tracez.page-handler.ts
@@ -243,7 +243,7 @@ export class TracezPageHandler {
           ejs.render(summaryFile, {latencyBucketNames}, options);
       /** HTML selected trace list */
       const renderedSelectedTraces: string = selectedTraces ?
-          ejs.render(spansFile, {selectedTraces}, options) :
+          ejs.render(spansFile, selectedTraces, options) :
           '';
       /** RootSpan lines */
       const renderedSpanCells: string =


### PR DESCRIPTION
The template expects the span properties to be in the "global" scope.
(postmortem idea: we should start to consider testing on template outputs)