### PR TITLE
`startChildSpan` with `SpanOptions` interface only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+**This release has a breaking change. Please test your code accordingly after upgrading.**
+
+- Remove Span's `startChildSpan(nameOrOptions?: string|SpanOptions, kind?: SpanKind)` interface, now only `SpanOptions` object interface is supported.
 
 ## 0.0.12 - 2019-05-13
 - Add `defaultAttributes` config to `Tracer.start(config)`

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
@@ -184,25 +184,12 @@ export class NoRecordSpan implements types.Span {
 
   /**
    * Starts a new no record child span in the no record root span.
-   * @param nameOrOptions Span name string or SpanOptions object.
-   * @param kind Span kind if not using SpanOptions object.
+   * @param [options] A SpanOptions object to start a child span.
    */
-  startChildSpan(
-      nameOrOptions?: string|types.SpanOptions,
-      kind?: types.SpanKind): types.Span {
+  startChildSpan(options?: types.SpanOptions): types.Span {
     const noRecordChild = new NoRecordSpan(this);
-
-    const spanName =
-        typeof nameOrOptions === 'object' ? nameOrOptions.name : nameOrOptions;
-    const spanKind =
-        typeof nameOrOptions === 'object' ? nameOrOptions.kind : kind;
-    if (spanName) {
-      noRecordChild.name = spanName;
-    }
-    if (spanKind) {
-      noRecordChild.kind = spanKind;
-    }
-
+    if (options && options.name) noRecordChild.name = options.name;
+    if (options && options.kind) noRecordChild.kind = options.kind;
     noRecordChild.start();
     return noRecordChild;
   }

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -354,12 +354,9 @@ export class Span implements types.Span {
 
   /**
    * Starts a new child span.
-   * @param nameOrOptions Span name string or SpanOptions object.
-   * @param kind Span kind if not using SpanOptions object.
+   * @param [options] A SpanOptions object to start a child span.
    */
-  startChildSpan(
-      nameOrOptions?: string|types.SpanOptions,
-      kind?: types.SpanKind): types.Span {
+  startChildSpan(options?: types.SpanOptions): types.Span {
     if (this.ended) {
       this.logger.debug(
           'calling %s.startSpan() on ended %s %o', this.className,
@@ -374,12 +371,8 @@ export class Span implements types.Span {
     }
 
     const child = new Span(this.tracer, this);
-    const spanName =
-        typeof nameOrOptions === 'object' ? nameOrOptions.name : nameOrOptions;
-    const spanKind =
-        typeof nameOrOptions === 'object' ? nameOrOptions.kind : kind;
-    if (spanName) child.name = spanName;
-    if (spanKind) child.kind = spanKind;
+    if (options && options.name) child.name = options.name;
+    if (options && options.kind) child.kind = options.kind;
 
     child.start();
     this.spansLocal.push(child);

--- a/packages/opencensus-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-core/src/trace/model/tracer-base.ts
@@ -215,7 +215,7 @@ export class CoreTracerBase implements types.TracerBase {
           'no current trace found - must start a new root span first');
       return new NoRecordSpan();
     }
-    const span = options.childOf.startChildSpan(options.name, options.kind);
+    const span = options.childOf.startChildSpan(options);
 
     // Add default attributes
     const defaultAttributes = this.config && this.config.defaultAttributes;

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -458,9 +458,7 @@ export interface Span {
   truncate(): void;
 
   /** Starts a new Span instance as a child of this instance */
-  startChildSpan(name?: string, kind?: SpanKind): Span;
   startChildSpan(options?: SpanOptions): Span;
-  startChildSpan(nameOrOptions?: string|SpanOptions, kind?: SpanKind): Span;
 }
 
 /** Interface for TracerBase */
@@ -515,7 +513,6 @@ export interface TracerBase extends SpanEventListener {
 
   /**
    * Start a new Span instance to the currentRootSpan
-   * @param childOf Span
    * @param [options] A TraceOptions object to start a root span.
    * @returns The new Span instance started
    */


### PR DESCRIPTION
Continuation of #484, this PR is to cleanup and match internal interfaces with top level APIs. i.e. Internal `startChildSpan` interface accepts same argument(`SpanOptions`) as public facing Tracer's  `startChildSpan`.

**This PR does not contain any breaking change.**