### PR TITLE
feat(core): support object type attribute on spans

### DIFF
--- a/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
@@ -149,7 +149,7 @@ export class NoRecordSpan implements types.Span {
   }
 
   /** No-op implementation of this method. */
-  addAttribute(key: string, value: string|number|boolean|string) {}
+  addAttribute(key: string, value: string|number|boolean|object) {}
 
   /** No-op implementation of this method. */
   addAnnotation(

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
@@ -149,7 +149,7 @@ export class NoRecordSpan implements types.Span {
   }
 
   /** No-op implementation of this method. */
-  addAttribute(key: string, value: string|number|boolean) {}
+  addAttribute(key: string, value: string|number|boolean|string) {}
 
   /** No-op implementation of this method. */
   addAnnotation(

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -195,7 +195,7 @@ export class Span implements types.Span {
    * @param key Describes the value added.
    * @param value The result of an operation.
    */
-  addAttribute(key: string, value: string|number|boolean) {
+  addAttribute(key: string, value: string|number|boolean|object) {
     if (this.attributes[key]) {
       delete this.attributes[key];
     }
@@ -208,7 +208,9 @@ export class Span implements types.Span {
         delete this.attributes[attributeKeyToDelete];
       }
     }
-    this.attributes[key] = value;
+    const serializedValue =
+        typeof value === 'object' ? JSON.stringify(value) : value;
+    this.attributes[key] = serializedValue;
   }
 
   /**

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -194,7 +194,7 @@ export class Span implements types.Span {
    * Adds an atribute to the span.
    * @param key Describes the value added.
    * @param value The result of an operation. If the value is a typeof object
-   * it has to be JSON.stringify-able, cannot contain circular dependencies.
+   *     it has to be JSON.stringify-able, cannot contain circular dependencies.
    */
   addAttribute(key: string, value: string|number|boolean|object) {
     if (this.attributes[key]) {

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -193,7 +193,8 @@ export class Span implements types.Span {
   /**
    * Adds an atribute to the span.
    * @param key Describes the value added.
-   * @param value The result of an operation.
+   * @param value The result of an operation. If the value is a typeof object
+   * it has to be JSON.stringify-able, cannot contain circular dependencies.
    */
   addAttribute(key: string, value: string|number|boolean|object) {
     if (this.attributes[key]) {

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -406,7 +406,7 @@ export interface Span {
    * @param key Describes the value added.
    * @param value The result of an operation.
    */
-  addAttribute(key: string, value: string|number|boolean): void;
+  addAttribute(key: string, value: string|number|boolean|object): void;
 
   /**
    * Adds an annotation to the span.

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -195,6 +195,10 @@ describe('Span', () => {
         assert.equal(
             span.attributes['testKey' + attType], 'testValue' + attType);
       });
+      span.addAttribute('object', {foo: 'bar'});
+      assert.equal(span.attributes['object'], '{"foo":"bar"}');
+      span.addAttribute('array', [1, 2, 3]);
+      assert.equal(span.attributes['array'], '[1,2,3]');
     });
 
     it('should drop extra attributes', () => {


### PR DESCRIPTION
It is expensive to add object type values to the span now because the user needs to serialize them even if the sampling decision is none. After this change, the `NoRecordSpan` would handle it in a zero cost way.