### PR TITLE
Chore: upgrade engines field to >=8

### DIFF
--- a/examples/grpc/package.json
+++ b/examples/grpc/package.json
@@ -13,7 +13,7 @@
   "author": "OpenCensus Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "scripts": {
     "lint": "semistandard *.js",

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -13,7 +13,7 @@
   "author": "OpenCensus Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "scripts": {
     "lint": "semistandard *.js",

--- a/examples/stats/exporter/package.json
+++ b/examples/stats/exporter/package.json
@@ -16,7 +16,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [],
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-core/package.json
+++ b/packages/opencensus-core/package.json
@@ -27,7 +27,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-exporter-instana/package.json
+++ b/packages/opencensus-exporter-instana/package.json
@@ -25,7 +25,7 @@
   "author": "Instana Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-exporter-jaeger/package.json
+++ b/packages/opencensus-exporter-jaeger/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-exporter-ocagent/package.json
+++ b/packages/opencensus-exporter-ocagent/package.json
@@ -28,7 +28,7 @@
   "author": "OpenCensus Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-exporter-prometheus/package.json
+++ b/packages/opencensus-exporter-prometheus/package.json
@@ -25,7 +25,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-exporter-stackdriver/package.json
+++ b/packages/opencensus-exporter-stackdriver/package.json
@@ -26,7 +26,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-exporter-zipkin/package.json
+++ b/packages/opencensus-exporter-zipkin/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-exporter-zpages/package.json
+++ b/packages/opencensus-exporter-zpages/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-all/package.json
+++ b/packages/opencensus-instrumentation-all/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-grpc/package.json
+++ b/packages/opencensus-instrumentation-grpc/package.json
@@ -25,7 +25,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-http/package.json
+++ b/packages/opencensus-instrumentation-http/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-http2/package.json
+++ b/packages/opencensus-instrumentation-http2/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-https/package.json
+++ b/packages/opencensus-instrumentation-https/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-ioredis/package.json
+++ b/packages/opencensus-instrumentation-ioredis/package.json
@@ -26,7 +26,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-mongodb/package.json
+++ b/packages/opencensus-instrumentation-mongodb/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-instrumentation-redis/package.json
+++ b/packages/opencensus-instrumentation-redis/package.json
@@ -25,7 +25,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-nodejs-base/package.json
+++ b/packages/opencensus-nodejs-base/package.json
@@ -26,7 +26,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-nodejs/package.json
+++ b/packages/opencensus-nodejs/package.json
@@ -26,7 +26,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-propagation-b3/package.json
+++ b/packages/opencensus-propagation-b3/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-propagation-binaryformat/package.json
+++ b/packages/opencensus-propagation-binaryformat/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-propagation-jaeger/package.json
+++ b/packages/opencensus-propagation-jaeger/package.json
@@ -25,7 +25,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src",

--- a/packages/opencensus-propagation-tracecontext/package.json
+++ b/packages/opencensus-propagation-tracecontext/package.json
@@ -24,7 +24,7 @@
   "author": "OpenCensus Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opencensus-resource-util/package.json
+++ b/packages/opencensus-resource-util/package.json
@@ -24,7 +24,7 @@
   "author": "OpenCensus Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8"
   },
   "files": [
     "build/src/**/*.js",


### PR DESCRIPTION
We have already deprecated Node 6 support #511.