### PR TITLE
Exporter/Prometheus: Fix missing tags for HTTP metrics

### DIFF
--- a/packages/opencensus-exporter-prometheus/src/prometheus-stats.ts
+++ b/packages/opencensus-exporter-prometheus/src/prometheus-stats.ts
@@ -103,9 +103,16 @@ export class PrometheusStatsExporter implements StatsEventListener {
   private getLabelValues(columns: TagKey[], tags: Map<TagKey, TagValue>):
       labelValues {
     const labels: labelValues = {};
+
+    // TODO: Consider make original tags map with string:TagValue type.
+    const tagsWithStringKey: Map<string, TagValue|undefined> = new Map();
+    for (const key of tags.keys()) {
+      tagsWithStringKey.set(key.name, tags.get(key));
+    }
+
     columns.forEach((tagKey) => {
-      if (tags.has(tagKey)) {
-        const tagValue = tags.get(tagKey);
+      if (tagsWithStringKey.has(tagKey.name)) {
+        const tagValue = tagsWithStringKey.get(tagKey.name);
         if (tagValue) {
           labels[tagKey.name] = tagValue.value;
         }

--- a/packages/opencensus-exporter-prometheus/test/test-prometheus-stats.ts
+++ b/packages/opencensus-exporter-prometheus/test/test-prometheus-stats.ts
@@ -24,7 +24,7 @@ describe('Prometheus Stats Exporter', () => {
   const prometheusServerUrl = `http://localhost:${options.port}/metrics`;
   const tagKey1 = {name: 'tagKey1'};
   const tagValue1 = {value: 'tagValue1'};
-  const tagKeys = [tagKey1];
+  const tagKeys = [{name: 'tagKey1'}];
   const tagMap = new TagMap();
   tagMap.set(tagKey1, tagValue1);
 


### PR DESCRIPTION
Currently, the `tags` is a type of map with `TagKey` as Key and `TagValue` as value. We used `Map.prototype.has` function to detect if a key is already defined, if no skip it otherwise get the associated value for it. AFAIK, The maps detects existence ( Map.prototype.has ( key )) of keys based on equality (===). Primitives like strings and numbers are compared by their value, while objects (arrays, plain objects) are compared by their reference. That comparison by reference basically checks to see if the objects given refer to the same location in memory. 

To solve the problem (short-term), I would prefer to create copy of original map with string as the key type. The alternative solution would be to change `tags: Map<TagKey, TagValue>` to `tags: Map<string, TagValue>`. It would require lots of refactoring, and and an API level breaking change.

These changes have all been tested locally and been confirmed to be working. 