### PR TITLE
chore: add node 12 ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,14 @@ workflows:
           filters: *release_tags
       - node11:
           filters: *release_tags
+      - node12:
+          filters: *release_tags
       - publish_npm:
           requires:
             - node8
             - node10
             - node11
+            - node12
           filters:
             branches:
               ignore: /.*/
@@ -74,6 +77,14 @@ jobs:
   node11:
     docker:
       - image: node:11
+        user: node
+        environment: *test_env
+      - *mongo_service
+      - *redis_service
+    <<: *unit_tests
+  node12:
+    docker:
+      - image: node:12
         user: node
         environment: *test_env
       - *mongo_service


### PR DESCRIPTION
~~I am optimistic about tests and build, Let's see how much work required to add support for node 12.
Edit 2: I have updated GRPC package to 1.20.3 to pass the build on Node 12 #535.~~