### PR TITLE
Add support for Derived Cumulative API

### DIFF
--- a/packages/opencensus-core/src/index.ts
+++ b/packages/opencensus-core/src/index.ts
@@ -23,6 +23,8 @@ export * from './trace/instrumentation/types';
 export * from './trace/propagation/types';
 export * from './exporters/types';
 export * from './common/types';
+export * from './metrics/types';
+export * from './metrics/cumulative/types';
 export * from './metrics/gauges/types';
 export {Metric, MetricDescriptor, TimeSeries, MetricDescriptorType, LabelKey, LabelValue, Point as TimeSeriesPoint, DistributionValue, BucketOptions, Bucket as DistributionBucket, SummaryValue, Explicit, Exemplar, Timestamp, Snapshot, ValueAtPercentile, MetricProducerManager, MetricProducer} from './metrics/export/types';
 
@@ -74,6 +76,7 @@ export * from './metrics/metric-registry';
 
 // Cumulative CLASSES
 export * from './metrics/cumulative/cumulative';
+export * from './metrics/cumulative/derived-cumulative';
 
 // GAUGES CLASSES
 export * from './metrics/gauges/derived-gauge';

--- a/packages/opencensus-core/src/metrics/cumulative/derived-cumulative.ts
+++ b/packages/opencensus-core/src/metrics/cumulative/derived-cumulative.ts
@@ -149,20 +149,22 @@ export class DerivedCumulative implements Meter {
       descriptor: this.metricDescriptor,
       timeseries: Array.from(
           this.registeredPoints,
-          ([_, cumulativeEntry]) => {
-            const newValue = cumulativeEntry.extractor();
-            const value = newValue > cumulativeEntry.prevValue ?
-                newValue :
-                cumulativeEntry.prevValue;
-            cumulativeEntry.prevValue = value;
+          ([_, cumulativeEntry]):
+              TimeSeries => {
+                const newValue = cumulativeEntry.extractor();
+                const value = newValue > cumulativeEntry.prevValue ?
+                    newValue :
+                    cumulativeEntry.prevValue;
+                cumulativeEntry.prevValue = value;
 
-            return {
-              labelValues:
-                  [...cumulativeEntry.labelValues, ...this.constantLabelValues],
-              points: [{value, timestamp}],
-              startTimestamp: this.startTime
-            } as TimeSeries;
-          })
+                return {
+                  labelValues: [
+                    ...cumulativeEntry.labelValues, ...this.constantLabelValues
+                  ],
+                  points: [{value, timestamp}],
+                  startTimestamp: this.startTime
+                };
+              })
     };
   }
 }

--- a/packages/opencensus-core/src/metrics/cumulative/derived-cumulative.ts
+++ b/packages/opencensus-core/src/metrics/cumulative/derived-cumulative.ts
@@ -44,15 +44,14 @@ export class DerivedCumulative implements Meter {
   /**
    * Constructs a new DerivedCumulative instance.
    *
-   * @param {string} name The name of the metric.
-   * @param {string} description The description of the metric.
-   * @param {string} unit The unit of the metric.
-   * @param {MetricDescriptorType} type The type of metric.
-   * @param {LabelKey[]} labelKeys The list of the label keys.
-   * @param {Map<LabelKey, LabelValue>} constantLabels The map of constant
-   *     labels for the Metric.
-   * @param {Timestamp} startTime The time when the cumulative metric start
-   *     measuring the value.
+   * @param name The name of the metric.
+   * @param description The description of the metric.
+   * @param unit The unit of the metric.
+   * @param type The type of metric.
+   * @param labelKeys The list of the label keys.
+   * @param constantLabels The map of constant labels for the Metric.
+   * @param startTime The time when the cumulative metric start measuring the
+   *     value.
    */
   constructor(
       name: string, description: string, unit: string,
@@ -70,10 +69,10 @@ export class DerivedCumulative implements Meter {
 
   /**
    * Creates a TimeSeries. The value of a single point in the TimeSeries is
-   * observed from a obj. The ValueExtractor is invoked whenever
+   * observed from an object or function. The ValueExtractor is invoked whenever
    * metrics are collected, meaning the reported value is up-to-date.
    *
-   * @param {LabelValue[]} labelValues The list of the label values.
+   * @param labelValues The list of the label values.
    * @param objOrFn obj The obj to get the size or length or value from. If
    *     multiple options are available, the value (ToValueInterface) takes
    *     precedence first, followed by length and size. e.g value -> length ->
@@ -121,7 +120,7 @@ export class DerivedCumulative implements Meter {
    * references to previous Point objects are invalid (not part of the
    * metric).
    *
-   * @param {LabelValue[]} labelValues The list of label values.
+   * @param labelValues The list of label values.
    */
   removeTimeSeries(labelValues: LabelValue[]): void {
     validateNotNull(labelValues, 'labelValues');
@@ -139,8 +138,7 @@ export class DerivedCumulative implements Meter {
   /**
    * Provides a Metric with one or more TimeSeries.
    *
-   * @returns {Metric} The Metric, or null if TimeSeries is not present in
-   *     Metric.
+   * @returns The Metric, or null if TimeSeries is not present in Metric.
    */
   getMetric(): Metric|null {
     if (this.registeredPoints.size === 0) {

--- a/packages/opencensus-core/src/metrics/cumulative/derived-cumulative.ts
+++ b/packages/opencensus-core/src/metrics/cumulative/derived-cumulative.ts
@@ -23,9 +23,16 @@ import * as util from '../utils';
 
 type ValueExtractor = () => number;
 
+/**
+ * An interface that describes the entry for every TimeSeries (Point) added to
+ * the Cumulative metric.
+ */
 interface CumulativeEntry {
+  /** The list of the label values. */
   readonly labelValues: LabelValue[];
+  /** The function to get the actual value of point. */
   readonly extractor: ValueExtractor;
+  /** The previous value of the point. */
   prevValue: number;
 }
 

--- a/packages/opencensus-core/src/metrics/types.ts
+++ b/packages/opencensus-core/src/metrics/types.ts
@@ -41,3 +41,36 @@ export interface MetricOptions {
   // TODO(mayurkale): Add resource information.
   // https://github.com/census-instrumentation/opencensus-specs/pull/248
 }
+
+/** Interface for objects with "length()" method. */
+export interface LengthMethodInterface {
+  length(): number;
+}
+
+/** Interface for objects with "length" attribute (e.g. Array). */
+export interface LengthAttributeInterface {
+  length: number;
+}
+
+/** Interface for objects with "size" method. */
+export interface SizeMethodInterface {
+  size(): number;
+}
+
+/** Interface for objects with "size" attribute (e.g. Map, Set). */
+export interface SizeAttributeInterface {
+  size: number;
+}
+
+/** Interface for objects with "getValue" method. */
+export interface ToValueInterface {
+  getValue(): number;
+}
+
+export interface AccessorFunction {
+  (): number;
+}
+
+export type AccessorInterface =
+    LengthAttributeInterface|LengthMethodInterface|SizeAttributeInterface|
+    SizeMethodInterface|ToValueInterface|AccessorFunction;

--- a/packages/opencensus-core/src/metrics/utils.ts
+++ b/packages/opencensus-core/src/metrics/utils.ts
@@ -74,3 +74,45 @@ export function isSizeMethodInterface(obj: any): obj is SizeMethodInterface {
 export function isToValueInterface(obj: any): obj is ToValueInterface {
   return obj && typeof obj.getValue === 'function';
 }
+
+// TODO(mayurkale): Consider to use unknown type instead of any for above
+// functions, unknown type is available since TypeScript 3.0
+// Fact: unknown acts like a type-safe version of any by requiring us to
+// perform some type of checking before we can use the value of the unknown
+// element or any of its properties. Below functions will help to perform
+// structural check on given object.
+
+// // Performs a structural check on given object.
+// // tslint:disable-next-line:no-any
+// function _isLengthAttributeInterface(obj: any): boolean {
+//   return !!obj && typeof obj === 'object' && 'length' in obj &&
+//       typeof obj.length === 'number';
+// }
+
+// // Performs a structural check on given object.
+// // tslint:disable-next-line:no-any
+// function _isLengthMethodInterface(obj: any): boolean {
+//   return !!obj && typeof obj === 'object' && 'length' in obj &&
+//       typeof obj.length === 'function';
+// }
+
+// // Performs a structural check on given object.
+// // tslint:disable-next-line:no-any
+// function _isSizeAttributeInterface(obj: any): boolean {
+//   return !!obj && typeof obj === 'object' && 'size' in obj &&
+//       typeof obj.size === 'number';
+// }
+
+// // Performs a structural check on given object.
+// // tslint:disable-next-line:no-any
+// function _isSizeMethodInterface(obj: any): boolean {
+//   return !!obj && typeof obj === 'object' && 'size' in obj &&
+//       typeof obj.size === 'function';
+// }
+
+// // Performs a structural check on given object.
+// // tslint:disable-next-line:no-any
+// function _isToValueInterface(obj: any): boolean {
+//   return !!obj && typeof obj === 'object' && 'getValue' in obj &&
+//       typeof obj.getValue === 'function';
+// }

--- a/packages/opencensus-core/src/metrics/utils.ts
+++ b/packages/opencensus-core/src/metrics/utils.ts
@@ -15,6 +15,7 @@
  */
 
 import {LabelValue} from './export/types';
+import {LengthAttributeInterface, LengthMethodInterface, SizeAttributeInterface, SizeMethodInterface, ToValueInterface} from './types';
 
 const COMMA_SEPARATOR = ',';
 const UNSET_LABEL_VALUE: LabelValue = {
@@ -39,4 +40,37 @@ export function hashLabelValues(labelValues: LabelValue[]): string {
  */
 export function initializeDefaultLabels(count: number): LabelValue[] {
   return new Array(count).fill(UNSET_LABEL_VALUE);
+}
+
+// Checks if the specified collection is a LengthAttributeInterface.
+// tslint:disable-next-line:no-any
+export function isLengthAttributeInterface(obj: any):
+    obj is LengthAttributeInterface {
+  return obj && typeof obj.length === 'number';
+}
+
+// Checks if the specified collection is a LengthMethodInterface.
+// tslint:disable-next-line:no-any
+export function isLengthMethodInterface(obj: any):
+    obj is LengthMethodInterface {
+  return obj && typeof obj.length === 'function';
+}
+
+// Checks if the specified collection is a SizeAttributeInterface.
+// tslint:disable-next-line:no-any
+export function isSizeAttributeInterface(obj: any):
+    obj is SizeAttributeInterface {
+  return obj && typeof obj.size === 'number';
+}
+
+// Checks if the specified collection is a SizeMethodInterface.
+// tslint:disable-next-line:no-any
+export function isSizeMethodInterface(obj: any): obj is SizeMethodInterface {
+  return obj && typeof obj.size === 'function';
+}
+
+// Checks if the specified callbackFn is a ToValueInterface.
+// tslint:disable-next-line:no-any
+export function isToValueInterface(obj: any): obj is ToValueInterface {
+  return obj && typeof obj.getValue === 'function';
 }

--- a/packages/opencensus-core/src/metrics/utils.ts
+++ b/packages/opencensus-core/src/metrics/utils.ts
@@ -42,6 +42,12 @@ export function initializeDefaultLabels(count: number): LabelValue[] {
   return new Array(count).fill(UNSET_LABEL_VALUE);
 }
 
+// TODO(mayurkale): Consider to use unknown type instead of any for below
+// functions, unknown type is available since TypeScript 3.0
+// Fact: unknown acts like a type-safe version of any by requiring us to
+// perform some type of checking before we can use the value of the unknown
+// element or any of its properties.
+
 // Checks if the specified collection is a LengthAttributeInterface.
 // tslint:disable-next-line:no-any
 export function isLengthAttributeInterface(obj: any):
@@ -74,45 +80,3 @@ export function isSizeMethodInterface(obj: any): obj is SizeMethodInterface {
 export function isToValueInterface(obj: any): obj is ToValueInterface {
   return obj && typeof obj.getValue === 'function';
 }
-
-// TODO(mayurkale): Consider to use unknown type instead of any for above
-// functions, unknown type is available since TypeScript 3.0
-// Fact: unknown acts like a type-safe version of any by requiring us to
-// perform some type of checking before we can use the value of the unknown
-// element or any of its properties. Below functions will help to perform
-// structural check on given object.
-
-// // Performs a structural check on given object.
-// // tslint:disable-next-line:no-any
-// function _isLengthAttributeInterface(obj: any): boolean {
-//   return !!obj && typeof obj === 'object' && 'length' in obj &&
-//       typeof obj.length === 'number';
-// }
-
-// // Performs a structural check on given object.
-// // tslint:disable-next-line:no-any
-// function _isLengthMethodInterface(obj: any): boolean {
-//   return !!obj && typeof obj === 'object' && 'length' in obj &&
-//       typeof obj.length === 'function';
-// }
-
-// // Performs a structural check on given object.
-// // tslint:disable-next-line:no-any
-// function _isSizeAttributeInterface(obj: any): boolean {
-//   return !!obj && typeof obj === 'object' && 'size' in obj &&
-//       typeof obj.size === 'number';
-// }
-
-// // Performs a structural check on given object.
-// // tslint:disable-next-line:no-any
-// function _isSizeMethodInterface(obj: any): boolean {
-//   return !!obj && typeof obj === 'object' && 'size' in obj &&
-//       typeof obj.size === 'function';
-// }
-
-// // Performs a structural check on given object.
-// // tslint:disable-next-line:no-any
-// function _isToValueInterface(obj: any): boolean {
-//   return !!obj && typeof obj === 'object' && 'getValue' in obj &&
-//       typeof obj.getValue === 'function';
-// }

--- a/packages/opencensus-core/test/test-derived-cumulative.ts
+++ b/packages/opencensus-core/test/test-derived-cumulative.ts
@@ -1,0 +1,280 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {TEST_ONLY} from '../src/common/time-util';
+import {DerivedCumulative} from '../src/metrics/cumulative/derived-cumulative';
+import {LabelKey, LabelValue, MetricDescriptorType, Timestamp} from '../src/metrics/export/types';
+
+const METRIC_NAME = 'metric-name';
+const METRIC_DESCRIPTION = 'metric-description';
+const UNIT = '1';
+const CUMULATIVE_INT64 = MetricDescriptorType.CUMULATIVE_INT64;
+const CUMULATIVE_DOUBLE = MetricDescriptorType.CUMULATIVE_DOUBLE;
+const LABEL_KEYS: LabelKey[] = [{key: 'code', description: 'desc'}];
+const LABEL_VALUES_200: LabelValue[] = [{value: '200'}];
+const LABEL_VALUES_400: LabelValue[] = [{value: '400'}];
+const LABEL_VALUES_EXRTA: LabelValue[] = [{value: '200'}, {value: '400'}];
+const EMPTY_CONSTANT_LABELS = new Map();
+const CONSTANT_LABELS = new Map();
+CONSTANT_LABELS.set({key: 'host', description: 'host'}, {value: 'localhost'});
+
+describe('DerivedCumulative', () => {
+  let instance: DerivedCumulative;
+  const realHrtimeFn = process.hrtime;
+  const realNowFn = Date.now;
+  const mockedTime: Timestamp = {seconds: 1450000100, nanos: 1e7};
+  const expectedMetricDescriptor = {
+    name: METRIC_NAME,
+    description: METRIC_DESCRIPTION,
+    unit: UNIT,
+    type: CUMULATIVE_INT64,
+    labelKeys: LABEL_KEYS
+  };
+  const startime: Timestamp = {seconds: 1400000100, nanos: 1e7};
+
+  beforeEach(() => {
+    instance = new DerivedCumulative(
+        METRIC_NAME, METRIC_DESCRIPTION, UNIT, CUMULATIVE_INT64, LABEL_KEYS,
+        EMPTY_CONSTANT_LABELS, startime);
+
+    process.hrtime = () => [100, 1e7];
+    Date.now = () => 1450000000000;
+    // Force the clock to recalibrate the time offset with the mocked time
+    TEST_ONLY.setHrtimeReference();
+  });
+
+  afterEach(() => {
+    process.hrtime = realHrtimeFn;
+    Date.now = realNowFn;
+    // Reset the hrtime reference so that it uses a real clock again.
+    TEST_ONLY.resetHrtimeFunctionCache();
+  });
+
+  describe('createTimeSeries()', () => {
+    it('should throw an error when the keys and values dont have same size',
+       () => {
+         assert.throws(() => {
+           instance.createTimeSeries(LABEL_VALUES_EXRTA, new Map());
+         }, /^Error: Label Keys and Label Values don't have same size$/);
+       });
+
+    it('should return a Metric', () => {
+      const map = new Map();
+      map.set('key', 'value');
+      instance.createTimeSeries(LABEL_VALUES_200, map);
+      map.set('key1', 'value1');
+
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(metric!.timeseries, [{
+                               labelValues: LABEL_VALUES_200,
+                               points: [{value: 2, timestamp: mockedTime}],
+                               startTimestamp: startime
+                             }]);
+      // add data in collection
+      map.set('key2', 'value2');
+      map.set('key3', 'value3');
+
+      // add new timeseries with length-method
+      const arr = new Array(5).fill('test');
+      instance.createTimeSeries(LABEL_VALUES_400, {
+        size: () => arr.length,
+      });
+
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      assert.equal(metric!.timeseries.length, 2);
+      assert.deepStrictEqual(metric!.timeseries, [
+        {
+          labelValues: LABEL_VALUES_200,
+          points: [{value: 4, timestamp: mockedTime}],
+          startTimestamp: startime
+        },
+        {
+          labelValues: LABEL_VALUES_400,
+          points: [{value: 5, timestamp: mockedTime}],
+          startTimestamp: startime
+        }
+      ]);
+    });
+
+    it('should return a Metric (INT64) - custom object', () => {
+      class QueueManager {
+        getValue(): number {
+          return 45;
+        }
+      }
+      const queue = new QueueManager();
+      instance.createTimeSeries(LABEL_VALUES_200, queue);
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(metric!.timeseries, [{
+                               labelValues: LABEL_VALUES_200,
+                               points: [{value: 45, timestamp: mockedTime}],
+                               startTimestamp: startime
+                             }]);
+    });
+
+    it('should return a Metric value from a function', () => {
+      class QueueManager {
+        private depth = 0;
+        get pendingJobs() {
+          return this.depth;
+        }
+        addJob() {
+          this.depth++;
+        }
+      }
+      const queue = new QueueManager();
+      queue.addJob();
+      instance.createTimeSeries(LABEL_VALUES_200, () => {
+        return queue.pendingJobs;
+      });
+
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(metric!.timeseries, [{
+                               labelValues: LABEL_VALUES_200,
+                               points: [{value: 1, timestamp: mockedTime}],
+                               startTimestamp: startime
+                             }]);
+      // Simulate a adding multiple jobs in queue
+      queue.addJob();
+      queue.addJob();
+      queue.addJob();
+      metric = instance.getMetric();
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(
+          metric!.timeseries[0].points, [{value: 4, timestamp: mockedTime}]);
+    });
+
+    it('should return a Metric (Double) - custom object', () => {
+      class QueueManager {
+        getValue(): number {
+          return 0.7;
+        }
+      }
+      const queue = new QueueManager();
+      const doubleInstance = new DerivedCumulative(
+          METRIC_NAME, METRIC_DESCRIPTION, UNIT, CUMULATIVE_DOUBLE, LABEL_KEYS,
+          EMPTY_CONSTANT_LABELS, startime);
+      doubleInstance.createTimeSeries(LABEL_VALUES_200, queue);
+      const metric = doubleInstance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric!.descriptor, {
+        name: METRIC_NAME,
+        description: METRIC_DESCRIPTION,
+        unit: UNIT,
+        type: CUMULATIVE_DOUBLE,
+        labelKeys: LABEL_KEYS
+      });
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(metric!.timeseries, [{
+                               labelValues: LABEL_VALUES_200,
+                               points: [{value: 0.7, timestamp: mockedTime}],
+                               startTimestamp: startime
+                             }]);
+    });
+
+    it('should ignore dropping (decreasing) value', () => {
+      const map = new Map();
+      instance.createTimeSeries(LABEL_VALUES_200, map);
+      map.set('key', 'value');
+      map.set('key1', 'value1');
+      let metric = instance.getMetric();
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(metric!.timeseries, [{
+                               labelValues: LABEL_VALUES_200,
+                               points: [{value: 2, timestamp: mockedTime}],
+                               startTimestamp: startime
+                             }]);
+
+      map.clear();
+      metric = instance.getMetric();
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(metric!.timeseries, [{
+                               labelValues: LABEL_VALUES_200,
+                               points: [{value: 2, timestamp: mockedTime}],
+                               startTimestamp: startime
+                             }]);
+    });
+
+    it('should not create same timeseries again', () => {
+      const map = new Map();
+      instance.createTimeSeries(LABEL_VALUES_200, map);
+      map.set('key', 'value');
+      const metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      assert.equal(metric!.timeseries.length, 1);
+      assert.deepStrictEqual(metric!.timeseries, [{
+                               labelValues: LABEL_VALUES_200,
+                               points: [{value: 1, timestamp: mockedTime}],
+                               startTimestamp: startime
+                             }]);
+
+      // create timeseries with same labels.
+      assert.throws(() => {
+        instance.createTimeSeries(LABEL_VALUES_200, map);
+      }, /^Error: A different time series with the same labels already exists.$/);
+    });
+  });
+
+  describe('removeTimeSeries()', () => {
+    it('should remove TimeSeries', () => {
+      const arr: string[] = [];
+      instance.createTimeSeries(LABEL_VALUES_200, arr);
+      arr.push('test');
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      instance.removeTimeSeries(LABEL_VALUES_200);
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+
+  describe('clear()', () => {
+    it('should clear all TimeSeries', () => {
+      const map = new Map();
+      instance.createTimeSeries(LABEL_VALUES_200, {
+        size: () => map.size,
+      });
+      map.set('key', 'value');
+
+      const arr: string[] = [];
+      instance.createTimeSeries(LABEL_VALUES_400, {
+        size: () => arr.length,
+      });
+      arr.push('test');
+      let metric = instance.getMetric();
+      assert.notEqual(metric, null);
+      assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
+      assert.equal(metric!.timeseries.length, 2);
+      instance.clear();
+      metric = instance.getMetric();
+      assert.deepStrictEqual(metric, null);
+    });
+  });
+});


### PR DESCRIPTION
Updates #450 

Specs: https://github.com/census-instrumentation/opencensus-specs/pull/254/files?short_path=0aaf645#diff-0aaf6455b2b0b7a5f2ed45f6b36792ee

This is mostly same as [derived-gauge](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/metrics/gauges/derived-gauge.ts). 

Last piece, registering with **[Metric-Registry](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/metrics/metric-registry.ts)** will be in a follow-up PR.