### PR TITLE
 Enable to receive credentials object in creating Stackdriver exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Exporter/Stats/Stackdriver: Add support for exemplar
+- exporter-stackdriver: Add support the credentials option used for authentication instead of your application default credentials
 
 ## 0.0.13 - 2019-05-20
 - Exporter/Stats/Prometheus: Fix missing tags for HTTP metrics

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
@@ -16,7 +16,7 @@
 
 import {Exporter, ExporterBuffer, Span as OCSpan, SpanContext} from '@opencensus/core';
 import {logger, Logger} from '@opencensus/core';
-import {auth, JWT} from 'google-auth-library';
+import {auth as globalAuth, GoogleAuth, JWT} from 'google-auth-library';
 import {google} from 'googleapis';
 import {getDefaultResource} from './common-utils';
 import {createAttributes, createLinks, createTimeEvents, getResourceLabels, stringToTruncatableString} from './stackdriver-cloudtrace-utils';
@@ -24,6 +24,7 @@ import {AttributeValue, Span, SpansWithCredentials, StackdriverExporterOptions} 
 
 google.options({headers: {'x-opencensus-outgoing-request': 0x1}});
 const cloudTrace = google.cloudtrace('v2');
+let auth = globalAuth;
 
 /** Format and sends span information to Stackdriver */
 export class StackdriverTraceExporter implements Exporter {
@@ -39,6 +40,9 @@ export class StackdriverTraceExporter implements Exporter {
     this.exporterBuffer = new ExporterBuffer(this, options);
     this.RESOURCE_LABELS =
         getResourceLabels(getDefaultResource(this.projectId));
+    if (options.credentials) {
+      auth = new GoogleAuth({credentials: options.credentials});
+    }
   }
 
   /**

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -15,7 +15,7 @@
  */
 
 import {logger, Logger, Measurement, Metric, MetricDescriptor as OCMetricDescriptor, MetricProducerManager, Metrics, StatsEventListener, TagKey, TagValue, version, View} from '@opencensus/core';
-import {auth, JWT} from 'google-auth-library';
+import {auth as globalAuth, GoogleAuth, JWT} from 'google-auth-library';
 import {google} from 'googleapis';
 import {getDefaultResource} from './common-utils';
 import {createMetricDescriptorData, createTimeSeriesList} from './stackdriver-monitoring-utils';
@@ -31,6 +31,7 @@ const OC_HEADER = {
 
 google.options({headers: OC_HEADER});
 const monitoring = google.monitoring('v3');
+let auth = globalAuth;
 
 /** Format and sends Stats to Stackdriver */
 export class StackdriverStatsExporter implements StatsEventListener {
@@ -63,6 +64,9 @@ export class StackdriverStatsExporter implements StatsEventListener {
       this.onMetricUploadError = options.onMetricUploadError;
     }
     this.DEFAULT_RESOURCE = getDefaultResource(this.projectId);
+    if (options.credentials) {
+      auth = new GoogleAuth({credentials: options.credentials});
+    }
   }
 
   /**

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 import {Bucket, ExporterConfig} from '@opencensus/core';
-import {JWT} from 'google-auth-library';
+import {JWT, JWTInput} from 'google-auth-library';
 
 export type Span = {
   name?: string,
@@ -151,6 +151,11 @@ export interface StackdriverExporterOptions extends ExporterConfig {
    * of a stackdriver metric. Optional
    */
   prefix?: string;
+  /**
+   * Create a JWT instance using the given credentials input containing
+   * client_email and private_key properties. Optional
+   */
+  credentials?: JWTInput;
 
   /**
    * Is called whenever the exporter fails to upload metrics to stackdriver.

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -152,8 +152,8 @@ export interface StackdriverExporterOptions extends ExporterConfig {
    */
   prefix?: string;
   /**
-   * Create a JWT instance using the given credentials input containing
-   * client_email and private_key properties. Optional
+   * If this field is set, its contents will be used for authentication
+   * instead of your application default credentials. Optional
    */
   credentials?: JWTInput;
 


### PR DESCRIPTION
To fix https://github.com/census-instrumentation/opencensus-node/issues/537

This PR enables us to set the Stackdriver's credentials from the environment variables instead of ADC. c.f. https://cloud.google.com/docs/authentication/production
It's ok to use `GOOGLE_APPLICATION_CREDENTIALS` as before or use the `credentials` option passing to the `StackdriverTraceExporter / StackdriverStatsExporter` constructor.

```ts
import { StackdriverTraceExporter } from "@opencensus/exporter-stackdriver";

// load the environment variable with keys encoded with Base64
const jsonContent = Buffer.from(process.env.CREDENTIALS_BASE64, "base64").toString();
const credentials = JSON.parse(jsonContent);

const exporter = StackdriverTraceExporter({
  projectId: "project-id",
  credentails: credentials,
});
```