### PR TITLE
Plug-in Cumulative APIs into the Metric-Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add Cumulative (`DoubleCumulative`, `Int64Cumulative`) APIs.
+
  **This release has a breaking change. Please test your code accordingly after upgrading.**
 
  - removing Tracer's `startChildSpan(name?: string, kind?: types.SpanKind)` interface

--- a/packages/opencensus-core/src/metrics/metric-registry.ts
+++ b/packages/opencensus-core/src/metrics/metric-registry.ts
@@ -47,9 +47,9 @@ export class MetricRegistry {
    * convenient form when you want to manually increase and decrease values as
    * per your service requirements.
    *
-   * @param {string} name The name of the metric.
-   * @param {MetricOptions} options The options for the metric.
-   * @returns {Gauge} A Int64 Gauge metric.
+   * @param name The name of the metric.
+   * @param options The options for the metric.
+   * @returns A Int64 Gauge metric.
    */
   addInt64Gauge(name: string, options?: MetricOptions): Gauge {
     const description =
@@ -78,9 +78,9 @@ export class MetricRegistry {
    * convenient form when you want to manually increase and decrease values as
    * per your service requirements.
    *
-   * @param {string} name The name of the metric.
-   * @param {MetricOptions} options The options for the metric.
-   * @returns {Gauge} A Double Gauge metric.
+   * @param name The name of the metric.
+   * @param options The options for the metric.
+   * @returns A Double Gauge metric.
    */
   addDoubleGauge(name: string, options?: MetricOptions): Gauge {
     const description =
@@ -109,9 +109,9 @@ export class MetricRegistry {
    * convenient form when you want to manually increase and decrease values as
    * per your service requirements.
    *
-   * @param {string} name The name of the metric.
-   * @param {MetricOptions} options The options for the metric.
-   * @returns {DerivedGauge} A Int64 DerivedGauge metric.
+   * @param name The name of the metric.
+   * @param options The options for the metric.
+   * @returns A Int64 DerivedGauge metric.
    */
   addDerivedInt64Gauge(name: string, options?: MetricOptions): DerivedGauge {
     const description =
@@ -140,9 +140,9 @@ export class MetricRegistry {
    * convenient form when you want to manually increase and decrease values as
    * per your service requirements.
    *
-   * @param {string} name The name of the metric.
-   * @param {MetricOptions} options The options for the metric.
-   * @returns {DerivedGauge} A Double DerivedGauge metric.
+   * @param name The name of the metric.
+   * @param options The options for the metric.
+   * @returns A Double DerivedGauge metric.
    */
   addDerivedDoubleGauge(name: string, options?: MetricOptions): DerivedGauge {
     const description =
@@ -171,9 +171,9 @@ export class MetricRegistry {
    * useful when you want to manually increase and reset values as per service
    * requirements.
    *
-   * @param {string} name The name of the metric.
-   * @param {MetricOptions} options The options for the metric.
-   * @returns {Cumulative} A Int64 Cumulative metric.
+   * @param name The name of the metric.
+   * @param options The options for the metric.
+   * @returns A Int64 Cumulative metric.
    */
   addInt64Cumulative(name: string, options?: MetricOptions): Cumulative {
     const description =
@@ -202,9 +202,9 @@ export class MetricRegistry {
    * useful when you want to manually increase and reset values as per service
    * requirements.
    *
-   * @param {string} name The name of the metric.
-   * @param {MetricOptions} options The options for the metric.
-   * @returns {Cumulative} A Double Cumulative metric.
+   * @param name The name of the metric.
+   * @param options The options for the metric.
+   * @returns A Double Cumulative metric.
    */
   addDoubleCumulative(name: string, options?: MetricOptions): Cumulative {
     const description =
@@ -231,8 +231,8 @@ export class MetricRegistry {
   /**
    * Registers metric to register.
    *
-   * @param {string} name The name of the metric.
-   * @param {Meter} meter The metric to register.
+   * @param name The name of the metric.
+   * @param meter The metric to register.
    */
   private registerMetric(name: string, meter: Meter): void {
     if (this.registeredMetrics.has(name)) {
@@ -245,7 +245,7 @@ export class MetricRegistry {
   /**
    * Gets a metric producer for registry.
    *
-   * @returns {MetricProducer} The metric producer.
+   * @returns The metric producer.
    */
   getMetricProducer(): MetricProducer {
     return this.metricProducer;
@@ -267,7 +267,7 @@ class MetricProducerForRegistry extends BaseMetricProducer {
   /**
    * Gets a collection of produced Metric`s to be exported.
    *
-   * @returns {Metric[]} The list of metrics.
+   * @returns The list of metrics.
    */
   getMetrics(): Metric[] {
     return Array.from(this.registeredMetrics.values())

--- a/packages/opencensus-core/src/metrics/metric-registry.ts
+++ b/packages/opencensus-core/src/metrics/metric-registry.ts
@@ -16,6 +16,7 @@
 
 import {validateArrayElementsNotNull, validateDuplicateKeys, validateMapElementNotNull, validateNotNull} from '../common/validations';
 import {MeasureUnit} from '../stats/types';
+import {Cumulative} from './cumulative/cumulative';
 import {BaseMetricProducer} from './export/base-metric-producer';
 import {Metric, MetricDescriptorType, MetricProducer} from './export/types';
 import {DerivedGauge} from './gauges/derived-gauge';
@@ -163,6 +164,68 @@ export class MetricRegistry {
         MetricDescriptorType.GAUGE_DOUBLE, labelKeysCopy, constantLabels);
     this.registerMetric(name, derivedDoubleGauge);
     return derivedDoubleGauge;
+  }
+
+  /**
+   * Builds a new Int64 cumulative to be added to the registry. This API is
+   * useful when you want to manually increase and reset values as per service
+   * requirements.
+   *
+   * @param {string} name The name of the metric.
+   * @param {MetricOptions} options The options for the metric.
+   * @returns {Cumulative} A Int64 Cumulative metric.
+   */
+  addInt64Cumulative(name: string, options?: MetricOptions): Cumulative {
+    const description =
+        (options && options.description) || MetricRegistry.DEFAULT_DESCRIPTION;
+    const unit = (options && options.unit) || MetricRegistry.DEFAULT_UNIT;
+    const labelKeys =
+        (options && options.labelKeys) || MetricRegistry.DEFAULT_LABEL_KEYS;
+    const constantLabels = (options && options.constantLabels) ||
+        MetricRegistry.DEFAULT_CONSTANT_LABEL;
+    // TODO(mayurkale): Add support for resource
+
+    validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
+    validateMapElementNotNull(constantLabels, MetricRegistry.CONSTANT_LABELS);
+    validateDuplicateKeys(labelKeys, constantLabels);
+
+    const labelKeysCopy = Object.assign([], labelKeys);
+    const int64Cumulative = new Cumulative(
+        validateNotNull(name, MetricRegistry.NAME), description, unit,
+        MetricDescriptorType.CUMULATIVE_INT64, labelKeysCopy, constantLabels);
+    this.registerMetric(name, int64Cumulative);
+    return int64Cumulative;
+  }
+
+  /**
+   * Builds a new double cumulative to be added to the registry. This API is
+   * useful when you want to manually increase and reset values as per service
+   * requirements.
+   *
+   * @param {string} name The name of the metric.
+   * @param {MetricOptions} options The options for the metric.
+   * @returns {Cumulative} A Double Cumulative metric.
+   */
+  addDoubleCumulative(name: string, options?: MetricOptions): Cumulative {
+    const description =
+        (options && options.description) || MetricRegistry.DEFAULT_DESCRIPTION;
+    const unit = (options && options.unit) || MetricRegistry.DEFAULT_UNIT;
+    const labelKeys =
+        (options && options.labelKeys) || MetricRegistry.DEFAULT_LABEL_KEYS;
+    const constantLabels = (options && options.constantLabels) ||
+        MetricRegistry.DEFAULT_CONSTANT_LABEL;
+    // TODO(mayurkale): Add support for resource
+
+    validateArrayElementsNotNull(labelKeys, MetricRegistry.LABEL_KEY);
+    validateMapElementNotNull(constantLabels, MetricRegistry.CONSTANT_LABELS);
+    validateDuplicateKeys(labelKeys, constantLabels);
+
+    const labelKeysCopy = Object.assign([], labelKeys);
+    const doubleCumulative = new Cumulative(
+        validateNotNull(name, MetricRegistry.NAME), description, unit,
+        MetricDescriptorType.CUMULATIVE_DOUBLE, labelKeysCopy, constantLabels);
+    this.registerMetric(name, doubleCumulative);
+    return doubleCumulative;
   }
 
   /**


### PR DESCRIPTION
Updates #450

Registering Derived Cumulative APIs with **[Metric-Registry](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/metrics/metric-registry.ts)** will be in a follow-up PR. Dependency on #503