### PR TITLE
Chore: remove node 6 ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node6:
-          filters: *release_tags
       - node8:
           filters: *release_tags
       - node10:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node6
             - node8
             - node10
             - node11
@@ -58,14 +57,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node6:
-    docker:
-      - image: node:6
-        user: node
-        environment: *test_env
-      - *mongo_service
-      - *redis_service
-    <<: *unit_tests
   node8:
     docker:
       - image: node:8


### PR DESCRIPTION
Fixes #511.

The follow up PR should be to upgrade engines field to >=8.x.