### PR TITLE
set CurrentRootSpan correctly

### DIFF
--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -305,6 +305,9 @@ export class Span implements types.Span {
       parentSpanId: this.parentSpanId,
       traceState: this.traceState
     });
+    if (!this.parentSpanId) {
+      this.tracer.setCurrentRootSpan(this);
+    }
 
     this.tracer.onStartSpan(this);
   }

--- a/packages/opencensus-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-core/src/trace/model/tracer-base.ts
@@ -61,6 +61,9 @@ export class CoreTracerBase implements types.TracerBase {
     return noopPropagation;
   }
 
+  /** Sets the current root span. */
+  setCurrentRootSpan(root: types.Span) {}
+
   /**
    * Starts a tracer.
    * @param config A tracer configuration object to start a tracer.
@@ -134,16 +137,13 @@ export class CoreTracerBase implements types.TracerBase {
         rootSpan.start();
         return fn(rootSpan);
       }
-
       // Sampling is off
       this.logger.debug('Sampling is off, starting new no record root span');
-      const noRecordRootSpan = new NoRecordRootSpan(
-          this, name, kind, traceId, parentSpanId, traceState);
-      return fn(noRecordRootSpan);
+    } else {
+      // Tracer is inactive
+      this.logger.debug('Tracer is inactive, starting new no record root span');
     }
 
-    // Tracer is inactive
-    this.logger.debug('Tracer is inactive, starting new no record root span');
     const noRecordRootSpan = new NoRecordRootSpan(
         this, name, kind, traceId, parentSpanId, traceState);
     return fn(noRecordRootSpan);

--- a/packages/opencensus-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-core/src/trace/model/tracer-base.ts
@@ -62,7 +62,9 @@ export class CoreTracerBase implements types.TracerBase {
   }
 
   /** Sets the current root span. */
-  setCurrentRootSpan(root: types.Span) {}
+  setCurrentRootSpan(root: types.Span) {
+    // no-op, this is only required in case of tracer with cls.
+  }
 
   /**
    * Starts a tracer.

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -47,6 +47,11 @@ export class CoreTracer extends CoreTracerBase implements types.Tracer {
 
   /** Sets the current root span. */
   set currentRootSpan(root: types.Span) {
+    this.setCurrentRootSpan(root);
+  }
+
+  /** Sets the current root span. */
+  setCurrentRootSpan(root: types.Span) {
     if (this.contextManager.active) {
       this.contextManager.set('rootspan', root);
     }
@@ -62,7 +67,6 @@ export class CoreTracer extends CoreTracerBase implements types.Tracer {
     const self = this;
     return self.contextManager.runAndReturn(() => {
       return super.startRootSpan(options, (root) => {
-        self.currentRootSpan = root;
         return fn(root);
       });
     });
@@ -74,7 +78,7 @@ export class CoreTracer extends CoreTracerBase implements types.Tracer {
     if (!root) {
       return this.logger.debug('cannot start trace - no active trace found');
     }
-    if (this.currentRootSpan !== root) {
+    if (this.currentRootSpan.traceId !== root.traceId) {
       this.logger.debug(
           'currentRootSpan != root on notifyStart. Need more investigation.');
     }
@@ -88,7 +92,7 @@ export class CoreTracer extends CoreTracerBase implements types.Tracer {
       this.logger.debug('cannot end trace - no active trace found');
       return;
     }
-    if (this.currentRootSpan !== root) {
+    if (this.currentRootSpan.traceId !== root.traceId) {
       this.logger.debug(
           'currentRootSpan != root on notifyEnd. Need more investigation.');
     }

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -78,7 +78,8 @@ export class CoreTracer extends CoreTracerBase implements types.Tracer {
     if (!root) {
       return this.logger.debug('cannot start trace - no active trace found');
     }
-    if (this.currentRootSpan.traceId !== root.traceId) {
+    if (!this.currentRootSpan ||
+        this.currentRootSpan.traceId !== root.traceId) {
       this.logger.debug(
           'currentRootSpan != root on notifyStart. Need more investigation.');
     }
@@ -92,7 +93,8 @@ export class CoreTracer extends CoreTracerBase implements types.Tracer {
       this.logger.debug('cannot end trace - no active trace found');
       return;
     }
-    if (this.currentRootSpan.traceId !== root.traceId) {
+    if (!this.currentRootSpan ||
+        this.currentRootSpan.traceId !== root.traceId) {
       this.logger.debug(
           'currentRootSpan != root on notifyEnd. Need more investigation.');
     }

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -517,6 +517,9 @@ export interface TracerBase extends SpanEventListener {
    * @returns The new Span instance started
    */
   startChildSpan(options?: SpanOptions): Span;
+
+  /** Sets the current root span. */
+  setCurrentRootSpan(root: Span): void;
 }
 
 /** Interface for Tracer */

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -259,8 +259,9 @@ export interface SpanContext {
 
 /** Defines an end span event listener */
 export interface SpanEventListener {
-  /** Happens when a span is ended */
+  /** Happens when a span is started */
   onStartSpan(span: Span): void;
+  /** Happens when a span is ended */
   onEndSpan(span: Span): void;
 }
 


### PR DESCRIPTION
While debugging #526, I found we are not assigning `currentRootSpan` correctly, especially in case of tracer with cls. Ideally, we should set `currentRootSpan` before the `onStartSpan` event. This change is done in https://github.com/census-instrumentation/opencensus-node/commit/92edaa9d406ac74e1805a4e80b756acedc413001#diff-b46c2c01fbf239aae015e19185803e0dL154

The `onStartSpan` and `onEndSpan` events contains following check -> 
```
if (this.currentRootSpan.traceId !== root.traceId) {
      this.logger.debug(
          'currentRootSpan != root on notifyStart. Need more investigation.');
    }
```