### PR TITLE
Change CLS import to make stats types more general. (Fix #527)

### DIFF
--- a/packages/opencensus-core/src/stats/types.ts
+++ b/packages/opencensus-core/src/stats/types.ts
@@ -15,10 +15,13 @@
  */
 
 import {StatsEventListener} from '../exporters/types';
-import * as cls from '../internal/cls';
 import {Metric} from '../metrics/export/types';
 import {TagMap} from '../tags/tag-map';
 import {TagKey, TagValue} from '../tags/types';
+
+/** Default type for functions */
+// tslint:disable:no-any
+type Func<T> = (...args: any[]) => T;
 
 /** Main interface for stats. */
 export interface Stats {
@@ -107,7 +110,7 @@ export interface Stats {
    * @param fn Callback function.
    * @returns The callback return.
    */
-  withTagContext<T>(tags: TagMap, fn: cls.Func<T>): T;
+  withTagContext<T>(tags: TagMap, fn: Func<T>): T;
 
   /** Gets the current tag context. */
   getCurrentTagContext(): TagMap;

--- a/packages/opencensus-core/src/trace/instrumentation/types.ts
+++ b/packages/opencensus-core/src/trace/instrumentation/types.ts
@@ -55,7 +55,7 @@ export type PluginNames = {
 };
 
 export type PluginInternalFilesVersion = {
-  [pluginName: string]: string
+  [pluginName: string]: string;
 };
 
 /**


### PR DESCRIPTION
This PR fixes Issue [#527](https://github.com/census-instrumentation/opencensus-node/issues/527).

* Adds a Default function declaration in @opencensus/core stats/types.ts to avoid import of internal functionality.
* As small change, adds missing semicolon.
