### PR TITLE
Exporter/Stackdriver: Support Exemplar in Stackdriver TimeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Exporter/Stats/Stackdriver: Add support for exemplar
+
 ## 0.0.13 - 2019-05-20
 - Exporter/Stats/Prometheus: Fix missing tags for HTTP metrics
 - http-instrumentation: add support for the addition of custom attributes to spans

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -195,6 +195,7 @@ export interface Distribution {
   sumOfSquaredDeviation: number;
   bucketOptions: {explicitBuckets: {bounds: Bucket[];}};
   bucketCounts: number[];
+  exemplars?: Exemplar[];
 }
 
 export interface Point {
@@ -223,4 +224,33 @@ export interface MonitoredResource {
 
   /** Set of labels that describe the resource. */
   labels: {[key: string]: string};
+}
+
+/**
+ * Exemplars are example points that may be used to annotate aggregated
+ * Distribution values. They are metadata that gives information about a
+ * particular value added to a Distribution bucket.
+ */
+export interface Exemplar {
+  /** Value of the exemplar point. */
+  value: number;
+  /** The observation (sampling) time of the above value. */
+  timestamp: string;
+  /** Contextual information about the example value. */
+  attachments: Any[];
+}
+
+/**
+ * `Any` contains an arbitrary serialized protocol buffer message along with a
+ * URL that describes the type of the serialized message.
+ */
+export interface Any {
+  /**
+   * A URL/resource name that uniquely identifies the type of the serialized
+   * protocol buffer message.
+   */
+  '@type': string;
+
+  /** Must be a valid serialized protocol buffer of the above specified type. */
+  value: string;
 }


### PR DESCRIPTION
Fixes #365, Follow-up PR of https://github.com/census-instrumentation/opencensus-node/pull/405.

Stackdriver TimeSeries#Exemplar API: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TimeSeries#Exemplar