### PR TITLE
Trace Context Propagation: return null instead of empty spancontext

### DIFF
--- a/packages/opencensus-propagation-tracecontext/src/tracecontext-format.ts
+++ b/packages/opencensus-propagation-tracecontext/src/tracecontext-format.ts
@@ -35,11 +35,9 @@ function traceParentToSpanContext(traceParent: string): SpanContext|null {
   const match = traceParent.match(TRACE_PARENT_REGEX);
   if (!match) return null;
   const parts = traceParent.split('-');
-  const version = parts[0];
-  const traceId = parts[1];
-  const spanId = parts[2];
+  const [version, traceId, spanId, option] = parts;
   // tslint:disable-next-line:ban Needed to parse hexadecimal.
-  const options = parseInt(parts[3], 16);
+  const options = parseInt(option, 16);
 
   if (!isValidVersion(version) || !isValidTraceId(traceId) ||
       !isValidSpanId(spanId)) {
@@ -50,10 +48,7 @@ function traceParentToSpanContext(traceParent: string): SpanContext|null {
 
 /** Converts a headers type to a string. */
 function parseHeader(str: string|string[]|undefined): string|undefined {
-  if (Array.isArray(str)) {
-    return str[0];
-  }
-  return str;
+  return Array.isArray(str) ? str[0] : str;
 }
 
 /**

--- a/packages/opencensus-propagation-tracecontext/test/test-tracecontext-format.ts
+++ b/packages/opencensus-propagation-tracecontext/test/test-tracecontext-format.ts
@@ -16,7 +16,6 @@
 
 import {HeaderGetter, HeaderSetter, SpanContext} from '@opencensus/core';
 import * as assert from 'assert';
-
 import {DEFAULT_OPTIONS, TRACE_PARENT, TRACE_STATE, TraceContextFormat} from '../src/';
 
 const traceContextFormat = new TraceContextFormat();
@@ -24,17 +23,6 @@ const traceContextFormat = new TraceContextFormat();
 type Headers = Record<string, string|string[]>;
 
 describe('TraceContextPropagation', () => {
-  let emptySpanContext: SpanContext;
-
-  beforeEach(() => {
-    emptySpanContext = {
-      traceId: '',
-      spanId: '',
-      options: DEFAULT_OPTIONS,
-      traceState: undefined
-    };
-  });
-
   // Generates the appropriate `traceparent` header for the given SpanContext
   const traceParentHeaderFromSpanContext =
       (spanContext: SpanContext): string => {
@@ -69,7 +57,6 @@ describe('TraceContextPropagation', () => {
 
     it('should gracefully handle multiple traceparent headers', () => {
       const firstContext = traceContextFormat.generate();
-      firstContext.traceState = undefined;
 
       const headers: Headers = {};
       headers[TRACE_PARENT] = [
@@ -140,12 +127,8 @@ describe('TraceContextPropagation', () => {
           }
         };
 
-        const shouldReceiveSpanContext = {...emptySpanContext, traceState: ''};
-
         const extractedSpanContext = traceContextFormat.extract(getter);
-
-        assert.deepEqual(
-            extractedSpanContext, shouldReceiveSpanContext, testCase);
+        assert.deepEqual(extractedSpanContext, null, testCase);
       });
     });
 
@@ -206,7 +189,7 @@ describe('TraceContextPropagation', () => {
       };
 
       const extractedSpanContext = traceContextFormat.extract(getter);
-      assert.deepEqual(extractedSpanContext, emptySpanContext);
+      assert.deepEqual(extractedSpanContext, null);
     });
   });
 
@@ -230,8 +213,12 @@ describe('TraceContextPropagation', () => {
     });
 
     it('should inject a tracestate header', () => {
-      const spanContext:
-          SpanContext = {...emptySpanContext, traceState: 'foo=bar'};
+      const spanContext: SpanContext = {
+        traceId: '',
+        spanId: '',
+        options: DEFAULT_OPTIONS,
+        traceState: 'foo=bar'
+      };
       const headers: Headers = {};
       const setter: HeaderSetter = {
         setHeader(name: string, value: string) {


### PR DESCRIPTION
Fixes #546 

This PR contains the following changes:
1. Get rid of superfluous falseness checks in Trace Context Propagation.
2. If there is no trace context in the headers, or if the parsed `TraceId` or `SpanId` is invalid, return null instead of empty `SpanContext` object.

These changes have all been tested locally and been confirmed to be working.