### PR TITLE
Remove "triage me" label from ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: bug, triage me
+labels: bug
 ---
 
 Please answer these questions before submitting a bug report.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: feature-request, triage me
+labels: feature-request
 ---
 
 **NB:** Before opening a feature request against this repo, consider whether the feature should/could be implemented in other the OpenCensus libraries in other languages. If so, please [open an issue on opencensus-specs](https://github.com/census-instrumentation/opencensus-specs/issues/new) first.


### PR DESCRIPTION
This is to match other languages templates. Example: https://github.com/census-instrumentation/opencensus-python/tree/master/.github/ISSUE_TEMPLATE