### PR TITLE
[PROPOSAL] feat(tracer): separate cls out of tracer

### DIFF
--- a/packages/opencensus-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-core/src/trace/model/tracer-base.ts
@@ -105,10 +105,9 @@ export class CoreTracerBase implements types.TracerBase {
   /**
    * Starts a root span.
    * @param options A TraceOptions object to start a root span.
-   * @param fn A callback function to run after starting a root span.
+   * @returns {Span} A new root span.
    */
-  startRootSpan<T>(options: types.TraceOptions, fn: (root: types.Span) => T):
-      T {
+  startRootSpan(options: types.TraceOptions): types.Span {
     const spanContext: types.SpanContext = options.spanContext ||
         {spanId: '', traceId: uuid.v4().split('-').join('')};
     const parentSpanId = spanContext.spanId;
@@ -125,21 +124,21 @@ export class CoreTracerBase implements types.TracerBase {
         const rootSpan =
             new RootSpan(this, name, kind, traceId, parentSpanId, traceState);
         rootSpan.start();
-        return fn(rootSpan);
+        return rootSpan;
       }
 
       // Sampling is off
       this.logger.debug('Sampling is off, starting new no record root span');
       const noRecordRootSpan = new NoRecordRootSpan(
           this, name, kind, traceId, parentSpanId, traceState);
-      return fn(noRecordRootSpan);
+      return noRecordRootSpan;
     }
 
     // Tracer is inactive
     this.logger.debug('Tracer is inactive, starting new no record root span');
     const noRecordRootSpan = new NoRecordRootSpan(
         this, name, kind, traceId, parentSpanId, traceState);
-    return fn(noRecordRootSpan);
+    return noRecordRootSpan;
   }
 
   /** Notifies listeners of the span start. */

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -497,9 +497,17 @@ export interface TracerBase extends SpanEventListener {
    * Start a new RootSpan to currentRootSpan
    * @param options Options for tracer instance
    * @param fn Callback function
-   * @returns The callback return
+   * @returns {Span} A root span
    */
-  startRootSpan<T>(options: TraceOptions, fn: (root: Span) => T): T;
+  startRootSpan(options: TraceOptions): Span;
+
+  /**
+   * Start a new Span instance to the currentRootSpan
+   * @param childOf Span
+   * @param [options] A TraceOptions object to start a root span.
+   * @returns The new Span instance started
+   */
+  startChildSpan(options?: SpanOptions): Span;
 
   /**
    * Register a OnEndSpanEventListener on the tracer instance
@@ -512,14 +520,6 @@ export interface TracerBase extends SpanEventListener {
    * @param listener The listener to unregister.
    */
   unregisterSpanEventListener(listener: SpanEventListener): void;
-
-  /**
-   * Start a new Span instance to the currentRootSpan
-   * @param childOf Span
-   * @param [options] A TraceOptions object to start a root span.
-   * @returns The new Span instance started
-   */
-  startChildSpan(options?: SpanOptions): Span;
 }
 
 /** Interface for Tracer */
@@ -529,6 +529,20 @@ export interface Tracer extends TracerBase {
 
   /** Clear the currentRootSpan from tracer instance */
   clearCurrentTrace(): void;
+
+  /**
+   * Sets span to CLS
+   * @param span Span to setup in context.
+   * @param fn A callback function that runs after context setup.
+   */
+  withSpan<T>(span: Span, fn: () => T): T;
+
+  /**
+   * Starts a root span and sets it to context.
+   * @param options Options for tracer instance
+   * @param fn A callback function to run after starting a root span.
+   */
+  startWithRootSpan<T>(options: TraceOptions, fn: (root: Span) => T): T;
 
   /**
    * Binds the trace context to the given function.

--- a/packages/opencensus-core/src/trace/types.ts
+++ b/packages/opencensus-core/src/trace/types.ts
@@ -19,7 +19,7 @@ import * as configTypes from './config/types';
 import * as modelTypes from './model/types';
 
 /** Main interface for tracing. */
-export interface Tracing {
+export interface TracingBase {
   /** Object responsible for managing a trace. */
   readonly tracer: modelTypes.TracerBase;
 
@@ -51,4 +51,10 @@ export interface Tracing {
    * @param exporter The exporter to stop sending traces to.
    */
   unregisterExporter(exporter: exportersTypes.Exporter): Tracing;
+}
+
+/** Main interface for tracing. */
+export interface Tracing extends TracingBase {
+  /** Object responsible for managing a trace. */
+  readonly tracer: modelTypes.Tracer;
 }

--- a/packages/opencensus-core/test/test-tracer-base.ts
+++ b/packages/opencensus-core/test/test-tracer-base.ts
@@ -127,9 +127,7 @@ describe('Tracer Base', () => {
     before(() => {
       const tracer = new CoreTracerBase();
       tracer.start(defaultConfig);
-      tracer.startRootSpan(options, (rootSpan) => {
-        rootSpanLocal = rootSpan;
-      });
+      rootSpanLocal = tracer.startRootSpan(options);
     });
     it('should create a new RootSpan instance', () => {
       assert.ok(rootSpanLocal instanceof Span);
@@ -145,17 +143,15 @@ describe('Tracer Base', () => {
 
     it('should start the new NoRecordRootSpan instance', () => {
       tracer.start(config);
-      tracer.startRootSpan(options, (rootSpan) => {
-        assert.ok(rootSpan instanceof NoRecordRootSpan);
-      });
+      const rootSpan = tracer.startRootSpan(options);
+      assert.ok(rootSpan instanceof NoRecordRootSpan);
     });
 
     it('should start the new RootSpan instance when always sampling provided at span level',
        () => {
          tracer.start(config);
-         tracer.startRootSpan({name: 'test', samplingRate: 1}, (rootSpan) => {
-           assert.ok(rootSpan);
-         });
+         const rootSpan = tracer.startRootSpan({name: 'test', samplingRate: 1});
+         assert.ok(rootSpan);
        });
   });
 
@@ -165,17 +161,15 @@ describe('Tracer Base', () => {
 
     it('should start the new RootSpan instance', () => {
       tracer.start(config);
-      tracer.startRootSpan(options, (rootSpan) => {
-        assert.ok(rootSpan);
-      });
+      const rootSpan = tracer.startRootSpan(options);
+      assert.ok(rootSpan);
     });
 
     it('should start the new NoRecordRootSpan instance when never sampling provided at span level',
        () => {
          tracer.start(config);
-         tracer.startRootSpan({name: 'test', samplingRate: 0}, (rootSpan) => {
-           assert.ok(rootSpan instanceof NoRecordRootSpan);
-         });
+         const rootSpan = tracer.startRootSpan({name: 'test', samplingRate: 0});
+         assert.ok(rootSpan instanceof NoRecordRootSpan);
        });
   });
 
@@ -184,9 +178,8 @@ describe('Tracer Base', () => {
        () => {
          const tracer = new CoreTracerBase();
          assert.strictEqual(tracer.active, false);
-         tracer.startRootSpan(options, (rootSpan) => {
-           assert.ok(rootSpan instanceof NoRecordRootSpan);
-         });
+         const rootSpan = tracer.startRootSpan(options);
+         assert.ok(rootSpan instanceof NoRecordRootSpan);
        });
   });
 
@@ -197,11 +190,10 @@ describe('Tracer Base', () => {
     it('should create new RootSpan instance, no propagation', () => {
       const tracer = new CoreTracerBase();
       tracer.start(defaultConfig);
-      tracer.startRootSpan(traceOptions, (rootSpan) => {
-        assert.ok(rootSpan);
-        assert.strictEqual(rootSpan.name, traceOptions.name);
-        assert.strictEqual(rootSpan.kind, traceOptions.kind);
-      });
+      const rootSpan = tracer.startRootSpan(traceOptions);
+      assert.ok(rootSpan);
+      assert.strictEqual(rootSpan.name, traceOptions.name);
+      assert.strictEqual(rootSpan.kind, traceOptions.kind);
     });
 
     const spanContextPropagated = {
@@ -215,13 +207,12 @@ describe('Tracer Base', () => {
       const tracer = new CoreTracerBase();
       tracer.start(defaultConfig);
       traceOptions.spanContext = spanContextPropagated;
-      tracer.startRootSpan(traceOptions, (rootSpan) => {
-        assert.ok(rootSpan);
-        assert.strictEqual(rootSpan.name, traceOptions.name);
-        assert.strictEqual(rootSpan.kind, traceOptions.kind);
-        assert.strictEqual(rootSpan.traceId, spanContextPropagated.traceId);
-        assert.strictEqual(rootSpan.parentSpanId, spanContextPropagated.spanId);
-      });
+      const rootSpan = tracer.startRootSpan(traceOptions);
+      assert.ok(rootSpan);
+      assert.strictEqual(rootSpan.name, traceOptions.name);
+      assert.strictEqual(rootSpan.kind, traceOptions.kind);
+      assert.strictEqual(rootSpan.traceId, spanContextPropagated.traceId);
+      assert.strictEqual(rootSpan.parentSpanId, spanContextPropagated.spanId);
     });
 
     it('should create the new RootSpan with no propagation (options bit is not set)',
@@ -229,14 +220,13 @@ describe('Tracer Base', () => {
          const tracer = new CoreTracerBase();
          tracer.start(defaultConfig);
          traceOptions.spanContext!.options = 0x0;
-         tracer.startRootSpan(traceOptions, (rootSpan) => {
-           assert.ok(rootSpan);
-           assert.strictEqual(rootSpan.name, traceOptions.name);
-           assert.strictEqual(rootSpan.kind, traceOptions.kind);
-           assert.strictEqual(rootSpan.traceId, spanContextPropagated.traceId);
-           assert.strictEqual(
-               rootSpan.parentSpanId, spanContextPropagated.spanId);
-         });
+         const rootSpan = tracer.startRootSpan(traceOptions);
+         assert.ok(rootSpan);
+         assert.strictEqual(rootSpan.name, traceOptions.name);
+         assert.strictEqual(rootSpan.kind, traceOptions.kind);
+         assert.strictEqual(rootSpan.traceId, spanContextPropagated.traceId);
+         assert.strictEqual(
+             rootSpan.parentSpanId, spanContextPropagated.spanId);
        });
 
     it('should create a tracer with default TraceParams when no parameters are specified upon initialisation',
@@ -280,10 +270,9 @@ describe('Tracer Base', () => {
     before(() => {
       tracer = new CoreTracerBase();
       tracer.start(defaultConfig);
-      tracer.startRootSpan(options, (rootSpan) => {
-        span = tracer.startChildSpan(
-            {name: 'spanName', kind: types.SpanKind.CLIENT, childOf: rootSpan});
-      });
+      const rootSpan = tracer.startRootSpan(options);
+      span = tracer.startChildSpan(
+          {name: 'spanName', kind: types.SpanKind.CLIENT, childOf: rootSpan});
     });
     it('should create a Span instance', () => {
       assert.ok(span instanceof Span);
@@ -295,72 +284,67 @@ describe('Tracer Base', () => {
     });
 
     it('should start a span with SpanObject', () => {
-      tracer.startRootSpan(options, (rootSpan) => {
-        const spanWithObject = tracer.startChildSpan(
-            {name: 'my-span', kind: types.SpanKind.SERVER, childOf: rootSpan});
-        assert.ok(spanWithObject.started);
-        assert.strictEqual(spanWithObject.name, 'my-span');
-        assert.strictEqual(spanWithObject.kind, types.SpanKind.SERVER);
-      });
+      const rootSpan = tracer.startRootSpan(options);
+      const spanWithObject = tracer.startChildSpan(
+          {name: 'my-span', kind: types.SpanKind.SERVER, childOf: rootSpan});
+      assert.ok(spanWithObject.started);
+      assert.strictEqual(spanWithObject.name, 'my-span');
+      assert.strictEqual(spanWithObject.kind, types.SpanKind.SERVER);
     });
 
     it('should start a span with SpanObject-name', () => {
-      tracer.startRootSpan(options, (rootSpan) => {
-        const spanWithObject =
-            tracer.startChildSpan({name: 'my-span1', childOf: rootSpan});
-        assert.ok(spanWithObject.started);
-        assert.strictEqual(spanWithObject.name, 'my-span1');
-        assert.strictEqual(spanWithObject.kind, types.SpanKind.UNSPECIFIED);
-      });
+      const rootSpan = tracer.startRootSpan(options);
+      const spanWithObject =
+          tracer.startChildSpan({name: 'my-span1', childOf: rootSpan});
+      assert.ok(spanWithObject.started);
+      assert.strictEqual(spanWithObject.name, 'my-span1');
+      assert.strictEqual(spanWithObject.kind, types.SpanKind.UNSPECIFIED);
     });
 
     it('should start a no-record span without params', () => {
-      tracer.startRootSpan(options, (rootSpan) => {
-        const spanWithObject = tracer.startChildSpan();
-        assert.strictEqual(spanWithObject.name, 'no-record');
-        assert.strictEqual(spanWithObject.kind, types.SpanKind.UNSPECIFIED);
-      });
+      const spanWithObject = tracer.startChildSpan();
+      assert.strictEqual(spanWithObject.name, 'no-record');
+      assert.strictEqual(spanWithObject.kind, types.SpanKind.UNSPECIFIED);
     });
 
     it('should support nested children', () => {
-      tracer.startRootSpan(options, (rootSpan) => {
-        assert.strictEqual(rootSpan.numberOfChildren, 0);
-        const child1 = tracer.startChildSpan({
-          name: 'child1',
-          kind: types.SpanKind.UNSPECIFIED,
-          childOf: rootSpan
-        });
-        assert.strictEqual(rootSpan.numberOfChildren, 1);
-        assert.strictEqual(child1.numberOfChildren, 0);
-        const child2 = tracer.startChildSpan({
-          name: 'child2',
-          kind: types.SpanKind.UNSPECIFIED,
-          childOf: rootSpan
-        });
-        assert.strictEqual(rootSpan.numberOfChildren, 2);
-        const grandchild1 = tracer.startChildSpan({
-          name: 'grandchild1',
-          kind: types.SpanKind.UNSPECIFIED,
-          childOf: child1
-        });
-        assert.strictEqual(rootSpan.numberOfChildren, 2);
-        assert.strictEqual(child1.numberOfChildren, 1);
-        assert.strictEqual(child2.numberOfChildren, 0);
-        assert.strictEqual(grandchild1.numberOfChildren, 0);
-
-        assert.strictEqual(rootSpan.spans.length, 2);
-        assert.strictEqual(child1, rootSpan.spans[0]);
-        assert.strictEqual(child2, rootSpan.spans[1]);
-        assert.strictEqual(grandchild1.parentSpanId, child1.id);
-
-        assert.strictEqual(child1.spans.length, 1);
-        assert.strictEqual(grandchild1, child1.spans[0]);
-
-        assert.strictEqual(child2.spans.length, 0);
-        assert.strictEqual(grandchild1.spans.length, 0);
-
-        assert.strictEqual(rootSpan.allDescendants().length, 3);
+      const rootSpan = tracer.startRootSpan(options);
+      assert.strictEqual(rootSpan.numberOfChildren, 0);
+      const child1 = tracer.startChildSpan({
+        name: 'child1',
+        kind: types.SpanKind.UNSPECIFIED,
+        childOf: rootSpan
       });
+      assert.strictEqual(rootSpan.numberOfChildren, 1);
+      assert.strictEqual(child1.numberOfChildren, 0);
+      const child2 = tracer.startChildSpan({
+        name: 'child2',
+        kind: types.SpanKind.UNSPECIFIED,
+        childOf: rootSpan
+      });
+      assert.strictEqual(rootSpan.numberOfChildren, 2);
+      const grandchild1 = tracer.startChildSpan({
+        name: 'grandchild1',
+        kind: types.SpanKind.UNSPECIFIED,
+        childOf: child1
+      });
+      assert.strictEqual(rootSpan.numberOfChildren, 2);
+      assert.strictEqual(child1.numberOfChildren, 1);
+      assert.strictEqual(child2.numberOfChildren, 0);
+      assert.strictEqual(grandchild1.numberOfChildren, 0);
+
+      assert.strictEqual(rootSpan.spans.length, 2);
+      assert.strictEqual(child1, rootSpan.spans[0]);
+      assert.strictEqual(child2, rootSpan.spans[1]);
+      assert.strictEqual(grandchild1.parentSpanId, child1.id);
+
+      assert.strictEqual(child1.spans.length, 1);
+      assert.strictEqual(grandchild1, child1.spans[0]);
+
+      assert.strictEqual(child2.spans.length, 0);
+      assert.strictEqual(grandchild1.spans.length, 0);
+
+      assert.strictEqual(rootSpan.allDescendants().length, 3);
     });
   });
 
@@ -383,10 +367,9 @@ describe('Tracer Base', () => {
       tracer.registerSpanEventListener(eventListener);
       tracer.start(defaultConfig);
 
-      tracer.startRootSpan(options, (rootSpan) => {
-        rootSpan.end();
-        assert.equal(eventListener.testCount, tracer.eventListeners.length);
-      });
+      const rootSpan = tracer.startRootSpan(options);
+      rootSpan.end();
+      assert.equal(eventListener.testCount, tracer.eventListeners.length);
     });
   });
 });

--- a/packages/opencensus-core/test/test-tracer.ts
+++ b/packages/opencensus-core/test/test-tracer.ts
@@ -41,7 +41,7 @@ describe('Tracer', () => {
   describe('get/set currentRootSpan()', () => {
     const tracer = new CoreTracer().start(defaultConfig);
     it('should get the current RootSpan from tracer instance', () => {
-      tracer.startRootSpan(options, (root) => {
+      tracer.startWithRootSpan(options, (root) => {
         assert.ok(root);
         assert.ok(tracer.currentRootSpan instanceof Span);
         assert.strictEqual(tracer.currentRootSpan, root);
@@ -56,7 +56,7 @@ describe('Tracer', () => {
     before(() => {
       tracer = new CoreTracer();
       tracer.start(defaultConfig);
-      tracer.startRootSpan(options, (rootSpan) => {
+      tracer.startWithRootSpan(options, (rootSpan) => {
         rootSpanLocal = rootSpan;
       });
     });
@@ -64,7 +64,7 @@ describe('Tracer', () => {
       assert.ok(rootSpanLocal instanceof Span);
     });
     it('should set current root span', () => {
-      tracer.startRootSpan(options, (rootSpan) => {
+      tracer.startWithRootSpan(options, (rootSpan) => {
         assert.ok(tracer.currentRootSpan instanceof Span);
         assert.strictEqual(tracer.currentRootSpan, rootSpan);
       });
@@ -76,7 +76,7 @@ describe('Tracer', () => {
     it('should set the current root span to null', () => {
       const tracer = new CoreTracer();
       tracer.start(defaultConfig);
-      tracer.startRootSpan(options, (rootSpan) => {
+      tracer.startWithRootSpan(options, (rootSpan) => {
         assert.ok(tracer.currentRootSpan instanceof Span);
         assert.strictEqual(tracer.currentRootSpan, rootSpan);
         tracer.clearCurrentTrace();
@@ -89,11 +89,11 @@ describe('Tracer', () => {
   describe('startChildSpan()', () => {
     let span: types.Span;
     let rootSpanLocal: types.Span;
-    let tracer: types.TracerBase;
+    let tracer: types.Tracer;
     before(() => {
       tracer = new CoreTracer();
       tracer.start(defaultConfig);
-      tracer.startRootSpan(options, (rootSpan) => {
+      tracer.startWithRootSpan(options, (rootSpan) => {
         rootSpanLocal = rootSpan;
         span = tracer.startChildSpan(
             {name: 'spanName', kind: types.SpanKind.CLIENT});

--- a/packages/opencensus-exporter-instana/test/test-instana.ts
+++ b/packages/opencensus-exporter-instana/test/test-instana.ts
@@ -48,7 +48,7 @@ describe('Instana Exporter', function() {
       tracer.start(defaultConfig);
 
       return tracer
-          .startRootSpan(
+          .startWithRootSpan(
               {name: 'root-test'},
               async (rootSpan: Span) => {
                 const span = rootSpan.startChildSpan(

--- a/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
+++ b/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
@@ -107,7 +107,7 @@ describe('Jaeger Exporter', () => {
   /* Should export spans to Jaeger */
   describe('test spans are valid', () => {
     it('should encode as thrift', () => {
-      return tracer.startRootSpan({name: 'root-s01'}, (rootSpan) => {
+      return tracer.startWithRootSpan({name: 'root-s01'}, (rootSpan) => {
         const span = tracer.startChildSpan({name: 'child-s01'});
         span.addAttribute('testBool', true);
         span.addAttribute('testString', 'here');
@@ -193,7 +193,7 @@ describe('Jaeger Exporter', () => {
   /* Should export spans to Jaeger */
   describe('publish()', () => {
     it('should export spans to Jaeger', () => {
-      return tracer.startRootSpan({name: 'root-s01'}, (rootSpan) => {
+      return tracer.startWithRootSpan({name: 'root-s01'}, (rootSpan) => {
         const span = tracer.startChildSpan({name: 'child-s01'});
         span.end();
         rootSpan.end();
@@ -209,7 +209,7 @@ describe('Jaeger Exporter', () => {
   describe('addToBuffer force flush by timeout ', () => {
     it('should flush by timeout', (done) => {
       assert.strictEqual(exporter.queue.length, 0);
-      tracer.startRootSpan({name: 'root-s02'}, (rootSpan) => {
+      tracer.startWithRootSpan({name: 'root-s02'}, (rootSpan) => {
         const span = tracer.startChildSpan({name: 'child-s02'});
         span.end();
         rootSpan.end();

--- a/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
+++ b/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
@@ -186,7 +186,7 @@ describe('OpenCensus Agent Exporter', () => {
 
     // Create a rootSpan and one childSpan, then validate that those spans
     // arrived at the server through the grpc stream.
-    tracing.tracer.startRootSpan(
+    tracing.tracer.startWithRootSpan(
         {
           name: ROOT_SPAN_NAME,
           spanContext: {traceId: hexId(), spanId: hexId(), options: 0x1}
@@ -245,7 +245,7 @@ describe('OpenCensus Agent Exporter', () => {
       }
     };
 
-    tracing.tracer.startRootSpan(rootSpanOptions, (rootSpan: Span) => {
+    tracing.tracer.startWithRootSpan(rootSpanOptions, (rootSpan: Span) => {
       // Status
       rootSpan.setStatus(CanonicalCode.OK);
 
@@ -477,7 +477,7 @@ describe('OpenCensus Agent Exporter', () => {
          }
        };
 
-       tracing.tracer.startRootSpan(rootSpanOptions, (rootSpan: Span) => {
+       tracing.tracer.startWithRootSpan(rootSpanOptions, (rootSpan: Span) => {
          // Status
          rootSpan.setStatus(CanonicalCode.OK);
 

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace.ts
@@ -53,7 +53,7 @@ describe('Stackdriver Trace Exporter', function() {
   describe('onEndSpan()', () => {
     it('should add a root span to an exporter buffer', () => {
       const rootSpanOptions = {name: 'sdBufferTestRootSpan'};
-      return tracer.startRootSpan(rootSpanOptions, (rootSpan: OCSpan) => {
+      return tracer.startWithRootSpan(rootSpanOptions, (rootSpan: OCSpan) => {
         assert.strictEqual(exporter.exporterBuffer.getQueue().length, 0);
 
         const spanName = 'sdBufferTestChildSpan';
@@ -75,7 +75,7 @@ describe('Stackdriver Trace Exporter', function() {
 
   describe('translateSpan()', () => {
     it('should translate to stackdriver spans', () => {
-      return tracer.startRootSpan(
+      return tracer.startWithRootSpan(
           {name: 'root-test'}, async (rootSpan: OCSpan) => {
             const span = tracer.startChildSpan({name: 'spanTest'});
             span.end();
@@ -159,7 +159,7 @@ describe('Stackdriver Trace Exporter', function() {
       const failTracer = new CoreTracer();
       failTracer.start({samplingRate: 1});
       failTracer.registerSpanEventListener(failExporter);
-      return failTracer.startRootSpan(
+      return failTracer.startWithRootSpan(
           {name: 'sdNoExportTestRootSpan'}, async (rootSpan: OCSpan) => {
             const span =
                 failTracer.startChildSpan({name: 'sdNoExportTestChildSpan'});
@@ -178,7 +178,7 @@ describe('Stackdriver Trace Exporter', function() {
     });
 
     it('should export traces to stackdriver', () => {
-      return tracer.startRootSpan(
+      return tracer.startWithRootSpan(
           {name: 'sdExportTestRootSpan'}, async (rootSpan: OCSpan) => {
             const span = tracer.startChildSpan({name: 'sdExportTestChildSpan'});
 
@@ -209,7 +209,7 @@ describe('Stackdriver Trace Exporter', function() {
 
       nocks.oauth2(body => true);
 
-      return tracer.startRootSpan(
+      return tracer.startWithRootSpan(
           {name: 'sdErrorExportTestRootSpan'}, (rootSpan: OCSpan) => {
             const span =
                 tracer.startChildSpan({name: 'sdErrorExportTestChildSpan'});

--- a/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
@@ -72,7 +72,7 @@ describe('Zipkin Exporter', function() {
       tracer.registerSpanEventListener(exporter);
       tracer.start(defaultConfig);
 
-      tracer.startRootSpan({name: 'root-test'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'root-test'}, (rootSpan: Span) => {
         const span =
             rootSpan.startChildSpan({name: 'spanTest', kind: SpanKind.CLIENT});
         span.end();
@@ -89,7 +89,7 @@ describe('Zipkin Exporter', function() {
       const tracer = new CoreTracer();
       tracer.start(defaultConfig);
 
-      return tracer.startRootSpan(
+      return tracer.startWithRootSpan(
           {name: 'root-test'}, async (rootSpan: Span) => {
             const span = rootSpan.startChildSpan(
                 {name: 'spanTest', kind: SpanKind.CLIENT});
@@ -108,7 +108,7 @@ describe('Zipkin Exporter', function() {
       const tracer = new CoreTracer();
       tracer.start(defaultConfig);
 
-      return tracer.startRootSpan({name: 'root-test'}, (rootSpan: Span) => {
+      return tracer.startWithRootSpan({name: 'root-test'}, (rootSpan: Span) => {
         const span =
             rootSpan.startChildSpan({name: 'spanTest', kind: SpanKind.CLIENT});
         span.addAttribute('my-int-attribute', 100);
@@ -183,7 +183,7 @@ describe('Zipkin Exporter', function() {
          const tracer = new CoreTracer();
          tracer.start(defaultConfig);
 
-         return tracer.startRootSpan(
+         return tracer.startWithRootSpan(
              {name: 'root-test'}, async (rootSpan: Span) => {
                const span = rootSpan.startChildSpan(
                    {name: 'spanTest', kind: SpanKind.CLIENT});

--- a/packages/opencensus-exporter-zpages/test/test-zpages.ts
+++ b/packages/opencensus-exporter-zpages/test/test-zpages.ts
@@ -131,12 +131,13 @@ describe('Zpages Exporter', () => {
       tracing.start(defaultConfig);
       tracing.registerExporter(zpages);
 
-      tracing.tracer.startRootSpan({name: 'rootSpanTest'}, (rootSpan: Span) => {
-        const span = tracing.tracer.startChildSpan(
-            {name: 'spanNameTest', kind: SpanKind.CLIENT});
-        span.end();
-        rootSpan.end();
-      });
+      tracing.tracer.startWithRootSpan(
+          {name: 'rootSpanTest'}, (rootSpan: Span) => {
+            const span = tracing.tracer.startChildSpan(
+                {name: 'spanNameTest', kind: SpanKind.CLIENT});
+            span.end();
+            rootSpan.end();
+          });
       zpages.startServer(done);
     });
 
@@ -171,7 +172,7 @@ describe('Zpages Exporter', () => {
       tracing.start(defaultConfig);
       tracing.registerExporter(zpages);
 
-      tracing.tracer.startRootSpan({name: 'runningSpanTest'}, () => {});
+      tracing.tracer.startWithRootSpan({name: 'runningSpanTest'}, () => {});
       zpages.startServer(done);
     });
 

--- a/packages/opencensus-instrumentation-grpc/src/grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/src/grpc.ts
@@ -170,30 +170,33 @@ export class GrpcPlugin extends BasePlugin {
                 plugin.logger.debug(
                     'path func: %s', JSON.stringify(traceOptions));
 
-                return plugin.tracer.startRootSpan(traceOptions, rootSpan => {
-                  if (!rootSpan) {
-                    return originalFunc.call(self, call, callback);
-                  }
+                return plugin.tracer.startWithRootSpan(
+                    traceOptions, rootSpan => {
+                      if (!rootSpan) {
+                        return originalFunc.call(self, call, callback);
+                      }
 
-                  rootSpan.addAttribute(GrpcPlugin.ATTRIBUTE_GRPC_METHOD, name);
-                  if (traceOptions.kind) {
-                    rootSpan.addAttribute(
-                        GrpcPlugin.ATTRIBUTE_GRPC_KIND, traceOptions.kind);
-                  }
+                      rootSpan.addAttribute(
+                          GrpcPlugin.ATTRIBUTE_GRPC_METHOD, name);
+                      if (traceOptions.kind) {
+                        rootSpan.addAttribute(
+                            GrpcPlugin.ATTRIBUTE_GRPC_KIND, traceOptions.kind);
+                      }
 
-                  switch (type) {
-                    case 'unary':
-                    case 'client_stream':
-                      return plugin.clientStreamAndUnaryHandler(
-                          plugin, rootSpan, call, callback, originalFunc, self);
-                    case 'server_stream':
-                    case 'bidi':
-                      return plugin.serverStreamAndBidiHandler(
-                          plugin, rootSpan, call, originalFunc, self);
-                    default:
-                      break;
-                  }
-                });
+                      switch (type) {
+                        case 'unary':
+                        case 'client_stream':
+                          return plugin.clientStreamAndUnaryHandler(
+                              plugin, rootSpan, call, callback, originalFunc,
+                              self);
+                        case 'server_stream':
+                        case 'bidi':
+                          return plugin.serverStreamAndBidiHandler(
+                              plugin, rootSpan, call, originalFunc, self);
+                        default:
+                          break;
+                      }
+                    });
               };
             });
         return result;
@@ -332,7 +335,7 @@ export class GrpcPlugin extends BasePlugin {
         // function call is the first operation, therefore we create a root
         // span.
         if (!plugin.tracer.currentRootSpan) {
-          return plugin.tracer.startRootSpan(
+          return plugin.tracer.startWithRootSpan(
               traceOptions,
               plugin.makeGrpcClientRemoteCall(original, args, this, plugin));
         } else {

--- a/packages/opencensus-instrumentation-grpc/test/test-grpc.ts
+++ b/packages/opencensus-instrumentation-grpc/test/test-grpc.ts
@@ -497,7 +497,7 @@ describe('GrpcPlugin() ', function() {
                const options = {name: 'TestRootSpan'};
                const spanName = `grpc.pkg_test.GrpcTester/${method.methodName}`;
                let serverRoot: Span;
-               return tracer.startRootSpan(options, async (root: Span) => {
+               return tracer.startWithRootSpan(options, async (root: Span) => {
                  assert.strictEqual(root.name, options.name);
                  const args = [client, method.request];
                  await method.method.apply(this, args)
@@ -536,34 +536,37 @@ describe('GrpcPlugin() ', function() {
                tags.set({name: 'testKey1'}, {value: 'value1'});
                tags.set({name: 'testKey2'}, {value: 'value2'});
                return globalStats.withTagContext(tags, async () => {
-                 return tracer.startRootSpan(options, async (root: Span) => {
-                   assert.strictEqual(root.name, options.name);
-                   const args = [client, method.request];
-                   await method.method.apply(this, args)
-                       .then(
-                           (result: TestRequestResponse|
-                            TestRequestResponse[]) => {
-                             assert.ok(checkEqual(result)(method.result));
-                             assert.strictEqual(
-                                 rootSpanVerifier.endedRootSpans.length, 1);
+                 return tracer.startWithRootSpan(
+                     options, async (root: Span) => {
+                       assert.strictEqual(root.name, options.name);
+                       const args = [client, method.request];
+                       await method.method.apply(this, args)
+                           .then(
+                               (result: TestRequestResponse|
+                                TestRequestResponse[]) => {
+                                 assert.ok(checkEqual(result)(method.result));
+                                 assert.strictEqual(
+                                     rootSpanVerifier.endedRootSpans.length, 1);
 
-                             serverRoot = rootSpanVerifier.endedRootSpans[0];
-                             assertSpan(
-                                 serverRoot, spanName, SpanKind.SERVER,
-                                 grpcModule.status.OK);
-                           });
-                   root.end();
-                   assert.strictEqual(
-                       rootSpanVerifier.endedRootSpans.length, 2);
-                   const clientChild =
-                       rootSpanVerifier.endedRootSpans[1].spans[0];
-                   assertSpan(
-                       clientChild, spanName, SpanKind.CLIENT,
-                       grpcModule.status.OK);
-                   // propagation
-                   assertPropagation(clientChild, serverRoot);
-                   assert.deepEqual(globalStats.getCurrentTagContext(), tags);
-                 });
+                                 serverRoot =
+                                     rootSpanVerifier.endedRootSpans[0];
+                                 assertSpan(
+                                     serverRoot, spanName, SpanKind.SERVER,
+                                     grpcModule.status.OK);
+                               });
+                       root.end();
+                       assert.strictEqual(
+                           rootSpanVerifier.endedRootSpans.length, 2);
+                       const clientChild =
+                           rootSpanVerifier.endedRootSpans[1].spans[0];
+                       assertSpan(
+                           clientChild, spanName, SpanKind.CLIENT,
+                           grpcModule.status.OK);
+                       // propagation
+                       assertPropagation(clientChild, serverRoot);
+                       assert.deepEqual(
+                           globalStats.getCurrentTagContext(), tags);
+                     });
                });
              });
         });
@@ -616,7 +619,7 @@ describe('GrpcPlugin() ', function() {
                const options = {name: 'TestRootSpan'};
                const spanName = `grpc.pkg_test.GrpcTester/${method.methodName}`;
                let serverRoot: Span;
-               return tracer.startRootSpan(options, async (root: Span) => {
+               return tracer.startWithRootSpan(options, async (root: Span) => {
                  assert.strictEqual(root.name, options.name);
                  const errRequest = (method.request instanceof Array) ?
                      method.request.slice(0, method.request.length) :

--- a/packages/opencensus-instrumentation-http/src/http.ts
+++ b/packages/opencensus-instrumentation-http/src/http.ts
@@ -194,7 +194,7 @@ export class HttpPlugin extends BasePlugin {
           }
         }
 
-        return plugin.tracer.startRootSpan(traceOptions, rootSpan => {
+        return plugin.tracer.startWithRootSpan(traceOptions, rootSpan => {
           if (!rootSpan) return original.apply(this, arguments);
 
           plugin.tracer.wrapEmitter(request);
@@ -326,7 +326,7 @@ export class HttpPlugin extends BasePlugin {
         // the first operation, therefore we create a root span.
         if (!plugin.tracer.currentRootSpan) {
           plugin.logger.debug('outgoingRequest starting a root span');
-          return plugin.tracer.startRootSpan(
+          return plugin.tracer.startWithRootSpan(
               traceOptions,
               plugin.getMakeRequestTraceFunction(request, options, plugin));
         } else {

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -262,7 +262,7 @@ describe('HttpPlugin', () => {
       const testPath = '/outgoing/rootSpan/childs/1';
       doNock(urlHost, testPath, 200, 'Ok');
       const options = {name: 'TestRootSpan'};
-      return tracer.startRootSpan(options, async (root: Span) => {
+      return tracer.startWithRootSpan(options, async (root: Span) => {
         await httpRequest.get(`${urlHost}${testPath}`).then((result) => {
           assert.ok(root.name.indexOf('TestRootSpan') >= 0);
           assert.strictEqual(root.spans.length, 1);
@@ -287,7 +287,7 @@ describe('HttpPlugin', () => {
                urlHost, testPath, httpErrorCodes[i],
                httpErrorCodes[i].toString());
            const options = {name: 'TestRootSpan'};
-           return tracer.startRootSpan(options, async (root: Span) => {
+           return tracer.startWithRootSpan(options, async (root: Span) => {
              await httpRequest.get(`${urlHost}${testPath}`).then((result) => {
                assert.ok(root.name.indexOf('TestRootSpan') >= 0);
                assert.strictEqual(root.spans.length, 1);
@@ -308,7 +308,7 @@ describe('HttpPlugin', () => {
       const num = 5;
       doNock(urlHost, testPath, 200, 'Ok', num);
       const options = {name: 'TestRootSpan'};
-      return tracer.startRootSpan(options, async (root: Span) => {
+      return tracer.startWithRootSpan(options, async (root: Span) => {
         assert.ok(root.name.indexOf('TestRootSpan') >= 0);
         for (let i = 0; i < num; i++) {
           await httpRequest.get(`${urlHost}${testPath}`).then((result) => {

--- a/packages/opencensus-instrumentation-http2/src/http2.ts
+++ b/packages/opencensus-instrumentation-http2/src/http2.ts
@@ -102,7 +102,7 @@ export class Http2Plugin extends HttpPlugin {
         // case there is no root span, this means that the outgoing request is
         // the first operation, therefore we create a root span.
         if (!plugin.tracer.currentRootSpan) {
-          return plugin.tracer.startRootSpan(
+          return plugin.tracer.startWithRootSpan(
               traceOptions,
               plugin.getMakeHttp2RequestTraceFunction(
                   request, headers, authority, plugin));
@@ -232,7 +232,7 @@ export class Http2Plugin extends HttpPlugin {
           return stream.respond.apply(this, arguments);
         };
 
-        return plugin.tracer.startRootSpan(traceOptions, rootSpan => {
+        return plugin.tracer.startWithRootSpan(traceOptions, rootSpan => {
           if (!rootSpan) return original.apply(this, arguments);
 
           plugin.tracer.wrapEmitter(stream);

--- a/packages/opencensus-instrumentation-http2/test/test-http2.ts
+++ b/packages/opencensus-instrumentation-http2/test/test-http2.ts
@@ -180,7 +180,7 @@ describe('Http2Plugin', () => {
       const requestOptions = {':method': 'GET', ':path': testPath};
       const options = {name: 'TestRootSpan'};
 
-      return tracer.startRootSpan(options, async (root: Span) => {
+      return tracer.startWithRootSpan(options, async (root: Span) => {
         await http2Request.get(client, requestOptions).then((result) => {
           assert.ok(root.name.indexOf('TestRootSpan') >= 0);
           assert.strictEqual(root.spans.length, 1);
@@ -200,7 +200,7 @@ describe('Http2Plugin', () => {
            const requestOptions = {':method': 'GET', ':path': testPath};
            const options = {name: 'TestRootSpan'};
 
-           return tracer.startRootSpan(options, async (root: Span) => {
+           return tracer.startWithRootSpan(options, async (root: Span) => {
              await http2Request.get(client, requestOptions).then((result) => {
                assert.ok(root.name.indexOf('TestRootSpan') >= 0);
                assert.strictEqual(root.spans.length, 1);
@@ -221,7 +221,7 @@ describe('Http2Plugin', () => {
       const num = 5;
       const options = {name: 'TestRootSpan'};
 
-      return tracer.startRootSpan(options, async (root: Span) => {
+      return tracer.startWithRootSpan(options, async (root: Span) => {
         assert.ok(root.name.indexOf('TestRootSpan') >= 0);
         for (let i = 0; i < num; i++) {
           await http2Request.get(client, requestOptions).then((result) => {

--- a/packages/opencensus-instrumentation-https/test/test-https.ts
+++ b/packages/opencensus-instrumentation-https/test/test-https.ts
@@ -201,7 +201,7 @@ describe('HttpsPlugin', () => {
           const testPath = '/outgoing/rootSpan/childs/1';
           doNock(urlHost, testPath, 200, 'Ok');
           const options = {name: 'TestRootSpan'};
-          return tracer.startRootSpan(options, async (root: Span) => {
+          return tracer.startWithRootSpan(options, async (root: Span) => {
             await requestMethod(`${urlHost}${testPath}`).then((result) => {
               assert.ok(root.name.indexOf('TestRootSpan') >= 0);
               assert.strictEqual(root.spans.length, 1);
@@ -222,7 +222,7 @@ describe('HttpsPlugin', () => {
                    urlHost, testPath, httpErrorCodes[i],
                    httpErrorCodes[i].toString());
                const options = {name: 'TestRootSpan'};
-               return tracer.startRootSpan(options, async (root: Span) => {
+               return tracer.startWithRootSpan(options, async (root: Span) => {
                  await requestMethod(`${urlHost}${testPath}`).then((result) => {
                    assert.ok(root.name.indexOf('TestRootSpan') >= 0);
                    assert.strictEqual(root.spans.length, 1);
@@ -242,7 +242,7 @@ describe('HttpsPlugin', () => {
           const num = 5;
           doNock(urlHost, testPath, 200, 'Ok', num);
           const options = {name: 'TestRootSpan'};
-          return tracer.startRootSpan(options, async (root: Span) => {
+          return tracer.startWithRootSpan(options, async (root: Span) => {
             assert.ok(root.name.indexOf('TestRootSpan') >= 0);
             for (let i = 0; i < num; i++) {
               await requestMethod(`${urlHost}${testPath}`).then((result) => {

--- a/packages/opencensus-instrumentation-ioredis/test/test-ioredis.ts
+++ b/packages/opencensus-instrumentation-ioredis/test/test-ioredis.ts
@@ -107,7 +107,7 @@ describe('IORedisPlugin', () => {
 
   describe('Instrumenting query operations', () => {
     it('should create a child span for hset', (done) => {
-      tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         client.hset('hash', 'random', 'random', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
@@ -122,7 +122,7 @@ describe('IORedisPlugin', () => {
     });
 
     it('should create a child span for get', (done) => {
-      tracer.startRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
         client.get('test', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(result, 'data');
@@ -137,15 +137,17 @@ describe('IORedisPlugin', () => {
     });
 
     it('should create a child span for del', (done) => {
-      tracer.startRootSpan({name: 'removeRootSpan'}, async (rootSpan: Span) => {
-        await client.del('test');
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
-        rootSpan.end();
-        assertSpan(rootSpanVerifier, `redis-del`, SpanKind.CLIENT, (span) => {
-          return span.attributes.arguments === undefined;
-        });
-        done();
-      });
+      tracer.startWithRootSpan(
+          {name: 'removeRootSpan'}, async (rootSpan: Span) => {
+            await client.del('test');
+            assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+            rootSpan.end();
+            assertSpan(
+                rootSpanVerifier, `redis-del`, SpanKind.CLIENT, (span) => {
+                  return span.attributes.arguments === undefined;
+                });
+            done();
+          });
     });
   });
 
@@ -155,7 +157,7 @@ describe('IORedisPlugin', () => {
     });
 
     it('should not create a child span for insert', (done) => {
-      tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         client.hset('hash', 'random', 'random', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
@@ -169,7 +171,7 @@ describe('IORedisPlugin', () => {
     });
 
     it('should not create a child span for get', (done) => {
-      tracer.startRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
         client.get('test', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(result, 'data');
@@ -183,14 +185,16 @@ describe('IORedisPlugin', () => {
     });
 
     it('should not create a child span for del', (done) => {
-      tracer.startRootSpan({name: 'removeRootSpan'}, async (rootSpan: Span) => {
-        await client.del('test');
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
-        rootSpan.end();
-        assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
-        assert.strictEqual(rootSpanVerifier.endedRootSpans[0].spans.length, 0);
-        done();
-      });
+      tracer.startWithRootSpan(
+          {name: 'removeRootSpan'}, async (rootSpan: Span) => {
+            await client.del('test');
+            assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
+            rootSpan.end();
+            assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 1);
+            assert.strictEqual(
+                rootSpanVerifier.endedRootSpans[0].spans.length, 0);
+            done();
+          });
     });
   });
 });

--- a/packages/opencensus-instrumentation-mongodb/test/test-mongodb.ts
+++ b/packages/opencensus-instrumentation-mongodb/test/test-mongodb.ts
@@ -148,7 +148,7 @@ describe('MongoDBPlugin', () => {
     it('should create a child span for insert', (done) => {
       const insertData = [{a: 1}, {a: 2}, {a: 3}];
 
-      tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         collection.insertMany(insertData, (err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -162,7 +162,7 @@ describe('MongoDBPlugin', () => {
     });
 
     it('should create a child span for update', (done) => {
-      tracer.startRootSpan({name: 'updateRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'updateRootSpan'}, (rootSpan: Span) => {
         collection.updateOne({a: 2}, {$set: {b: 1}}, (err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -176,7 +176,7 @@ describe('MongoDBPlugin', () => {
     });
 
     it('should create a child span for remove', (done) => {
-      tracer.startRootSpan({name: 'removeRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'removeRootSpan'}, (rootSpan: Span) => {
         collection.deleteOne({a: 3}, (err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -193,7 +193,7 @@ describe('MongoDBPlugin', () => {
   /** Should intercept cursor */
   describe('Instrumenting cursor operations', () => {
     it('should create a child span for find', (done) => {
-      tracer.startRootSpan({name: 'findRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'findRootSpan'}, (rootSpan: Span) => {
         collection.find({}).toArray((err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -210,7 +210,7 @@ describe('MongoDBPlugin', () => {
   /** Should intercept command */
   describe('Instrumenting command operations', () => {
     it('should create a child span for create index', (done) => {
-      tracer.startRootSpan({name: 'indexRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'indexRootSpan'}, (rootSpan: Span) => {
         collection.createIndex({a: 1}, (err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -224,7 +224,7 @@ describe('MongoDBPlugin', () => {
     });
 
     it('should create a child span for count', (done) => {
-      tracer.startRootSpan({name: 'countRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'countRootSpan'}, (rootSpan: Span) => {
         collection.count({a: 1}, (err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -246,7 +246,7 @@ describe('MongoDBPlugin', () => {
     it('should not create a child span for query', (done) => {
       const insertData = [{a: 1}, {a: 2}, {a: 3}];
 
-      tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         collection.insertMany(insertData, (err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -260,7 +260,7 @@ describe('MongoDBPlugin', () => {
     });
 
     it('should not create a child span for cursor', (done) => {
-      tracer.startRootSpan({name: 'findRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'findRootSpan'}, (rootSpan: Span) => {
         collection.find({}).toArray((err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();
@@ -274,7 +274,7 @@ describe('MongoDBPlugin', () => {
     });
 
     it('should not create a child span for command', (done) => {
-      tracer.startRootSpan({name: 'indexRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'indexRootSpan'}, (rootSpan: Span) => {
         collection.createIndex({a: 1}, (err, result) => {
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
           rootSpan.end();

--- a/packages/opencensus-instrumentation-redis/test/test-redis.ts
+++ b/packages/opencensus-instrumentation-redis/test/test-redis.ts
@@ -109,7 +109,7 @@ describe('RedisPlugin', () => {
   /** Should intercept query */
   describe('Instrumenting query operations', () => {
     it('should create a child span for hset', (done) => {
-      tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         client.hset('hash', 'random', 'random', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
@@ -124,7 +124,7 @@ describe('RedisPlugin', () => {
     });
 
     it('should create a child span for get', (done) => {
-      tracer.startRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
         client.get('test', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(result, 'data');
@@ -140,7 +140,7 @@ describe('RedisPlugin', () => {
     });
 
     it('should create a child span for del', (done) => {
-      tracer.startRootSpan({name: 'removeRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'removeRootSpan'}, (rootSpan: Span) => {
         client.del('test', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
@@ -162,7 +162,7 @@ describe('RedisPlugin', () => {
     });
 
     it('should not create a child span for insert', (done) => {
-      tracer.startRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'insertRootSpan'}, (rootSpan: Span) => {
         client.hset('hash', 'random', 'random', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);
@@ -176,7 +176,7 @@ describe('RedisPlugin', () => {
     });
 
     it('should not create a child span for get', (done) => {
-      tracer.startRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'getRootSpan'}, (rootSpan: Span) => {
         client.get('test', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(result, 'data');
@@ -190,7 +190,7 @@ describe('RedisPlugin', () => {
     });
 
     it('should not create a child span for del', (done) => {
-      tracer.startRootSpan({name: 'removeRootSpan'}, (rootSpan: Span) => {
+      tracer.startWithRootSpan({name: 'removeRootSpan'}, (rootSpan: Span) => {
         client.del('test', (err, result) => {
           assert.ifError(err);
           assert.strictEqual(rootSpanVerifier.endedRootSpans.length, 0);

--- a/packages/opencensus-nodejs/README.md
+++ b/packages/opencensus-nodejs/README.md
@@ -48,7 +48,7 @@ In addition to automatic tracing, it is possible to manually create your own roo
 
 ```typescript
 const rootSpanOptions = { name: 'your root span' };
-tracing.tracer.startRootSpan(rootSpanOptions, (rootSpan) => {
+tracing.tracer.startWithRootSpan(rootSpanOptions, (rootSpan) => {
 
     // You can create as many child spans as needed
     childSpan = tracing.tracer.startChildSpan({ name: 'name of your child span' });


### PR DESCRIPTION
**This PR is work in progress...**

On the meeting with @bogdandrutu there was this idea to have a pure Tracer API and making Span creation synchronous and turning CLS to a layer top of the pure Tracer API. This PR experiments with this API with the current Opencensus Node library.

Pure Tracer APIs:
```
  /**
   * Start a new RootSpan to currentRootSpan
   * @param options Options for tracer instance
   * @param fn Callback function
   * @returns {Span} A root span
   */
  startRootSpan(options: TraceOptions): Span;

  /**
   * Start a new Span instance to the currentRootSpan
   * @param childOf Span
   * @param [options] A TraceOptions object to start a root span.
   * @returns The new Span instance started
   */
  startChildSpan(options?: SpanOptions): Span;
```

CLS Layer top of the pure API:
```
  /**
   * Sets span to CLS
   * @param span Span to setup in context.
   * @param fn A callback function that runs after context setup.
   */
  withSpan<T>(span: Span, fn: () => T): T;

  /**
   * Starts a root span and sets it to context.
   * @param options Options for tracer instance
   * @param fn A callback function to run after starting a root span.
   */
  startWithRootSpan<T>(options: TraceOptions, fn: (root: Span) => T): T;
```