### PR TITLE
Replace assert.equal with assert.strictEqual

### DIFF
--- a/packages/opencensus-core/test/test-binary-serializer.ts
+++ b/packages/opencensus-core/test/test-binary-serializer.ts
@@ -109,7 +109,7 @@ describe('Binary Format Serializer', () => {
         0x02, 0x76, 0x32
       ]);
       const tags = deserializeBinary(buff);
-      assert.equal(tags.tags.size, 1);
+      assert.strictEqual(tags.tags.size, 1);
       assert.deepStrictEqual(tags, expectedTags);
     });
   });

--- a/packages/opencensus-core/test/test-console-logger.ts
+++ b/packages/opencensus-core/test/test-console-logger.ts
@@ -36,7 +36,7 @@ describe('ConsoleLogger', () => {
   describe('new ConsoleLogger()', () => {
     it('should log with default levels', () => {
       logger.logger();
-      assert.equal(LEVELS.length, ConsoleLogger.LEVELS.length);
+      assert.strictEqual(LEVELS.length, ConsoleLogger.LEVELS.length);
     });
 
     it('should log with error', () => {
@@ -65,7 +65,7 @@ describe('ConsoleLogger', () => {
 
       const validateString = consoleTxt.indexOf('warn');
 
-      assert.equal(validateString, -1);
+      assert.strictEqual(validateString, -1);
     });
 
     it('should not log info', () => {
@@ -75,7 +75,7 @@ describe('ConsoleLogger', () => {
 
       const validateString = consoleTxt.indexOf('info');
 
-      assert.equal(validateString, -1);
+      assert.strictEqual(validateString, -1);
     });
 
     it('should not log debug', () => {
@@ -84,7 +84,7 @@ describe('ConsoleLogger', () => {
       unhookIntercept();
       const validateString = consoleTxt.indexOf('debug');
 
-      assert.equal(validateString, -1);
+      assert.strictEqual(validateString, -1);
     });
   });
 
@@ -98,7 +98,7 @@ describe('ConsoleLogger', () => {
       unhookIntercept();
       const validateString = consoleTxt.indexOf('error');
 
-      assert.equal(validateString, -1);
+      assert.strictEqual(validateString, -1);
     });
 
     it('should not log warn', () => {
@@ -108,7 +108,7 @@ describe('ConsoleLogger', () => {
 
       const validateString = consoleTxt.indexOf('warn');
 
-      assert.equal(validateString, -1);
+      assert.strictEqual(validateString, -1);
     });
 
     it('should not log info', () => {
@@ -118,7 +118,7 @@ describe('ConsoleLogger', () => {
 
       const validateString = consoleTxt.indexOf('info');
 
-      assert.equal(validateString, -1);
+      assert.strictEqual(validateString, -1);
     });
 
     it('should not log debug', () => {
@@ -127,7 +127,7 @@ describe('ConsoleLogger', () => {
       unhookIntercept();
       const validateString = consoleTxt.indexOf('debug');
 
-      assert.equal(validateString, -1);
+      assert.strictEqual(validateString, -1);
     });
   });
 });

--- a/packages/opencensus-core/test/test-cumulative.ts
+++ b/packages/opencensus-core/test/test-cumulative.ts
@@ -73,7 +73,7 @@ describe('CUMULATIVE', () => {
 
       let metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 1, timestamp: mockedTime}],
@@ -86,7 +86,7 @@ describe('CUMULATIVE', () => {
       point1.inc();
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -136,7 +136,7 @@ describe('CUMULATIVE', () => {
       point.inc();
       const metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 1, timestamp: mockedTime}],
@@ -149,7 +149,7 @@ describe('CUMULATIVE', () => {
       point.inc(10);
       let metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 10, timestamp: mockedTime}],
@@ -160,7 +160,7 @@ describe('CUMULATIVE', () => {
       point1.inc(30);
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 40, timestamp: mockedTime}],
@@ -181,7 +181,7 @@ describe('CUMULATIVE', () => {
 
       const metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
@@ -202,7 +202,7 @@ describe('CUMULATIVE', () => {
           instance.getOrCreateTimeSeries([{value: '400'}, {value: '200'}]);
       point1.inc(400);
       const metric = instance.getMetric();
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
     });
 
     it('should add constant labels', () => {
@@ -214,8 +214,8 @@ describe('CUMULATIVE', () => {
           instance.getOrCreateTimeSeries([{value: '200'}, {value: '400'}]);
       point.inc(200);
       const metric = instance.getMetric();
-      assert.equal(metric!.descriptor.type, 5);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.descriptor.type, 5);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.descriptor.labelKeys, [
         {key: 'k1', description: 'desc'}, {key: 'k2', description: 'desc'},
         {key: 'host', description: 'host'}
@@ -241,7 +241,7 @@ describe('CUMULATIVE', () => {
       const metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor.labelKeys.length, 3);
       assert.deepStrictEqual(metric!.descriptor.type, 5);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues:
@@ -256,7 +256,7 @@ describe('CUMULATIVE', () => {
       point.inc(300);
       let metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: [UNSET_LABEL_VALUE],
                                points: [{value: 300, timestamp: mockedTime}],
@@ -267,7 +267,7 @@ describe('CUMULATIVE', () => {
       point1.inc(400);
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: [UNSET_LABEL_VALUE],
                                points: [{value: 700, timestamp: mockedTime}],
@@ -296,7 +296,7 @@ describe('CUMULATIVE', () => {
       point1.inc(10);
       let metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       instance.clear();
       metric = instance.getMetric();
       assert.deepStrictEqual(metric, null);

--- a/packages/opencensus-core/test/test-derived-cumulative.ts
+++ b/packages/opencensus-core/test/test-derived-cumulative.ts
@@ -81,7 +81,7 @@ describe('DerivedCumulative', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 2, timestamp: mockedTime}],
@@ -99,7 +99,7 @@ describe('DerivedCumulative', () => {
 
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -125,7 +125,7 @@ describe('DerivedCumulative', () => {
       const metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 45, timestamp: mockedTime}],
@@ -152,7 +152,7 @@ describe('DerivedCumulative', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 1, timestamp: mockedTime}],
@@ -163,7 +163,7 @@ describe('DerivedCumulative', () => {
       queue.addJob();
       queue.addJob();
       metric = instance.getMetric();
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries[0].points, [{value: 4, timestamp: mockedTime}]);
     });
@@ -188,7 +188,7 @@ describe('DerivedCumulative', () => {
         type: CUMULATIVE_DOUBLE,
         labelKeys: LABEL_KEYS
       });
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 0.7, timestamp: mockedTime}],
@@ -203,7 +203,7 @@ describe('DerivedCumulative', () => {
       map.set('key1', 'value1');
       let metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 2, timestamp: mockedTime}],
@@ -212,7 +212,7 @@ describe('DerivedCumulative', () => {
 
       map.clear();
       metric = instance.getMetric();
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 2, timestamp: mockedTime}],
@@ -227,7 +227,7 @@ describe('DerivedCumulative', () => {
       const metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [{
                                labelValues: LABEL_VALUES_200,
                                points: [{value: 1, timestamp: mockedTime}],
@@ -271,7 +271,7 @@ describe('DerivedCumulative', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       instance.clear();
       metric = instance.getMetric();
       assert.deepStrictEqual(metric, null);

--- a/packages/opencensus-core/test/test-derived-gauge.ts
+++ b/packages/opencensus-core/test/test-derived-gauge.ts
@@ -79,7 +79,7 @@ describe('DerivedGauge', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -101,7 +101,7 @@ describe('DerivedGauge', () => {
 
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -132,7 +132,7 @@ describe('DerivedGauge', () => {
       const metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -163,7 +163,7 @@ describe('DerivedGauge', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -178,7 +178,7 @@ describe('DerivedGauge', () => {
       queue.addJob();
       queue.addJob();
       metric = instance.getMetric();
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries[0].points, [{
             value: 4,
@@ -207,7 +207,7 @@ describe('DerivedGauge', () => {
         type: GAUGE_DOUBLE,
         labelKeys: LABEL_KEYS
       });
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -239,7 +239,7 @@ describe('DerivedGauge', () => {
         type: GAUGE_DOUBLE,
         labelKeys: [...LABEL_KEYS, ...Array.from(CONSTANT_LABELS.keys())]
       });
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues:
@@ -259,7 +259,7 @@ describe('DerivedGauge', () => {
       const metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -305,7 +305,7 @@ describe('DerivedGauge', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       instance.clear();
       metric = instance.getMetric();
       assert.deepStrictEqual(metric, null);

--- a/packages/opencensus-core/test/test-gauge.ts
+++ b/packages/opencensus-core/test/test-gauge.ts
@@ -81,7 +81,7 @@ describe('GAUGE_INT64', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -98,7 +98,7 @@ describe('GAUGE_INT64', () => {
       point1.set(-8);
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -124,7 +124,7 @@ describe('GAUGE_INT64', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -139,7 +139,7 @@ describe('GAUGE_INT64', () => {
       point1.add(30);
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: LABEL_VALUES_200,
@@ -158,7 +158,7 @@ describe('GAUGE_INT64', () => {
       const metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
@@ -181,7 +181,7 @@ describe('GAUGE_INT64', () => {
           instance.getOrCreateTimeSeries([{value: '400'}, {value: '200'}]);
       point1.add(400);
       const metric = instance.getMetric();
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
     });
 
     it('should add constant labels', () => {
@@ -193,7 +193,7 @@ describe('GAUGE_INT64', () => {
           instance.getOrCreateTimeSeries([{value: '200'}, {value: '400'}]);
       point.add(200);
       const metric = instance.getMetric();
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.descriptor.labelKeys, [
         {key: 'k1', description: 'desc'}, {key: 'k2', description: 'desc'},
         {key: 'host', description: 'host'}
@@ -223,7 +223,7 @@ describe('GAUGE_INT64', () => {
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor.labelKeys.length, 3);
       assert.deepStrictEqual(metric!.descriptor.type, 1);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues:
@@ -241,7 +241,7 @@ describe('GAUGE_INT64', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
@@ -257,7 +257,7 @@ describe('GAUGE_INT64', () => {
       metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(
           metric!.timeseries, [{
             labelValues: [UNSET_LABEL_VALUE],
@@ -290,7 +290,7 @@ describe('GAUGE_INT64', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       instance.clear();
       metric = instance.getMetric();
       assert.deepStrictEqual(metric, null);
@@ -343,7 +343,7 @@ describe('GAUGE_DOUBLE', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -358,7 +358,7 @@ describe('GAUGE_DOUBLE', () => {
       const point1 = instance.getOrCreateTimeSeries(LABEL_VALUES_400);
       point1.set(-8.3);
       metric = instance.getMetric();
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -384,7 +384,7 @@ describe('GAUGE_DOUBLE', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -399,7 +399,7 @@ describe('GAUGE_DOUBLE', () => {
       point1.add(30.18);
       metric = instance.getMetric();
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: LABEL_VALUES_200,
@@ -418,7 +418,7 @@ describe('GAUGE_DOUBLE', () => {
       const metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: [UNSET_LABEL_VALUE],
@@ -435,7 +435,7 @@ describe('GAUGE_DOUBLE', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: [UNSET_LABEL_VALUE],
@@ -451,7 +451,7 @@ describe('GAUGE_DOUBLE', () => {
       metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues: [UNSET_LABEL_VALUE],
@@ -476,7 +476,7 @@ describe('GAUGE_DOUBLE', () => {
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor.labelKeys.length, 3);
       assert.deepStrictEqual(metric!.descriptor.type, 2);
-      assert.equal(metric!.timeseries.length, 1);
+      assert.strictEqual(metric!.timeseries.length, 1);
       assert.deepStrictEqual(metric!.timeseries, [
         {
           labelValues:
@@ -510,7 +510,7 @@ describe('GAUGE_DOUBLE', () => {
       let metric = instance.getMetric();
       assert.notEqual(metric, null);
       assert.deepStrictEqual(metric!.descriptor, expectedMetricDescriptor);
-      assert.equal(metric!.timeseries.length, 2);
+      assert.strictEqual(metric!.timeseries.length, 2);
       instance.clear();
       metric = instance.getMetric();
       assert.deepStrictEqual(metric, null);

--- a/packages/opencensus-core/test/test-metric-component.ts
+++ b/packages/opencensus-core/test/test-metric-component.ts
@@ -32,7 +32,8 @@ describe('MetricsComponent()', () => {
   });
 
   it('should register metricRegistry to MetricProducerManger', () => {
-    assert.equal(metricProducerManagerInstance.getAllMetricProducer().size, 1);
+    assert.strictEqual(
+        metricProducerManagerInstance.getAllMetricProducer().size, 1);
     assert.ok(metricProducerManagerInstance.getAllMetricProducer().has(
         metricsComponent.getMetricRegistry().getMetricProducer()));
   });

--- a/packages/opencensus-core/test/test-metric-producer-manager.ts
+++ b/packages/opencensus-core/test/test-metric-producer-manager.ts
@@ -35,7 +35,7 @@ describe('MetricProducerManager()', () => {
           metricProducerManagerInstance.getAllMetricProducer();
 
       assert.notDeepEqual(metricProducerList, null);
-      assert.equal(metricProducerList.size, 1);
+      assert.strictEqual(metricProducerList.size, 1);
     });
 
     it('should not add same metricproducer metricProducerManagerInstance',
@@ -46,7 +46,7 @@ describe('MetricProducerManager()', () => {
          const metricProducerList =
              metricProducerManagerInstance.getAllMetricProducer();
 
-         assert.equal(metricProducerList.size, 1);
+         assert.strictEqual(metricProducerList.size, 1);
          assert.ok(metricProducerList.has(metricProducer));
        });
 
@@ -57,7 +57,7 @@ describe('MetricProducerManager()', () => {
          const metricProducerList =
              metricProducerManagerInstance.getAllMetricProducer();
 
-         assert.equal(metricProducerList.size, 2);
+         assert.strictEqual(metricProducerList.size, 2);
          assert.ok(metricProducerList.has(metricProducer));
          assert.ok(metricProducerList.has(metricProducerOther));
        });
@@ -69,11 +69,11 @@ describe('MetricProducerManager()', () => {
 
       const metricProducerList =
           metricProducerManagerInstance.getAllMetricProducer();
-      assert.equal(metricProducerList.size, 1);
+      assert.strictEqual(metricProducerList.size, 1);
       assert.ok(metricProducerList.has(metricProducer));
 
       metricProducerManagerInstance.remove(metricProducer);
-      assert.equal(metricProducerList.size, 0);
+      assert.strictEqual(metricProducerList.size, 0);
     });
   });
 });

--- a/packages/opencensus-core/test/test-metric-producer.ts
+++ b/packages/opencensus-core/test/test-metric-producer.ts
@@ -90,7 +90,7 @@ describe('Metric producer for stats', () => {
     assert.deepStrictEqual(actualMetricDescriptor1, expectedMetricDescriptor1);
     assert.strictEqual(actualTimeSeries1.length, 1);
     assert.deepStrictEqual(actualTimeSeries1[0].labelValues, labelValues);
-    assert.equal(actualTimeSeries1[0].points[0].value, 25);
+    assert.strictEqual(actualTimeSeries1[0].points[0].value, 25);
   });
 
   it('should add count stats',
@@ -112,12 +112,12 @@ describe('Metric producer for stats', () => {
            actualMetricDescriptor1, expectedMetricDescriptor1);
        assert.strictEqual(actualTimeSeries1.length, 1);
        assert.deepStrictEqual(actualTimeSeries1[0].labelValues, labelValues);
-       assert.equal(actualTimeSeries1[0].points[0].value, 25);
+       assert.strictEqual(actualTimeSeries1[0].points[0].value, 25);
        assert.deepStrictEqual(
            actualMetricDescriptor2, expectedMetricDescriptor2);
        assert.strictEqual(actualTimeSeries2.length, 1);
        assert.deepStrictEqual(actualTimeSeries2[0].labelValues, labelValues);
-       assert.equal(actualTimeSeries2[0].points[0].value, 1);
+       assert.strictEqual(actualTimeSeries2[0].points[0].value, 1);
 
        // update count view
        view.recordMeasurement(measurement2, tagMap);
@@ -145,13 +145,13 @@ describe('Metric producer for stats', () => {
     assert.strictEqual(actualTimeSeries1.length, 1);
     assert.strictEqual(actualTimeSeries1.length, 1);
     assert.deepStrictEqual(actualTimeSeries1[0].labelValues, labelValues);
-    assert.equal(actualTimeSeries1[0].points[0].value, 25);
+    assert.strictEqual(actualTimeSeries1[0].points[0].value, 25);
     assert.deepStrictEqual(actualMetricDescriptor2, expectedMetricDescriptor2);
     assert.strictEqual(actualTimeSeries2.length, 1);
     assert.deepStrictEqual(actualMetricDescriptor3, expectedMetricDescriptor3);
     assert.strictEqual(actualTimeSeries3.length, 1);
     assert.deepStrictEqual(actualTimeSeries3[0].labelValues, labelValues);
-    assert.equal(actualTimeSeries3[0].points[0].value, 300);
+    assert.strictEqual(actualTimeSeries3[0].points[0].value, 300);
   });
 
   it('should add distribution stats', () => {
@@ -178,13 +178,13 @@ describe('Metric producer for stats', () => {
     assert.deepStrictEqual(actualMetricDescriptor1, expectedMetricDescriptor1);
     assert.strictEqual(actualTimeSeries1.length, 1);
     assert.deepStrictEqual(actualTimeSeries1[0].labelValues, labelValues);
-    assert.equal(actualTimeSeries1[0].points[0].value, 25);
+    assert.strictEqual(actualTimeSeries1[0].points[0].value, 25);
     assert.deepStrictEqual(actualMetricDescriptor2, expectedMetricDescriptor2);
     assert.strictEqual(actualTimeSeries2.length, 1);
     assert.deepStrictEqual(actualMetricDescriptor3, expectedMetricDescriptor3);
     assert.strictEqual(actualTimeSeries3.length, 1);
     assert.deepStrictEqual(actualTimeSeries3[0].labelValues, labelValues);
-    assert.equal(actualTimeSeries3[0].points[0].value, 300);
+    assert.strictEqual(actualTimeSeries3[0].points[0].value, 300);
     assert.deepStrictEqual(actualMetricDescriptor4, expectedMetricDescriptor4);
     assert.strictEqual(actualTimeSeries4.length, 1);
     assert.deepStrictEqual(actualTimeSeries4[0].labelValues, labelValues);

--- a/packages/opencensus-core/test/test-metric-registry.ts
+++ b/packages/opencensus-core/test/test-metric-registry.ts
@@ -73,7 +73,7 @@ describe('addInt64Gauge', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 100);
+    assert.strictEqual(point.value, 100);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -97,7 +97,7 @@ describe('addInt64Gauge', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 100);
+    assert.strictEqual(point.value, 100);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -157,7 +157,7 @@ describe('addDoubleGauge', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 0.7);
+    assert.strictEqual(point.value, 0.7);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -202,7 +202,7 @@ describe('addDoubleGauge', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 5.5);
+    assert.strictEqual(point.value, 5.5);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -252,7 +252,7 @@ describe('addDerivedInt64Gauge', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 2);
+    assert.strictEqual(point.value, 2);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -304,7 +304,7 @@ describe('addDerivedInt64Gauge', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 2);
+    assert.strictEqual(point.value, 2);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -356,7 +356,7 @@ describe('addDerivedDoubleGauge', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 0.7);
+    assert.strictEqual(point.value, 0.7);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -410,7 +410,7 @@ describe('addInt64Cumulative', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 1);
+    assert.strictEqual(point.value, 1);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -434,7 +434,7 @@ describe('addInt64Cumulative', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 100);
+    assert.strictEqual(point.value, 100);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -492,7 +492,7 @@ describe('addDoubleCumulative', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 1.1);
+    assert.strictEqual(point.value, 1.1);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -517,7 +517,7 @@ describe('addDoubleCumulative', () => {
     assert.strictEqual(timeseries.length, 1);
     const [{points}] = timeseries;
     const [point] = points;
-    assert.equal(point.value, 101.12);
+    assert.strictEqual(point.value, 101.12);
     assert.deepStrictEqual(
         point.timestamp,
         {seconds: mockedTime.seconds, nanos: mockedTime.nanos});
@@ -824,22 +824,23 @@ describe('Add multiple gauges', () => {
     });
     assert.strictEqual(timeseries1.length, 1);
     assert.strictEqual(timeseries1[0].points.length, 1);
-    assert.equal(timeseries1[0].points[0].value, 100);
-    assert.equal(
+    assert.strictEqual(timeseries1[0].points[0].value, 100);
+    assert.strictEqual(
         timeseries1[0].points[0].timestamp.seconds, mockedTime.seconds);
-    assert.equal(timeseries1[0].points[0].timestamp.nanos, mockedTime.nanos);
+    assert.strictEqual(
+        timeseries1[0].points[0].timestamp.nanos, mockedTime.nanos);
     assert.strictEqual(timeseries2.length, 1);
     assert.strictEqual(timeseries2[0].points.length, 1);
-    assert.equal(timeseries2[0].points[0].value, 5.5);
+    assert.strictEqual(timeseries2[0].points[0].value, 5.5);
     assert.strictEqual(timeseries3.length, 1);
     assert.strictEqual(timeseries3[0].points.length, 1);
-    assert.equal(timeseries3[0].points[0].value, 5);
+    assert.strictEqual(timeseries3[0].points[0].value, 5);
     assert.deepStrictEqual(
         timeseries1[0].points[0].timestamp, timeseries2[0].points[0].timestamp);
     assert.deepStrictEqual(
         timeseries2[0].points[0].timestamp, timeseries3[0].points[0].timestamp);
     assert.strictEqual(timeseries4.length, 1);
     assert.strictEqual(timeseries4[0].points.length, 1);
-    assert.equal(timeseries4[0].points[0].value, 1);
+    assert.strictEqual(timeseries4[0].points[0].value, 1);
   });
 });

--- a/packages/opencensus-core/test/test-no-record-root-span.ts
+++ b/packages/opencensus-core/test/test-no-record-root-span.ts
@@ -33,6 +33,6 @@ describe('NoRecordRootSpan()', () => {
     noRecordRootSpan.addAttribute('my_first_attribute', 'foo');
     noRecordRootSpan.setStatus(CanonicalCode.OK);
     noRecordRootSpan.startChildSpan();
-    assert.equal(noRecordRootSpan.traceState, undefined);
+    assert.strictEqual(noRecordRootSpan.traceState, undefined);
   });
 });

--- a/packages/opencensus-core/test/test-no-record-span.ts
+++ b/packages/opencensus-core/test/test-no-record-span.ts
@@ -29,6 +29,6 @@ describe('NoRecordSpan()', () => {
     noRecordSpan.addMessageEvent(MessageEventType.RECEIVED, 1, 123456789);
     noRecordSpan.addAttribute('my_first_attribute', 'foo');
     noRecordSpan.setStatus(CanonicalCode.OK);
-    assert.equal(noRecordSpan.traceState, undefined);
+    assert.strictEqual(noRecordSpan.traceState, undefined);
   });
 });

--- a/packages/opencensus-core/test/test-recorder.ts
+++ b/packages/opencensus-core/test/test-recorder.ts
@@ -199,8 +199,8 @@ describe('Recorder', () => {
             Recorder.addMeasurement(
                 distributionData, measurement, attachments) as DistributionData;
 
-        assert.equal(aggregationData.sum, 5);
-        assert.equal(aggregationData.mean, 5);
+        assert.strictEqual(aggregationData.sum, 5);
+        assert.strictEqual(aggregationData.mean, 5);
         assert.deepStrictEqual(aggregationData.buckets, [2, 4, 6]);
         assert.deepStrictEqual(aggregationData.bucketCounts, [0, 0, 1, 0]);
         assert.deepStrictEqual(aggregationData.exemplars![0], undefined);
@@ -232,7 +232,7 @@ describe('Recorder', () => {
         tagMap.set(CALLER, CALLER_V);
         tagMap.set(METHOD, METHOD_V);
         const tagValues = Recorder.getTagValues(tagMap.tags, columns);
-        assert.equal(tagValues.length, 2);
+        assert.strictEqual(tagValues.length, 2);
         assert.deepStrictEqual(tagValues, [CALLER_V, METHOD_V]);
       });
 
@@ -242,7 +242,7 @@ describe('Recorder', () => {
            tagMap.set(CALLER, CALLER_V, NO_PROPAGATION_MD);
            tagMap.set(METHOD, METHOD_V, UNLIMITED_PROPAGATION_MD);
            const tagValues = Recorder.getTagValues(tagMap.tags, columns);
-           assert.equal(tagValues.length, 2);
+           assert.strictEqual(tagValues.length, 2);
            assert.deepStrictEqual(tagValues, [CALLER_V, METHOD_V]);
          });
 
@@ -252,7 +252,7 @@ describe('Recorder', () => {
            tagMap.set(CALLER, CALLER_V);
            tagMap.set(METHOD, METHOD_V);
            const tagValues = Recorder.getTagValues(tagMap.tags, columns);
-           assert.equal(tagValues.length, 3);
+           assert.strictEqual(tagValues.length, 3);
            assert.deepStrictEqual(tagValues, [CALLER_V, METHOD_V, null]);
          });
 
@@ -263,7 +263,7 @@ describe('Recorder', () => {
            tagMap.set(METHOD, METHOD_V);
            tagMap.set(ORIGINATOR, ORIGINATOR_V);
            const tagValues = Recorder.getTagValues(tagMap.tags, columns);
-           assert.equal(tagValues.length, 2);
+           assert.strictEqual(tagValues.length, 2);
            assert.deepStrictEqual(tagValues, [CALLER_V, METHOD_V]);
          });
     });

--- a/packages/opencensus-core/test/test-resource.ts
+++ b/packages/opencensus-core/test/test-resource.ts
@@ -42,7 +42,7 @@ describe('Resource()', () => {
     };
 
     assert.strictEqual(resource.type, 'k8s.io/container');
-    assert.equal(Object.keys(actualLabels).length, 3);
+    assert.strictEqual(Object.keys(actualLabels).length, 3);
     assert.deepEqual(actualLabels, expectedLabels);
   });
 });
@@ -59,8 +59,8 @@ describe('mergeResources()', () => {
     const resource = CoreResource.mergeResources(resources);
     const expectedLabels: Labels = {'a': '1', 'b': '2'};
 
-    assert.equal(resource.type, 't1');
-    assert.equal(Object.keys(resource.labels).length, 2);
+    assert.strictEqual(resource.type, 't1');
+    assert.strictEqual(Object.keys(resource.labels).length, 2);
     assert.deepEqual(resource.labels, expectedLabels);
   });
 
@@ -70,8 +70,8 @@ describe('mergeResources()', () => {
     const resource = CoreResource.mergeResources(resources);
     const expectedLabels: Labels = {'a': '1', 'b': '2'};
 
-    assert.equal(resource.type, 't1');
-    assert.equal(Object.keys(resource.labels).length, 2);
+    assert.strictEqual(resource.type, 't1');
+    assert.strictEqual(Object.keys(resource.labels).length, 2);
     assert.deepEqual(resource.labels, expectedLabels);
   });
 
@@ -81,8 +81,8 @@ describe('mergeResources()', () => {
     const resource = CoreResource.mergeResources(resources);
     const expectedLabels: Labels = {'a': '1', 'b': '3', 'c': '4'};
 
-    assert.equal(resource.type, 't2');
-    assert.equal(Object.keys(resource.labels).length, 3);
+    assert.strictEqual(resource.type, 't2');
+    assert.strictEqual(Object.keys(resource.labels).length, 3);
     assert.deepEqual(resource.labels, expectedLabels);
   });
 
@@ -91,8 +91,8 @@ describe('mergeResources()', () => {
     const resource = CoreResource.mergeResources(resources);
     const expectedLabels: Labels = {'a': '100', 'b': '2', 'c': '4'};
 
-    assert.equal(resource.type, 'default');
-    assert.equal(Object.keys(resource.labels).length, 3);
+    assert.strictEqual(resource.type, 'default');
+    assert.strictEqual(Object.keys(resource.labels).length, 3);
     assert.deepEqual(resource.labels, expectedLabels);
   });
 });

--- a/packages/opencensus-core/test/test-root-span.ts
+++ b/packages/opencensus-core/test/test-root-span.ts
@@ -65,15 +65,15 @@ describe('RootSpan', () => {
     it('should get numberOfChildren from rootspan instance', () => {
       const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
-      assert.equal(root.numberOfChildren, 0);
+      assert.strictEqual(root.numberOfChildren, 0);
       root.startChildSpan({name: 'spanName', kind: types.SpanKind.UNSPECIFIED});
-      assert.equal(root.numberOfChildren, 1);
+      assert.strictEqual(root.numberOfChildren, 1);
 
       for (let i = 0; i < 10; i++) {
         root.startChildSpan(
             {name: 'spanName' + i, kind: types.SpanKind.UNSPECIFIED});
       }
-      assert.equal(root.numberOfChildren, 11);
+      assert.strictEqual(root.numberOfChildren, 11);
     });
   });
 
@@ -81,35 +81,35 @@ describe('RootSpan', () => {
     it('should get nested spans from rootspan instance', () => {
       const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
-      assert.equal(root.numberOfChildren, 0);
+      assert.strictEqual(root.numberOfChildren, 0);
       const child1 = root.startChildSpan(
           {name: 'child1', kind: types.SpanKind.UNSPECIFIED});
-      assert.equal(root.numberOfChildren, 1);
-      assert.equal(child1.numberOfChildren, 0);
+      assert.strictEqual(root.numberOfChildren, 1);
+      assert.strictEqual(child1.numberOfChildren, 0);
       const child2 = root.startChildSpan(
           {name: 'child2', kind: types.SpanKind.UNSPECIFIED});
-      assert.equal(root.numberOfChildren, 2);
+      assert.strictEqual(root.numberOfChildren, 2);
       const grandchild1 = child1.startChildSpan({
         name: 'grandchild1',
         kind: types.SpanKind.UNSPECIFIED,
       });
-      assert.equal(root.numberOfChildren, 2);
-      assert.equal(child1.numberOfChildren, 1);
-      assert.equal(child2.numberOfChildren, 0);
-      assert.equal(grandchild1.numberOfChildren, 0);
+      assert.strictEqual(root.numberOfChildren, 2);
+      assert.strictEqual(child1.numberOfChildren, 1);
+      assert.strictEqual(child2.numberOfChildren, 0);
+      assert.strictEqual(grandchild1.numberOfChildren, 0);
 
-      assert.equal(root.spans.length, 2);
-      assert.equal(child1, root.spans[0]);
-      assert.equal(child2, root.spans[1]);
-      assert.equal(grandchild1.parentSpanId, child1.id);
+      assert.strictEqual(root.spans.length, 2);
+      assert.strictEqual(child1, root.spans[0]);
+      assert.strictEqual(child2, root.spans[1]);
+      assert.strictEqual(grandchild1.parentSpanId, child1.id);
 
-      assert.equal(child1.spans.length, 1);
-      assert.equal(grandchild1, child1.spans[0]);
+      assert.strictEqual(child1.spans.length, 1);
+      assert.strictEqual(grandchild1, child1.spans[0]);
 
-      assert.equal(child2.spans.length, 0);
-      assert.equal(grandchild1.spans.length, 0);
+      assert.strictEqual(child2.spans.length, 0);
+      assert.strictEqual(grandchild1.spans.length, 0);
 
-      assert.equal(root.allDescendants().length, 3);
+      assert.strictEqual(root.allDescendants().length, 3);
     });
   });
 
@@ -120,11 +120,11 @@ describe('RootSpan', () => {
     it('should get trace id from rootspan instance', () => {
       const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       root.start();
-      assert.equal(root.traceId, root.spanContext.traceId);
+      assert.strictEqual(root.traceId, root.spanContext.traceId);
 
       const child = root.startChildSpan(
           {name: 'child', kind: types.SpanKind.UNSPECIFIED});
-      assert.equal(root.traceId, child.traceId);
+      assert.strictEqual(root.traceId, child.traceId);
     });
   });
 
@@ -240,7 +240,7 @@ describe('RootSpan', () => {
 
       ['String', 'Number', 'Boolean'].map(attType => {
         rootSpan.addAttribute('testKey' + attType, 'testValue' + attType);
-        assert.equal(
+        assert.strictEqual(
             rootSpan.attributes['testKey' + attType], 'testValue' + attType);
       });
     });
@@ -273,8 +273,9 @@ describe('RootSpan', () => {
       rootSpan.addAnnotation('description test');
 
       assert.ok(rootSpan.annotations.length > 0);
-      assert.equal(rootSpan.droppedAnnotationsCount, 0);
-      assert.equal(rootSpan.annotations[0].description, 'description test');
+      assert.strictEqual(rootSpan.droppedAnnotationsCount, 0);
+      assert.strictEqual(
+          rootSpan.annotations[0].description, 'description test');
       assert.deepEqual(rootSpan.annotations[0].attributes, {});
       assert.ok(rootSpan.annotations[0].timestamp > 0);
     });
@@ -300,7 +301,7 @@ describe('RootSpan', () => {
           rootSpan.traceId, span.id, types.LinkType.CHILD_LINKED_SPAN);
 
       assert.ok(rootSpan.links.length > 0);
-      assert.equal(rootSpan.droppedLinksCount, 0);
+      assert.strictEqual(rootSpan.droppedLinksCount, 0);
       assert.ok(instanceOfLink(rootSpan.links[0]));
     });
   });
@@ -320,7 +321,7 @@ describe('RootSpan', () => {
       rootSpan.addMessageEvent(types.MessageEventType.UNSPECIFIED, 1);
 
       assert.ok(rootSpan.messageEvents.length > 0);
-      assert.equal(rootSpan.droppedMessageEventsCount, 0);
+      assert.strictEqual(rootSpan.droppedMessageEventsCount, 0);
       assert.ok(instanceOfLink(rootSpan.messageEvents[0]));
     });
   });
@@ -329,14 +330,14 @@ describe('RootSpan', () => {
     it('should handle optional / undefined traceState', () => {
       const root = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       assert.ok(root instanceof RootSpan);
-      assert.equal(root.traceState, undefined);
+      assert.strictEqual(root.traceState, undefined);
     });
 
     it('should create a RootSpan instance with traceState', () => {
       const root =
           new RootSpan(tracer, name, kind, traceId, parentSpanId, 'traceState');
       assert.ok(root instanceof RootSpan);
-      assert.equal(root.traceState, 'traceState');
+      assert.strictEqual(root.traceState, 'traceState');
     });
   });
 });

--- a/packages/opencensus-core/test/test-sampler.ts
+++ b/packages/opencensus-core/test/test-sampler.ts
@@ -111,7 +111,7 @@ describe('Sampler', () => {
   });
   describe('getNumberOfAnnotationEventsPerSpan', () => {
     it('should return  12', () => {
-      assert.equal(
+      assert.strictEqual(
           TraceParamsBuilder.getNumberOfAnnotationEventsPerSpan(
               traceParameters),
           12);
@@ -119,20 +119,20 @@ describe('Sampler', () => {
   });
   describe('getNumberOfMessageEventsPerSpan', () => {
     it('should return 5', () => {
-      assert.equal(
+      assert.strictEqual(
           TraceParamsBuilder.getNumberOfMessageEventsPerSpan(traceParameters),
           5);
     });
   });
   describe('getNumberOfAttributesPerSpan', () => {
     it('should return 10', () => {
-      assert.equal(
+      assert.strictEqual(
           TraceParamsBuilder.getNumberOfAttributesPerSpan(traceParameters), 10);
     });
   });
   describe('getNumberOfLinksPerSpan', () => {
     it('should return 7', () => {
-      assert.equal(
+      assert.strictEqual(
           TraceParamsBuilder.getNumberOfLinksPerSpan(traceParameters), 7);
     });
   });

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -57,7 +57,7 @@ describe('Span', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
       const span = new Span(tracer, rootSpan);
-      assert.equal(span.traceId, rootSpan.traceId);
+      assert.strictEqual(span.traceId, rootSpan.traceId);
     });
   });
 
@@ -72,9 +72,9 @@ describe('Span', () => {
       const span = new Span(tracer, rootSpan);
       const context = span.spanContext;
 
-      assert.equal(context.traceId, rootSpan.traceId);
-      assert.equal(context.spanId, span.id);
-      assert.equal(context.options, 1);
+      assert.strictEqual(context.traceId, rootSpan.traceId);
+      assert.strictEqual(context.spanId, span.id);
+      assert.strictEqual(context.options, 1);
     });
   });
 
@@ -127,7 +127,7 @@ describe('Span', () => {
       const initialStartTime = span.startTime;
       span.start();
 
-      assert.equal(span.startTime, initialStartTime);
+      assert.strictEqual(span.startTime, initialStartTime);
     });
   });
 
@@ -175,7 +175,7 @@ describe('Span', () => {
       const initialEndTime = span.endTime;
       span.end();
 
-      assert.equal(span.endTime!.getTime(), initialEndTime!.getTime());
+      assert.strictEqual(span.endTime!.getTime(), initialEndTime!.getTime());
     });
   });
 
@@ -192,13 +192,13 @@ describe('Span', () => {
 
       ['String', 'Number', 'Boolean'].map(attType => {
         span.addAttribute('testKey' + attType, 'testValue' + attType);
-        assert.equal(
+        assert.strictEqual(
             span.attributes['testKey' + attType], 'testValue' + attType);
       });
       span.addAttribute('object', {foo: 'bar'});
-      assert.equal(span.attributes['object'], '{"foo":"bar"}');
+      assert.strictEqual(span.attributes['object'], '{"foo":"bar"}');
       span.addAttribute('array', [1, 2, 3]);
-      assert.equal(span.attributes['array'], '[1,2,3]');
+      assert.strictEqual(span.attributes['array'], '[1,2,3]');
     });
 
     it('should drop extra attributes', () => {
@@ -211,8 +211,8 @@ describe('Span', () => {
         span.addAttribute('attr' + i, 100);
       }
 
-      assert.equal(Object.keys(span.attributes).length, 32);
-      assert.equal(span.droppedAttributesCount, 8);
+      assert.strictEqual(Object.keys(span.attributes).length, 32);
+      assert.strictEqual(span.droppedAttributesCount, 8);
     });
   });
 
@@ -236,7 +236,7 @@ describe('Span', () => {
       span.addAnnotation('description test', {}, Date.now());
 
       assert.ok(span.annotations.length > 0);
-      assert.equal(span.droppedAnnotationsCount, 0);
+      assert.strictEqual(span.droppedAnnotationsCount, 0);
       assert.ok(instanceOfAnnotation(span.annotations[0]));
     });
 
@@ -250,8 +250,8 @@ describe('Span', () => {
         span.addAnnotation('description test', {}, Date.now());
       }
 
-      assert.equal(span.annotations.length, 32);
-      assert.equal(span.droppedAnnotationsCount, 8);
+      assert.strictEqual(span.annotations.length, 32);
+      assert.strictEqual(span.droppedAnnotationsCount, 8);
     });
   });
 
@@ -275,7 +275,7 @@ describe('Span', () => {
           span.traceId, rootSpan.id, types.LinkType.PARENT_LINKED_SPAN);
 
       assert.ok(span.links.length > 0);
-      assert.equal(span.droppedLinksCount, 0);
+      assert.strictEqual(span.droppedLinksCount, 0);
       assert.ok(instanceOfLink(span.links[0]));
     });
 
@@ -290,8 +290,8 @@ describe('Span', () => {
             span.traceId, rootSpan.id, types.LinkType.PARENT_LINKED_SPAN);
       }
 
-      assert.equal(span.links.length, 32);
-      assert.equal(span.droppedLinksCount, 3);
+      assert.strictEqual(span.links.length, 32);
+      assert.strictEqual(span.droppedLinksCount, 3);
     });
   });
 
@@ -324,7 +324,7 @@ describe('Span', () => {
                          uncompressedSize: 55,
                          compressedSize: 40,
                        }]);
-      assert.equal(span.droppedMessageEventsCount, 0);
+      assert.strictEqual(span.droppedMessageEventsCount, 0);
       assert.ok(instanceOfLink(span.messageEvents[0]));
     });
 
@@ -338,8 +338,8 @@ describe('Span', () => {
         span.addMessageEvent(types.MessageEventType.UNSPECIFIED, 1);
       }
 
-      assert.equal(span.messageEvents.length, 32);
-      assert.equal(span.droppedMessageEventsCount, 3);
+      assert.strictEqual(span.messageEvents.length, 32);
+      assert.strictEqual(span.droppedMessageEventsCount, 3);
     });
   });
 
@@ -351,10 +351,10 @@ describe('Span', () => {
       const span = new Span(tracer, rootSpan);
       span.start();
 
-      assert.equal(rootSpan.status.code, 0);
-      assert.equal(rootSpan.status.message, null);
-      assert.equal(span.status.code, 0);
-      assert.equal(span.status.message, null);
+      assert.strictEqual(rootSpan.status.code, 0);
+      assert.strictEqual(rootSpan.status.message, undefined);
+      assert.strictEqual(span.status.code, 0);
+      assert.strictEqual(span.status.message, undefined);
     });
 
     it('should set an error status', () => {
@@ -364,10 +364,10 @@ describe('Span', () => {
       span.start();
       span.setStatus(types.CanonicalCode.PERMISSION_DENIED, 'This is an error');
 
-      assert.equal(rootSpan.status.code, 0);
-      assert.equal(rootSpan.status.message, null);
-      assert.equal(span.status.code, 7);
-      assert.equal(span.status.message, 'This is an error');
+      assert.strictEqual(rootSpan.status.code, 0);
+      assert.strictEqual(rootSpan.status.message, undefined);
+      assert.strictEqual(span.status.code, 7);
+      assert.strictEqual(span.status.message, 'This is an error');
     });
   });
 
@@ -376,21 +376,21 @@ describe('Span', () => {
       const rootSpan =
           new RootSpan(tracer, name, kind, traceId, parentSpanId, 'traceState');
       rootSpan.start();
-      assert.equal(rootSpan.traceState, 'traceState');
+      assert.strictEqual(rootSpan.traceState, 'traceState');
 
       const span = new Span(tracer, rootSpan);
-      assert.equal(span.traceId, rootSpan.traceId);
-      assert.equal(span.traceState, 'traceState');
+      assert.strictEqual(span.traceId, rootSpan.traceId);
+      assert.strictEqual(span.traceState, 'traceState');
     });
 
     it('should handle optional / undefined traceState', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      assert.equal(rootSpan.traceState, undefined);
+      assert.strictEqual(rootSpan.traceState, undefined);
 
       const span = new Span(tracer, rootSpan);
-      assert.equal(span.traceId, rootSpan.traceId);
-      assert.equal(span.traceState, undefined);
+      assert.strictEqual(span.traceId, rootSpan.traceId);
+      assert.strictEqual(span.traceState, undefined);
     });
   });
 });

--- a/packages/opencensus-core/test/test-stats.ts
+++ b/packages/opencensus-core/test/test-stats.ts
@@ -223,7 +223,7 @@ describe('Stats', () => {
          const measurments =
              [{measure, value: 1}, {measure, value: -1}, {measure, value: 1}];
          globalStats.record(measurments, tagMap);
-         assert.equal(testExporter.recordedMeasurements.length, 0);
+         assert.strictEqual(testExporter.recordedMeasurements.length, 0);
        });
 
     it('should record against implicit context when set', () => {

--- a/packages/opencensus-core/test/test-tag-map.ts
+++ b/packages/opencensus-core/test/test-tag-map.ts
@@ -47,7 +47,7 @@ describe('TagMap()', () => {
     it('should set tagkey and tagvalue with default TagMetadata', () => {
       tagMap.set(key1, value1);
       const tags = tagMap.tagsWithMetadata;
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
       assert.deepStrictEqual(tags.get(key1), expectedTagValueWithMetadata1);
     });
 
@@ -59,7 +59,7 @@ describe('TagMap()', () => {
 
       tagMap.set(key1, value1, NO_PROPAGATION_MD);
       const tags = tagMap.tagsWithMetadata;
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
       assert.deepStrictEqual(tags.get(key1), expectedTagValueWithMetadata);
     });
 
@@ -72,7 +72,7 @@ describe('TagMap()', () => {
 
          tagMap.set(key1, value1, UNLIMITED_PROPAGATION_MD);
          const tags = tagMap.tagsWithMetadata;
-         assert.equal(tags.size, 1);
+         assert.strictEqual(tags.size, 1);
          assert.deepStrictEqual(tags.get(key1), expectedTagValueWithMetadata);
        });
 
@@ -91,19 +91,19 @@ describe('TagMap()', () => {
     it('should not set duplicate tagkey and tagvalue', () => {
       tagMap.set(key1, value1);
       const tags = tagMap.tagsWithMetadata;
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
       assert.deepStrictEqual(tags.get(key1), expectedTagValueWithMetadata1);
       tagMap.set(key1, value1);
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
     });
 
     it('should update existing tagkey', () => {
       tagMap.set(key1, value1);
       const tags = tagMap.tagsWithMetadata;
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
       assert.deepStrictEqual(tags.get(key1), expectedTagValueWithMetadata1);
       tagMap.set(key1, value2);
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
       assert.deepStrictEqual(tags.get(key1), expectedTagValueWithMetadata2);
     });
   });
@@ -111,16 +111,16 @@ describe('TagMap()', () => {
     it('should delete tagkey', () => {
       tagMap.set(key1, value1);
       const tags = tagMap.tagsWithMetadata;
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
       tagMap.delete(key1);
-      assert.equal(tags.size, 0);
+      assert.strictEqual(tags.size, 0);
     });
     it('should delete missing tagkey1', () => {
       tagMap.set(key1, value1);
       const tags = tagMap.tagsWithMetadata;
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
       tagMap.delete(key2);
-      assert.equal(tags.size, 1);
+      assert.strictEqual(tags.size, 1);
     });
   });
 });

--- a/packages/opencensus-core/test/test-text-format.ts
+++ b/packages/opencensus-core/test/test-text-format.ts
@@ -49,7 +49,7 @@ describe('Text Format Serializer', () => {
   describe('serializeTextFormat', () => {
     it('should serialize empty tag map', () => {
       const textFormat = serializeTextFormat(emptyTagMap);
-      assert.equal(textFormat, '');
+      assert.strictEqual(textFormat, '');
     });
 
     it('should serialize with one tag map', () => {

--- a/packages/opencensus-core/test/test-tracer-base.ts
+++ b/packages/opencensus-core/test/test-tracer-base.ts
@@ -245,13 +245,14 @@ describe('Tracer Base', () => {
        () => {
          const tracer = new CoreTracerBase();
          tracer.start(defaultConfig);
-         assert.equal(
+         assert.strictEqual(
              tracer.activeTraceParams.numberOfAnnontationEventsPerSpan,
              undefined);
-         assert.equal(
+         assert.strictEqual(
              tracer.activeTraceParams.numberOfAttributesPerSpan, undefined);
-         assert.equal(tracer.activeTraceParams.numberOfLinksPerSpan, undefined);
-         assert.equal(
+         assert.strictEqual(
+             tracer.activeTraceParams.numberOfLinksPerSpan, undefined);
+         assert.strictEqual(
              tracer.activeTraceParams.numberOfMessageEventsPerSpan, undefined);
        });
 
@@ -266,11 +267,12 @@ describe('Tracer Base', () => {
          defaultConfig.traceParams = traceParametersWithHigherThanMaximumValues;
          const tracer = new CoreTracerBase();
          tracer.start(defaultConfig);
-         assert.equal(
+         assert.strictEqual(
              tracer.activeTraceParams.numberOfAnnontationEventsPerSpan, 32);
-         assert.equal(tracer.activeTraceParams.numberOfAttributesPerSpan, 32);
-         assert.equal(tracer.activeTraceParams.numberOfLinksPerSpan, 32);
-         assert.equal(
+         assert.strictEqual(
+             tracer.activeTraceParams.numberOfAttributesPerSpan, 32);
+         assert.strictEqual(tracer.activeTraceParams.numberOfLinksPerSpan, 32);
+         assert.strictEqual(
              tracer.activeTraceParams.numberOfMessageEventsPerSpan, 128);
        });
   });
@@ -414,7 +416,8 @@ describe('Tracer Base', () => {
 
       tracer.startRootSpan(options, (rootSpan) => {
         rootSpan.end();
-        assert.equal(eventListener.testCount, tracer.eventListeners.length);
+        assert.strictEqual(
+            eventListener.testCount, tracer.eventListeners.length);
       });
     });
   });

--- a/packages/opencensus-core/test/test-validation.ts
+++ b/packages/opencensus-core/test/test-validation.ts
@@ -25,13 +25,13 @@ describe('isValidTagKey()', () => {
 
   it('should return false when tag key is 0 character long', () => {
     const tagKey = {name: ''};
-    assert.equal(isValidTagKey(tagKey), false);
+    assert.strictEqual(isValidTagKey(tagKey), false);
   });
 
   it('should return false when the tag key length is longer than 255 characters ',
      () => {
        const tagKey = {name: 'a'.repeat(256)};
-       assert.equal(isValidTagKey(tagKey), false);
+       assert.strictEqual(isValidTagKey(tagKey), false);
      });
 });
 
@@ -49,6 +49,6 @@ describe('isValidTagValue()', () => {
   it('should return false when the tag value length is longer than 255 characters ',
      () => {
        const tagValue = {value: 'a'.repeat(256)};
-       assert.equal(isValidTagValue(tagValue), false);
+       assert.strictEqual(isValidTagValue(tagValue), false);
      });
 });

--- a/packages/opencensus-core/test/test-variant-encoding.ts
+++ b/packages/opencensus-core/test/test-variant-encoding.ts
@@ -37,14 +37,14 @@ describe('variant encoding', () => {
     const variant = EncodeVarint(num);
     assert.deepEqual(variant, expectedBytes);
     const buff = Buffer.from(variant);
-    assert.equal(DecodeVarint(buff, 0), num);
+    assert.strictEqual(DecodeVarint(buff, 0), num);
   });
 
   for (const testCase of testCases) {
     it(`should encode and decode ${testCase} correctly`, () => {
       const variant = EncodeVarint(testCase);
       const buff = Buffer.from(variant);
-      assert.equal(DecodeVarint(buff, 0), testCase);
+      assert.strictEqual(DecodeVarint(buff, 0), testCase);
     });
   }
 });

--- a/packages/opencensus-core/test/test-view.ts
+++ b/packages/opencensus-core/test/test-view.ts
@@ -279,8 +279,8 @@ describe('BaseView', () => {
             } else {
               it('should have timeseries startTimestamp', () => {
                 assert.ok(startTimestamp);
-                assert.equal(typeof startTimestamp!.nanos, 'number');
-                assert.equal(typeof startTimestamp!.seconds, 'number');
+                assert.strictEqual(typeof startTimestamp!.nanos, 'number');
+                assert.strictEqual(typeof startTimestamp!.seconds, 'number');
                 assert.deepStrictEqual(startTimestamp, mockStartTimestamp);
               });
             }
@@ -311,10 +311,10 @@ describe('BaseView', () => {
         const [point] = points;
         const {timestamp, value} = point;
         assert.ok(timestamp);
-        assert.equal(typeof timestamp.nanos, 'number');
-        assert.equal(typeof timestamp.seconds, 'number');
-        assert.equal(timestamp.seconds, mockedTime.seconds);
-        assert.equal(timestamp.nanos, mockedTime.nanos);
+        assert.strictEqual(typeof timestamp.nanos, 'number');
+        assert.strictEqual(typeof timestamp.seconds, 'number');
+        assert.strictEqual(timestamp.seconds, mockedTime.seconds);
+        assert.strictEqual(timestamp.nanos, mockedTime.nanos);
         assert.notEqual(typeof value, 'number');
         assert.deepStrictEqual((value as DistributionValue), {
           bucketOptions: {explicit: {bounds: buckets}},
@@ -462,7 +462,7 @@ describe('BaseView', () => {
 
           it('should have points', () => {
             const {timeseries} = view.getMetric(mockStartTime);
-            assert.equal(timeseries.length, 2);
+            assert.strictEqual(timeseries.length, 2);
             const [{labelValues: labelValues1, points: points1}, {
               labelValues: labelValues2,
               points: points2
@@ -472,10 +472,10 @@ describe('BaseView', () => {
             let [point] = points1;
             let {timestamp, value} = point;
             assert.ok(timestamp);
-            assert.equal(typeof timestamp.nanos, 'number');
-            assert.equal(typeof timestamp.seconds, 'number');
-            assert.equal(timestamp.seconds, mockedTime.seconds);
-            assert.equal(timestamp.nanos, mockedTime.nanos);
+            assert.strictEqual(typeof timestamp.nanos, 'number');
+            assert.strictEqual(typeof timestamp.seconds, 'number');
+            assert.strictEqual(timestamp.seconds, mockedTime.seconds);
+            assert.strictEqual(timestamp.nanos, mockedTime.nanos);
             assert.notEqual(typeof value, 'number');
             assert.deepStrictEqual((value as DistributionValue), {
               bucketOptions: {explicit: {bounds: buckets}},
@@ -491,10 +491,10 @@ describe('BaseView', () => {
             [point] = points2;
             ({timestamp, value} = point);
             assert.ok(timestamp);
-            assert.equal(typeof timestamp.nanos, 'number');
-            assert.equal(typeof timestamp.seconds, 'number');
-            assert.equal(timestamp.seconds, mockedTime.seconds);
-            assert.equal(timestamp.nanos, mockedTime.nanos);
+            assert.strictEqual(typeof timestamp.nanos, 'number');
+            assert.strictEqual(typeof timestamp.seconds, 'number');
+            assert.strictEqual(timestamp.seconds, mockedTime.seconds);
+            assert.strictEqual(timestamp.nanos, mockedTime.nanos);
             assert.notEqual(typeof value, 'number');
             assert.deepStrictEqual((value as DistributionValue), {
               bucketOptions: {explicit: {bounds: buckets}},
@@ -525,11 +525,11 @@ describe('BaseView', () => {
         const [point] = points;
         const {timestamp, value} = point;
         assert.ok(timestamp);
-        assert.equal(typeof timestamp.nanos, 'number');
-        assert.equal(typeof timestamp.seconds, 'number');
-        assert.equal(timestamp.seconds, mockedTime.seconds);
-        assert.equal(timestamp.nanos, mockedTime.nanos);
-        assert.equal(typeof value, 'number');
+        assert.strictEqual(typeof timestamp.nanos, 'number');
+        assert.strictEqual(typeof timestamp.seconds, 'number');
+        assert.strictEqual(timestamp.seconds, mockedTime.seconds);
+        assert.strictEqual(timestamp.nanos, mockedTime.nanos);
+        assert.strictEqual(typeof value, 'number');
         assert.strictEqual(value, 5);
         assert.deepStrictEqual(startTimestamp, mockStartTimestamp);
       });
@@ -553,11 +553,11 @@ describe('BaseView', () => {
         const [point] = points;
         const {timestamp, value} = point;
         assert.ok(timestamp);
-        assert.equal(typeof timestamp.nanos, 'number');
-        assert.equal(typeof timestamp.seconds, 'number');
-        assert.equal(timestamp.seconds, mockedTime.seconds);
-        assert.equal(timestamp.nanos, mockedTime.nanos);
-        assert.equal(typeof value, 'number');
+        assert.strictEqual(typeof timestamp.nanos, 'number');
+        assert.strictEqual(typeof timestamp.seconds, 'number');
+        assert.strictEqual(timestamp.seconds, mockedTime.seconds);
+        assert.strictEqual(timestamp.nanos, mockedTime.nanos);
+        assert.strictEqual(typeof value, 'number');
         assert.strictEqual(value, total);
         assert.deepStrictEqual(startTimestamp, mockStartTimestamp);
       });
@@ -578,9 +578,9 @@ describe('BaseView', () => {
         assert.ok(points);
         const [point] = points;
         const {timestamp, value} = point;
-        assert.equal(timestamp.seconds, mockedTime.seconds);
-        assert.equal(timestamp.nanos, mockedTime.nanos);
-        assert.equal(typeof value, 'number');
+        assert.strictEqual(timestamp.seconds, mockedTime.seconds);
+        assert.strictEqual(timestamp.nanos, mockedTime.nanos);
+        assert.strictEqual(typeof value, 'number');
         assert.strictEqual(
             value, measurementValues[measurementValues.length - 1]);
         assert.strictEqual(startTimestamp, undefined);

--- a/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
+++ b/packages/opencensus-exporter-jaeger/test/test-jaeger.ts
@@ -152,7 +152,7 @@ describe('Jaeger Exporter', () => {
 
         assert.ok(testBoolSeen && testStringSeen && testNumSeen);
 
-        assert.equal(thriftSpan.references.length, 2);
+        assert.strictEqual(thriftSpan.references.length, 2);
         assert.deepEqual(thriftSpan.references, [
           {
             refType: ThriftReferenceType.CHILD_OF,

--- a/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
+++ b/packages/opencensus-exporter-ocagent/test/test-ocagent.ts
@@ -293,7 +293,7 @@ describe('OpenCensus Agent Exporter', () => {
           MockAgentEvent.ExportStreamMessageReceived,
           (message:
                opencensus.proto.agent.trace.v1.ExportTraceServiceRequest) => {
-            assert.equal(message.spans.length, 1);
+            assert.strictEqual(message.spans.length, 1);
             const span = message.spans[0];
             if (!span) {
               assert.fail('span is null or undefined');
@@ -305,8 +305,8 @@ describe('OpenCensus Agent Exporter', () => {
               assert.fail('span.name is null or undefined');
               return;
             }
-            assert.equal(span.name.value, 'root');
-            assert.equal(span.kind, 'SERVER');
+            assert.strictEqual(span.name.value, 'root');
+            assert.strictEqual(span.kind, 'SERVER');
 
             if (!span.tracestate) {
               assert.fail('span.tracestate is null or undefined');
@@ -339,7 +339,7 @@ describe('OpenCensus Agent Exporter', () => {
               my_attribute_number: {value: 'intValue', intValue: '456'},
               my_attribute_boolean: {value: 'boolValue', boolValue: false}
             });
-            assert.equal(span.attributes.droppedAttributesCount, 1);
+            assert.strictEqual(span.attributes.droppedAttributesCount, 1);
 
             // Time Events
             assert.deepEqual(span.timeEvents, {
@@ -507,15 +507,15 @@ describe('OpenCensus Agent Exporter', () => {
              MockAgentEvent.ExportStreamMessageReceived,
              (message: opencensus.proto.agent.trace.v1
                   .ExportTraceServiceRequest) => {
-               assert.equal(message.spans.length, 1);
+               assert.strictEqual(message.spans.length, 1);
                const span = message.spans[0];
                // Name / Context
                if (!span.name) {
                  assert.fail('span.name is null or undefined');
                  return;
                }
-               assert.equal(span.name.value, 'root');
-               assert.equal(span.kind, 'SERVER');
+               assert.strictEqual(span.name.value, 'root');
+               assert.strictEqual(span.kind, 'SERVER');
 
                if (!span.tracestate) {
                  assert.fail('span.tracestate is null or undefined');
@@ -546,7 +546,7 @@ describe('OpenCensus Agent Exporter', () => {
                    stringValue: {value: 'foo2', truncatedByteCount: 0}
                  }
                });
-               assert.equal(span.attributes.droppedAttributesCount, 0);
+               assert.strictEqual(span.attributes.droppedAttributesCount, 0);
 
                // Time Events
                assert.deepEqual(span.timeEvents, {

--- a/packages/opencensus-exporter-prometheus/test/test-prometheus-stats.ts
+++ b/packages/opencensus-exporter-prometheus/test/test-prometheus-stats.ts
@@ -58,11 +58,12 @@ describe('Prometheus Stats Exporter', () => {
             const body = chunk.toString();
             const lines = body.split('\n');
 
-            assert.equal(
+            assert.strictEqual(
                 lines[0],
                 '# HELP ocnodemetrics_countview A count aggregation example');
-            assert.equal(lines[1], '# TYPE ocnodemetrics_countview counter');
-            assert.equal(
+            assert.strictEqual(
+                lines[1], '# TYPE ocnodemetrics_countview counter');
+            assert.strictEqual(
                 lines[2], 'ocnodemetrics_countview{tagKey1="tagValue1"} 2');
             done();
           });
@@ -85,11 +86,11 @@ describe('Prometheus Stats Exporter', () => {
             const body = chunk.toString();
             const lines = body.split('\n');
 
-            assert.equal(
+            assert.strictEqual(
                 lines[0],
                 '# HELP ocnodemetrics_sumview A sum aggregation example');
-            assert.equal(lines[1], '# TYPE ocnodemetrics_sumview gauge');
-            assert.equal(
+            assert.strictEqual(lines[1], '# TYPE ocnodemetrics_sumview gauge');
+            assert.strictEqual(
                 lines[2], 'ocnodemetrics_sumview{tagKey1="tagValue1"} 5');
             done();
           });
@@ -112,11 +113,11 @@ describe('Prometheus Stats Exporter', () => {
             const body = chunk.toString();
             const lines = body.split('\n');
 
-            assert.equal(
+            assert.strictEqual(
                 lines[0],
                 '# HELP ocnodemetrics_sumview1 A sum aggregation example');
-            assert.equal(lines[1], '# TYPE ocnodemetrics_sumview1 gauge');
-            assert.equal(lines[2], 'ocnodemetrics_sumview1 5');
+            assert.strictEqual(lines[1], '# TYPE ocnodemetrics_sumview1 gauge');
+            assert.strictEqual(lines[2], 'ocnodemetrics_sumview1 5');
             done();
           });
         }).on('error', done);
@@ -138,11 +139,12 @@ describe('Prometheus Stats Exporter', () => {
             const body = chunk.toString();
             const lines = body.split('\n');
 
-            assert.equal(
+            assert.strictEqual(
                 lines[0],
                 '# HELP ocnodemetrics_lastvalueview A last value aggregation example');
-            assert.equal(lines[1], '# TYPE ocnodemetrics_lastvalueview gauge');
-            assert.equal(
+            assert.strictEqual(
+                lines[1], '# TYPE ocnodemetrics_lastvalueview gauge');
+            assert.strictEqual(
                 lines[2], 'ocnodemetrics_lastvalueview{tagKey1="tagValue1"} 3');
             done();
           });
@@ -165,30 +167,30 @@ describe('Prometheus Stats Exporter', () => {
           res.on('data', (chunk) => {
             const body = chunk.toString();
             const lines = body.split('\n');
-            assert.equal(
+            assert.strictEqual(
                 lines[0],
                 '# HELP ocnodemetrics_distributionview A distribution aggregation example');
-            assert.equal(
+            assert.strictEqual(
                 lines[1], '# TYPE ocnodemetrics_distributionview histogram');
-            assert.equal(
+            assert.strictEqual(
                 lines[2],
                 'ocnodemetrics_distributionview_bucket{le="10",tagKey1="tagValue1"} 0');
-            assert.equal(
+            assert.strictEqual(
                 lines[3],
                 'ocnodemetrics_distributionview_bucket{le="20",tagKey1="tagValue1"} 1');
-            assert.equal(
+            assert.strictEqual(
                 lines[4],
                 'ocnodemetrics_distributionview_bucket{le="30",tagKey1="tagValue1"} 1');
-            assert.equal(
+            assert.strictEqual(
                 lines[5],
                 'ocnodemetrics_distributionview_bucket{le="40",tagKey1="tagValue1"} 2');
-            assert.equal(
+            assert.strictEqual(
                 lines[6],
                 'ocnodemetrics_distributionview_bucket{le="+Inf",tagKey1="tagValue1"} 2');
-            assert.equal(
+            assert.strictEqual(
                 lines[7],
                 'ocnodemetrics_distributionview_sum{tagKey1="tagValue1"} 43');
-            assert.equal(
+            assert.strictEqual(
                 lines[8],
                 'ocnodemetrics_distributionview_count{tagKey1="tagValue1"} 2');
             done();
@@ -257,11 +259,13 @@ describe('Prometheus Stats Exporter with prefix option', () => {
             const body = chunk.toString();
             const lines = body.split('\n');
 
-            assert.equal(
+            assert.strictEqual(
                 lines[0],
                 '# HELP opencensus_test_key_1 A count aggregation example');
-            assert.equal(lines[1], '# TYPE opencensus_test_key_1 counter');
-            assert.equal(lines[2], 'opencensus_test_key_1{le="tagValue1"} 2');
+            assert.strictEqual(
+                lines[1], '# TYPE opencensus_test_key_1 counter');
+            assert.strictEqual(
+                lines[2], 'opencensus_test_key_1{le="tagValue1"} 2');
             done();
           });
         }).on('error', done);

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace-utils.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace-utils.ts
@@ -75,8 +75,8 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
     it('should return stackdriver links', () => {
       const stackdriverLinks = createLinks(links, 2);
 
-      assert.equal(stackdriverLinks.droppedLinksCount, 2);
-      assert.equal(stackdriverLinks.link!.length, 3);
+      assert.strictEqual(stackdriverLinks.droppedLinksCount, 2);
+      assert.strictEqual(stackdriverLinks.link!.length, 3);
       assert.deepEqual(stackdriverLinks.link, expectedLink);
     });
   });
@@ -176,9 +176,9 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
       const stackdriverTimeEvents =
           createTimeEvents(annotations, messageEvents, 2, 3);
 
-      assert.equal(stackdriverTimeEvents.droppedAnnotationsCount, 2);
-      assert.equal(stackdriverTimeEvents.droppedMessageEventsCount, 3);
-      assert.equal(stackdriverTimeEvents.timeEvent!.length, 6);
+      assert.strictEqual(stackdriverTimeEvents.droppedAnnotationsCount, 2);
+      assert.strictEqual(stackdriverTimeEvents.droppedMessageEventsCount, 3);
+      assert.strictEqual(stackdriverTimeEvents.timeEvent!.length, 6);
       assert.deepEqual(stackdriverTimeEvents.timeEvent, expectedTimeEvent);
     });
 
@@ -186,9 +186,9 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
        () => {
          const stackdriverTimeEvents = createTimeEvents([], [], 0, 0);
 
-         assert.equal(stackdriverTimeEvents.droppedAnnotationsCount, 0);
-         assert.equal(stackdriverTimeEvents.droppedMessageEventsCount, 0);
-         assert.equal(stackdriverTimeEvents.timeEvent!.length, 0);
+         assert.strictEqual(stackdriverTimeEvents.droppedAnnotationsCount, 0);
+         assert.strictEqual(stackdriverTimeEvents.droppedMessageEventsCount, 0);
+         assert.strictEqual(stackdriverTimeEvents.timeEvent!.length, 0);
        });
   });
 
@@ -203,8 +203,9 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
 
     it('should return stackdriver Attributes', () => {
       const stackdriverAttribute = createAttributes(attributes, {}, 0);
-      assert.equal(stackdriverAttribute.droppedAttributesCount, 0);
-      assert.equal(Object.keys(stackdriverAttribute.attributeMap!).length, 3);
+      assert.strictEqual(stackdriverAttribute.droppedAttributesCount, 0);
+      assert.strictEqual(
+          Object.keys(stackdriverAttribute.attributeMap!).length, 3);
       assert.deepEqual(stackdriverAttribute.attributeMap, expectedAttributeMap);
     });
 
@@ -219,8 +220,9 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
         'g.co/r/podId': {'intValue': '100'},
         'g.co/r/project_id': {'stringValue': {'value': 'project1'}}
       });
-      assert.equal(stackdriverAttribute.droppedAttributesCount, 2);
-      assert.equal(Object.keys(stackdriverAttribute.attributeMap!).length, 5);
+      assert.strictEqual(stackdriverAttribute.droppedAttributesCount, 2);
+      assert.strictEqual(
+          Object.keys(stackdriverAttribute.attributeMap!).length, 5);
       assert.deepEqual(stackdriverAttribute.attributeMap, expectedAttributeMap);
     });
   });
@@ -250,7 +252,7 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
 
       const resolvingPromise = Promise.resolve(resource);
       const resourceLabels = await getResourceLabels(resolvingPromise);
-      assert.equal(Object.keys(resourceLabels).length, 5);
+      assert.strictEqual(Object.keys(resourceLabels).length, 5);
       assert.deepEqual(resourceLabels, expectedLabels);
     });
 
@@ -272,7 +274,7 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
       };
       const resolvingPromise = Promise.resolve(resource);
       const resourceLabels = await getResourceLabels(resolvingPromise);
-      assert.equal(Object.keys(resourceLabels).length, 3);
+      assert.strictEqual(Object.keys(resourceLabels).length, 3);
       assert.deepEqual(resourceLabels, expectedLabels);
     });
 
@@ -299,7 +301,7 @@ describe('Stackdriver CloudTrace Exporter Utils', () => {
 
       const resolvingPromise = Promise.resolve(resource);
       const resourceLabels = await getResourceLabels(resolvingPromise);
-      assert.equal(Object.keys(resourceLabels).length, 4);
+      assert.strictEqual(Object.keys(resourceLabels).length, 4);
       assert.deepEqual(resourceLabels, expectedLabels);
     });
   });

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-cloudtrace.ts
@@ -83,7 +83,7 @@ describe('Stackdriver Trace Exporter', function() {
             rootSpan.end();
 
             const spanList = await exporter.translateSpan([rootSpan]);
-            assert.equal(spanList.length, 2);
+            assert.strictEqual(spanList.length, 2);
             assert.deepEqual(spanList, [
               {
                 'attributes': {
@@ -168,7 +168,7 @@ describe('Stackdriver Trace Exporter', function() {
             rootSpan.end();
 
             return failExporter.publish([rootSpan]).then(result => {
-              assert.equal(result.code, 401);
+              assert.strictEqual(result.code, 401);
               assert.ok(result.message.indexOf('batchWriteSpans error') >= 0);
 
               assert.strictEqual(

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring-utils.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring-utils.ts
@@ -384,7 +384,7 @@ describe('Stackdriver Stats Exporter Utils', () => {
       const timeSeriesList =
           createTimeSeriesList(metric, defaultResource, metricPrefix);
 
-      assert.equal(timeSeriesList.length, 1);
+      assert.strictEqual(timeSeriesList.length, 1);
       const [timeseries] = timeSeriesList;
       assert.deepStrictEqual(
           timeseries.metric.type,
@@ -405,7 +405,7 @@ describe('Stackdriver Stats Exporter Utils', () => {
          const timeSeriesList =
              createTimeSeriesList(metric, customResource, metricPrefix);
 
-         assert.equal(timeSeriesList.length, 1);
+         assert.strictEqual(timeSeriesList.length, 1);
          const [timeseries] = timeSeriesList;
          assert.deepStrictEqual(
              timeseries.metric.type,
@@ -427,7 +427,7 @@ describe('Stackdriver Stats Exporter Utils', () => {
          const timeSeriesList =
              createTimeSeriesList(gaugeMetric, defaultResource, metricPrefix);
 
-         assert.equal(timeSeriesList.length, 2);
+         assert.strictEqual(timeSeriesList.length, 2);
          const [timeseries1, timeseries2] = timeSeriesList;
          assert.deepStrictEqual(
              timeseries1.metric.type,
@@ -460,7 +460,7 @@ describe('Stackdriver Stats Exporter Utils', () => {
       const monitoredResource = await getDefaultResource('my-project-id');
       const {type, labels} = monitoredResource;
 
-      assert.equal(type, 'global');
+      assert.strictEqual(type, 'global');
       assert.deepEqual(labels, {project_id: 'my-project-id'});
     });
 
@@ -473,8 +473,8 @@ describe('Stackdriver Stats Exporter Utils', () => {
       const monitoredResource = await getDefaultResource('my-project-id');
       const {type, labels} = monitoredResource;
 
-      assert.equal(type, 'k8s_container');
-      assert.equal(Object.keys(labels).length, 5);
+      assert.strictEqual(type, 'k8s_container');
+      assert.strictEqual(Object.keys(labels).length, 5);
       assert.deepStrictEqual(labels, {
         'container_name': 'c1',
         'namespace_name': 'default',
@@ -491,8 +491,8 @@ describe('Stackdriver Stats Exporter Utils', () => {
       const monitoredResource = await getDefaultResource('my-project-id');
       const {type, labels} = monitoredResource;
 
-      assert.equal(type, 'gce_instance');
-      assert.equal(Object.keys(labels).length, 3);
+      assert.strictEqual(type, 'gce_instance');
+      assert.strictEqual(Object.keys(labels).length, 3);
       assert.deepStrictEqual(labels, {
         'instance_id': 'id1',
         'project_id': 'my-project-id',
@@ -508,8 +508,8 @@ describe('Stackdriver Stats Exporter Utils', () => {
       const monitoredResource = await getDefaultResource('my-project-id');
       const {type, labels} = monitoredResource;
 
-      assert.equal(type, 'aws_ec2_instance');
-      assert.equal(Object.keys(labels).length, 4);
+      assert.strictEqual(type, 'aws_ec2_instance');
+      assert.strictEqual(Object.keys(labels).length, 4);
       assert.deepStrictEqual(labels, {
         'instance_id': 'instance1',
         'region': 'aws:region1',

--- a/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/test/test-stackdriver-monitoring.ts
@@ -76,7 +76,7 @@ describe('Stackdriver Stats Exporter', () => {
 
     it('should not export for empty data', () => {
       globalStats.registerExporter(exporter);
-      assert.equal(mockLogger.debugBuffer.length, 0);
+      assert.strictEqual(mockLogger.debugBuffer.length, 0);
     });
 
     it('should export the data', async () => {
@@ -98,7 +98,7 @@ describe('Stackdriver Stats Exporter', () => {
       nocks.timeSeries(PROJECT_ID);
 
       await exporter.export();
-      assert.equal(mockLogger.debugBuffer.length, 1);
+      assert.strictEqual(mockLogger.debugBuffer.length, 1);
       const [metricDescriptor] = mockLogger.debugBuffer;
       assert.strictEqual(
           metricDescriptor.type,

--- a/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/test/test-zipkin.ts
@@ -96,7 +96,7 @@ describe('Zipkin Exporter', function() {
             span.end();
             rootSpan.end();
             return exporter.publish([rootSpan, rootSpan]).then((result) => {
-              assert.equal(result.statusCode, 202);
+              assert.strictEqual(result.statusCode, 202);
             });
           });
     });
@@ -201,7 +201,7 @@ describe('Zipkin Exporter', function() {
                span.end();
                rootSpan.end();
                return exporter.publish([rootSpan]).then((result) => {
-                 assert.equal(result.statusCode, 404);
+                 assert.strictEqual(result.statusCode, 404);
                });
              });
        });

--- a/packages/opencensus-exporter-zpages/test/test-zpages.ts
+++ b/packages/opencensus-exporter-zpages/test/test-zpages.ts
@@ -496,9 +496,9 @@ describe('Zpages Exporter', () => {
       rpczData = await zpagesClient.getRpcz();
       const measures = rpczData.measuresSent['ExampleMethod'];
       assert.strictEqual(measures.count.tot, 2);
-      assert.strictEqual(measures.avgLatency.tot.toFixed(3), 1.500);
-      assert.strictEqual(measures.input.tot.toFixed(3), 1.074);
-      assert.strictEqual(measures.output.tot.toFixed(3), 21.484);
+      assert.strictEqual(measures.avgLatency.tot.toFixed(3), '1.500');
+      assert.strictEqual(measures.input.tot.toFixed(3), '1.074');
+      assert.strictEqual(measures.output.tot.toFixed(3), '21.484');
       assert.strictEqual(measures.errors.tot, 2);
     });
 
@@ -578,9 +578,9 @@ describe('Zpages Exporter', () => {
       const measures = rpczData.measuresReceived['ExampleMethod'];
 
       assert.strictEqual(measures.count.tot, 2);
-      assert.strictEqual(measures.avgLatency.tot.toFixed(3), 1.500);
-      assert.strictEqual(measures.input.tot.toFixed(3), 2.148);
-      assert.strictEqual(measures.output.tot.toFixed(3), 1.074);
+      assert.strictEqual(measures.avgLatency.tot.toFixed(3), '1.500');
+      assert.strictEqual(measures.input.tot.toFixed(3), '2.148');
+      assert.strictEqual(measures.output.tot.toFixed(3), '1.074');
       assert.strictEqual(measures.errors.tot, 2);
     });
   });

--- a/packages/opencensus-exporter-zpages/test/test-zpages.ts
+++ b/packages/opencensus-exporter-zpages/test/test-zpages.ts
@@ -272,10 +272,10 @@ describe('Zpages Exporter', () => {
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/CountView'});
 
-        assert.equal(zpagesData.view.name, 'test/CountView');
-        assert.equal(zpagesData.view.description, 'A count test');
-        assert.equal(zpagesData.view.measure.name, 'testMeasureDouble');
-        assert.equal(zpagesData.view.aggregation, AggregationType.COUNT);
+        assert.strictEqual(zpagesData.view.name, 'test/CountView');
+        assert.strictEqual(zpagesData.view.description, 'A count test');
+        assert.strictEqual(zpagesData.view.measure.name, 'testMeasureDouble');
+        assert.strictEqual(zpagesData.view.aggregation, AggregationType.COUNT);
       });
 
       it('should get stats for view', async () => {
@@ -291,7 +291,7 @@ describe('Zpages Exporter', () => {
         const snapshot = data.snapshot as CountData;
         assert.deepEqual(data.tagKeys, tagKeys);
         assert.deepEqual(data.tagValues, tagValues);
-        assert.equal(snapshot.value, 2);
+        assert.strictEqual(snapshot.value, 2);
       });
     });
 
@@ -306,10 +306,10 @@ describe('Zpages Exporter', () => {
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/SumView'});
 
-        assert.equal(zpagesData.view.name, 'test/SumView');
-        assert.equal(zpagesData.view.description, 'A sum test');
-        assert.equal(zpagesData.view.measure.name, 'testMeasureDouble');
-        assert.equal(zpagesData.view.aggregation, AggregationType.SUM);
+        assert.strictEqual(zpagesData.view.name, 'test/SumView');
+        assert.strictEqual(zpagesData.view.description, 'A sum test');
+        assert.strictEqual(zpagesData.view.measure.name, 'testMeasureDouble');
+        assert.strictEqual(zpagesData.view.aggregation, AggregationType.SUM);
       });
 
       it('should get stats for view', async () => {
@@ -326,7 +326,7 @@ describe('Zpages Exporter', () => {
         const snapshot = data.snapshot as SumData;
         assert.deepEqual(data.tagKeys, tagKeys);
         assert.deepEqual(data.tagValues, tagValues);
-        assert.equal(snapshot.value, 33);
+        assert.strictEqual(snapshot.value, 33);
       });
     });
 
@@ -341,10 +341,11 @@ describe('Zpages Exporter', () => {
 
         zpagesData = await zpagesClient.getStatsz({path: 'test/LastValueView'});
 
-        assert.equal(zpagesData.view.name, 'test/LastValueView');
-        assert.equal(zpagesData.view.description, 'A last value test');
-        assert.equal(zpagesData.view.measure.name, 'testMeasureDouble');
-        assert.equal(zpagesData.view.aggregation, AggregationType.LAST_VALUE);
+        assert.strictEqual(zpagesData.view.name, 'test/LastValueView');
+        assert.strictEqual(zpagesData.view.description, 'A last value test');
+        assert.strictEqual(zpagesData.view.measure.name, 'testMeasureDouble');
+        assert.strictEqual(
+            zpagesData.view.aggregation, AggregationType.LAST_VALUE);
       });
 
       it('should get stats for view', async () => {
@@ -361,7 +362,7 @@ describe('Zpages Exporter', () => {
         const snapshot = data.snapshot as SumData;
         assert.deepEqual(data.tagKeys, tagKeys);
         assert.deepEqual(data.tagValues, tagValues);
-        assert.equal(snapshot.value, 11);
+        assert.strictEqual(snapshot.value, 11);
       });
     });
 
@@ -378,10 +379,11 @@ describe('Zpages Exporter', () => {
         zpagesData =
             await zpagesClient.getStatsz({path: 'test/DistributionView'});
 
-        assert.equal(zpagesData.view.name, 'test/DistributionView');
-        assert.equal(zpagesData.view.description, 'A distribution test');
-        assert.equal(zpagesData.view.measure.name, 'testMeasureDouble');
-        assert.equal(zpagesData.view.aggregation, AggregationType.DISTRIBUTION);
+        assert.strictEqual(zpagesData.view.name, 'test/DistributionView');
+        assert.strictEqual(zpagesData.view.description, 'A distribution test');
+        assert.strictEqual(zpagesData.view.measure.name, 'testMeasureDouble');
+        assert.strictEqual(
+            zpagesData.view.aggregation, AggregationType.DISTRIBUTION);
       });
 
       it('should get stats for view', async () => {
@@ -400,9 +402,9 @@ describe('Zpages Exporter', () => {
         const snapshot = data.snapshot as DistributionData;
         assert.deepEqual(data.tagKeys, tagKeys);
         assert.deepEqual(data.tagValues, tagValues);
-        assert.equal(snapshot.count, 2);
-        assert.equal(snapshot.mean, 16.5);
-        assert.equal(snapshot.sumOfSquaredDeviation, 60.5);
+        assert.strictEqual(snapshot.count, 2);
+        assert.strictEqual(snapshot.mean, 16.5);
+        assert.strictEqual(snapshot.sumOfSquaredDeviation, 60.5);
       });
     });
   });
@@ -493,11 +495,11 @@ describe('Zpages Exporter', () => {
 
       rpczData = await zpagesClient.getRpcz();
       const measures = rpczData.measuresSent['ExampleMethod'];
-      assert.equal(measures.count.tot, 2);
-      assert.equal(measures.avgLatency.tot.toFixed(3), 1.500);
-      assert.equal(measures.input.tot.toFixed(3), 1.074);
-      assert.equal(measures.output.tot.toFixed(3), 21.484);
-      assert.equal(measures.errors.tot, 2);
+      assert.strictEqual(measures.count.tot, 2);
+      assert.strictEqual(measures.avgLatency.tot.toFixed(3), 1.500);
+      assert.strictEqual(measures.input.tot.toFixed(3), 1.074);
+      assert.strictEqual(measures.output.tot.toFixed(3), 21.484);
+      assert.strictEqual(measures.errors.tot, 2);
     });
 
     it('should get the received stats', async () => {
@@ -575,11 +577,11 @@ describe('Zpages Exporter', () => {
       rpczData = await zpagesClient.getRpcz();
       const measures = rpczData.measuresReceived['ExampleMethod'];
 
-      assert.equal(measures.count.tot, 2);
-      assert.equal(measures.avgLatency.tot.toFixed(3), 1.500);
-      assert.equal(measures.input.tot.toFixed(3), 2.148);
-      assert.equal(measures.output.tot.toFixed(3), 1.074);
-      assert.equal(measures.errors.tot, 2);
+      assert.strictEqual(measures.count.tot, 2);
+      assert.strictEqual(measures.avgLatency.tot.toFixed(3), 1.500);
+      assert.strictEqual(measures.input.tot.toFixed(3), 2.148);
+      assert.strictEqual(measures.output.tot.toFixed(3), 1.074);
+      assert.strictEqual(measures.errors.tot, 2);
     });
   });
 });

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -241,7 +241,7 @@ describe('HttpPlugin', () => {
         assertSpanAttributes(span, 200, 'GET', hostName, testPath);
         assert.strictEqual(span.messageEvents.length, 1);
         assert.strictEqual(span.messageEvents[0].type, MessageEventType.SENT);
-        assert.strictEqual(span.messageEvents[0].id, '1');
+        assert.strictEqual(span.messageEvents[0].id, 1);
         assertClientStats(testExporter, 200, 'GET');
       });
     });
@@ -284,7 +284,7 @@ describe('HttpPlugin', () => {
           assertSpanAttributes(span, 200, 'GET', hostName, testPath);
           assert.strictEqual(span.messageEvents.length, 1);
           assert.strictEqual(span.messageEvents[0].type, MessageEventType.SENT);
-          assert.strictEqual(span.messageEvents[0].id, '1');
+          assert.strictEqual(span.messageEvents[0].id, 1);
           assertClientStats(testExporter, 200, 'GET');
         });
       });

--- a/packages/opencensus-instrumentation-http/test/test-http.ts
+++ b/packages/opencensus-instrumentation-http/test/test-http.ts
@@ -239,9 +239,9 @@ describe('HttpPlugin', () => {
 
         const span = spanVerifier.endedSpans[0];
         assertSpanAttributes(span, 200, 'GET', hostName, testPath);
-        assert.equal(span.messageEvents.length, 1);
-        assert.equal(span.messageEvents[0].type, MessageEventType.SENT);
-        assert.equal(span.messageEvents[0].id, '1');
+        assert.strictEqual(span.messageEvents.length, 1);
+        assert.strictEqual(span.messageEvents[0].type, MessageEventType.SENT);
+        assert.strictEqual(span.messageEvents[0].id, '1');
         assertClientStats(testExporter, 200, 'GET');
       });
     });
@@ -282,9 +282,9 @@ describe('HttpPlugin', () => {
           assert.strictEqual(root.traceId, root.spans[0].traceId);
           const span = root.spans[0];
           assertSpanAttributes(span, 200, 'GET', hostName, testPath);
-          assert.equal(span.messageEvents.length, 1);
-          assert.equal(span.messageEvents[0].type, MessageEventType.SENT);
-          assert.equal(span.messageEvents[0].id, '1');
+          assert.strictEqual(span.messageEvents.length, 1);
+          assert.strictEqual(span.messageEvents[0].type, MessageEventType.SENT);
+          assert.strictEqual(span.messageEvents[0].id, '1');
           assertClientStats(testExporter, 200, 'GET');
         });
       });
@@ -327,8 +327,8 @@ describe('HttpPlugin', () => {
             assert.strictEqual(root.spans.length, i + 1);
             assert.ok(root.spans[i].name.indexOf(testPath) >= 0);
             assert.strictEqual(root.traceId, root.spans[i].traceId);
-            assert.equal(root.spans[i].messageEvents[0].id, 1);
-            assert.equal(
+            assert.strictEqual(root.spans[i].messageEvents[0].id, 1);
+            assert.strictEqual(
                 root.spans[i].messageEvents[0].type, MessageEventType.SENT);
           });
         }
@@ -353,7 +353,7 @@ describe('HttpPlugin', () => {
 
          assert.strictEqual(spanVerifier.endedSpans.length, 0);
          await httpRequest.get(options).then((result) => {
-           assert.equal(result, 'Ok');
+           assert.strictEqual(result, 'Ok');
            assert.strictEqual(spanVerifier.endedSpans.length, 0);
          });
        });

--- a/packages/opencensus-instrumentation-http2/test/test-http2.ts
+++ b/packages/opencensus-instrumentation-http2/test/test-http2.ts
@@ -140,13 +140,13 @@ describe('Http2Plugin', () => {
 
         const span = spanVerifier.endedSpans[1];
         assertSpanAttributes(span, 200, 'GET', host, testPath);
-        assert.equal(span.messageEvents.length, 1);
-        assert.equal(span.messageEvents[0].type, MessageEventType.SENT);
-        assert.equal(span.messageEvents[0].id, '1');
+        assert.strictEqual(span.messageEvents.length, 1);
+        assert.strictEqual(span.messageEvents[0].type, MessageEventType.SENT);
+        assert.strictEqual(span.messageEvents[0].id, '1');
 
         const messageEvents = spanVerifier.endedSpans[0].messageEvents[0];
-        assert.equal(messageEvents.type, MessageEventType.RECEIVED);
-        assert.equal(messageEvents.id, '1');
+        assert.strictEqual(messageEvents.type, MessageEventType.RECEIVED);
+        assert.strictEqual(messageEvents.id, '1');
       });
     });
 

--- a/packages/opencensus-instrumentation-http2/test/test-http2.ts
+++ b/packages/opencensus-instrumentation-http2/test/test-http2.ts
@@ -142,11 +142,11 @@ describe('Http2Plugin', () => {
         assertSpanAttributes(span, 200, 'GET', host, testPath);
         assert.strictEqual(span.messageEvents.length, 1);
         assert.strictEqual(span.messageEvents[0].type, MessageEventType.SENT);
-        assert.strictEqual(span.messageEvents[0].id, '1');
+        assert.strictEqual(span.messageEvents[0].id, 1);
 
         const messageEvents = spanVerifier.endedSpans[0].messageEvents[0];
         assert.strictEqual(messageEvents.type, MessageEventType.RECEIVED);
-        assert.strictEqual(messageEvents.id, '1');
+        assert.strictEqual(messageEvents.id, 1);
       });
     });
 

--- a/packages/opencensus-instrumentation-https/test/test-https.ts
+++ b/packages/opencensus-instrumentation-https/test/test-https.ts
@@ -299,7 +299,7 @@ describe('HttpsPlugin', () => {
 
              assert.strictEqual(spanVerifier.endedSpans.length, 0);
              await requestMethod(options).then((result) => {
-               assert.equal(result, 'Ok');
+               assert.strictEqual(result, 'Ok');
                assert.strictEqual(spanVerifier.endedSpans.length, 0);
              });
            });

--- a/packages/opencensus-resource-util/test/test-detect-resource.ts
+++ b/packages/opencensus-resource-util/test/test-detect-resource.ts
@@ -73,7 +73,7 @@ describe('detectResource', () => {
        scope.done();
 
        assert.deepEqual(type, resource.K8S_CONTAINER_TYPE);
-       assert.equal(Object.keys(labels).length, 6);
+       assert.strictEqual(Object.keys(labels).length, 6);
        assert.strictEqual(
            labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-project-id');
        assert.strictEqual(labels[CLOUD_RESOURCE.ZONE_KEY], 'my-zone');
@@ -101,7 +101,7 @@ describe('detectResource', () => {
        scope.done();
 
        assert.deepEqual(type, resource.K8S_CONTAINER_TYPE);
-       assert.equal(Object.keys(labels).length, 6);
+       assert.strictEqual(Object.keys(labels).length, 6);
        assert.strictEqual(
            labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-project-id');
        assert.strictEqual(labels[CLOUD_RESOURCE.ZONE_KEY], 'my-zone');
@@ -139,7 +139,7 @@ describe('detectResource', () => {
        scope.done();
 
        assert.deepEqual(type, resource.K8S_CONTAINER_TYPE);
-       assert.equal(Object.keys(labels).length, 6);
+       assert.strictEqual(Object.keys(labels).length, 6);
        assert.strictEqual(
            labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-project-id');
        assert.strictEqual(labels[CLOUD_RESOURCE.ZONE_KEY], 'my-zone');
@@ -163,7 +163,7 @@ describe('detectResource', () => {
     scope.done();
 
     assert.deepEqual(type, resource.GCP_GCE_INSTANCE_TYPE);
-    assert.equal(Object.keys(labels).length, 3);
+    assert.strictEqual(Object.keys(labels).length, 3);
     assert.strictEqual(labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-project-id');
     assert.strictEqual(labels[CLOUD_RESOURCE.ZONE_KEY], 'my-zone');
     assert.strictEqual(labels[HOST_RESOURCE.ID_KEY], '4520031799277582000');
@@ -186,7 +186,7 @@ describe('detectResource', () => {
     scope.done();
 
     assert.deepEqual(type, resource.GCP_GCE_INSTANCE_TYPE);
-    assert.equal(Object.keys(labels).length, 3);
+    assert.strictEqual(Object.keys(labels).length, 3);
     assert.strictEqual(labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-project-id');
     assert.strictEqual(labels[CLOUD_RESOURCE.ZONE_KEY], 'my-zone');
     assert.strictEqual(labels[HOST_RESOURCE.ID_KEY], '4520031799277582000');
@@ -207,7 +207,7 @@ describe('detectResource', () => {
        scope.done();
 
        assert.deepEqual(type, resource.GCP_GCE_INSTANCE_TYPE);
-       assert.equal(Object.keys(labels).length, 3);
+       assert.strictEqual(Object.keys(labels).length, 3);
        assert.strictEqual(
            labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-project-id');
        assert.strictEqual(labels[CLOUD_RESOURCE.ZONE_KEY], '');
@@ -239,7 +239,7 @@ describe('detectResource', () => {
        scope.done();
 
        assert.deepEqual(type, 'global');
-       assert.equal(Object.keys(labels).length, 5);
+       assert.strictEqual(Object.keys(labels).length, 5);
        assert.strictEqual(
            labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-project-id');
        assert.strictEqual(labels[CLOUD_RESOURCE.ZONE_KEY], 'zone1');
@@ -260,7 +260,7 @@ describe('detectResource', () => {
     gcpScope.done();
 
     assert.deepEqual(type, resource.AWS_EC2_INSTANCE_TYPE);
-    assert.equal(Object.keys(labels).length, 3);
+    assert.strictEqual(Object.keys(labels).length, 3);
     assert.strictEqual(labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-account-id');
     assert.strictEqual(labels[HOST_RESOURCE.ID_KEY], 'my-instance-id');
     assert.strictEqual(labels[CLOUD_RESOURCE.REGION_KEY], 'my-region');
@@ -288,7 +288,7 @@ describe('detectResource', () => {
        gcpScope.done();
 
        assert.deepEqual(type, resource.AWS_EC2_INSTANCE_TYPE);
-       assert.equal(Object.keys(labels).length, 3);
+       assert.strictEqual(Object.keys(labels).length, 3);
        assert.strictEqual(
            labels[CLOUD_RESOURCE.ACCOUNT_ID_KEY], 'my-account-id');
        assert.strictEqual(labels[HOST_RESOURCE.ID_KEY], 'my-instance-id');
@@ -307,6 +307,6 @@ describe('detectResource', () => {
     gcpScope.done();
 
     assert.deepEqual(type, null);
-    assert.equal(Object.keys(labels).length, 0);
+    assert.strictEqual(Object.keys(labels).length, 0);
   });
 });


### PR DESCRIPTION
`assert.equal()` is deprecated since node v10.

There will be follow-up PRs,
1. Replace `assert.notEqua`l with `assert.notstrictEqual` 
2. Replace `assert.deepEqual` with `assert.deepStrictEqual`
3. Replace `assert.notDeepEqual` with `assert.notStrictEqual`