### PR TITLE
Object Trace Exporter for programatic span access

### DIFF
--- a/packages/opencensus-exporter-object/.npmignore
+++ b/packages/opencensus-exporter-object/.npmignore
@@ -1,0 +1,4 @@
+/bin
+/coverage
+/doc
+/test

--- a/packages/opencensus-exporter-object/AUTHORS
+++ b/packages/opencensus-exporter-object/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of OpenCensus authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+
+Google LLC
+Netflix

--- a/packages/opencensus-exporter-object/LICENSE
+++ b/packages/opencensus-exporter-object/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/opencensus-exporter-object/README.md
+++ b/packages/opencensus-exporter-object/README.md
@@ -1,0 +1,71 @@
+# OpenCensus Object Exporter
+[![Gitter chat][gitter-image]][gitter-url]
+
+OpenCensus Object Trace Exporter allows the user to collect and
+programatically access traces with [OpenCensus Node.js](https://github.com/census-instrumentation/opencensus-node). This module is useful for when you need
+to access collected spans programatically, for example for testing purposes.
+
+## Installation
+
+Install OpenCensus Object Trace Exporter with:
+
+```bash
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-object
+```
+
+## Usage
+
+For javascript:
+
+```javascript
+const tracing = require('@opencensus/nodejs');
+const { ObjectTraceExporter } = require('@opencensus/exporter-object');
+
+const exporter = new ObjectTraceExporter();
+```
+
+Similarly for Typescript:
+
+```typescript
+import * as tracing from '@opencensus/nodejs';
+import { ObjectTraceExporter } from '@opencensus/exporter-object';
+const exporter = new ObjectTraceExporter();
+```
+
+Now, register the exporter and start tracing.
+
+```javascript
+tracing.start({'exporter': exporter});
+```
+
+or
+
+```javascript
+tracing.registerExporter(exporter).start();
+```
+
+## Viewing your traces
+
+```javascript
+exporter.startedSpans.forEach((span: Span)) => {}
+exporter.endedSpans.forEach((span: Span)) => {}
+exporter.publishedSpans.forEach((span: Span)) => {}
+```
+
+## Reset exporter
+
+Empties `startedSpans`, `endedSpans` and `publishedSpans` span stores.
+
+```javascript
+exporter.reset();
+```
+
+## Useful links
+
+- For more information on OpenCensus, visit: <https://opencensus.io/>
+- To checkout the OpenCensus for Node.js, visit: <https://github.com/census-instrumentation/opencensus-node>
+- For help or feedback on this project, join us on [gitter](https://gitter.im/census-instrumentation/Lobby)
+
+[gitter-image]: https://badges.gitter.im/census-instrumentation/lobby.svg
+[gitter-url]: https://gitter.im/census-instrumentation/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/packages/opencensus-exporter-object/README.md
+++ b/packages/opencensus-exporter-object/README.md
@@ -2,8 +2,8 @@
 [![Gitter chat][gitter-image]][gitter-url]
 
 OpenCensus Object Trace Exporter allows the user to collect and
-programatically access traces with [OpenCensus Node.js](https://github.com/census-instrumentation/opencensus-node). This module is useful for when you need
-to access collected spans programatically, for example for testing purposes.
+programmatically access traces with [OpenCensus Node.js](https://github.com/census-instrumentation/opencensus-node). This module is useful for when you need
+to access collected spans programmatically, for example for testing purposes.
 
 ## Installation
 

--- a/packages/opencensus-exporter-object/codecov.yml
+++ b/packages/opencensus-exporter-object/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "::packages/opencensus-exporter-object/"

--- a/packages/opencensus-exporter-object/package-lock.json
+++ b/packages/opencensus-exporter-object/package-lock.json
@@ -1,0 +1,3033 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/generator/-/generator-7.4.4.tgz",
+			"integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
+			"requires": {
+				"@babel/types": "^7.4.4",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
+			"requires": {
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.4.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/parser/-/parser-7.4.5.tgz",
+			"integrity": "sha1-BK+NXVorBEoqG/+sweXmZzVE6HI="
+		},
+		"@babel/template": {
+			"version": "7.4.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/template/-/template-7.4.4.tgz",
+			"integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/traverse/-/traverse-7.4.5.tgz",
+			"integrity": "sha1-TpLRco/S8Yl9r90yHvv/khVsMhY=",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.4",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/types": "^7.4.4",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@babel/types/-/types-7.4.4.tgz",
+			"integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+			"optional": true
+		},
+		"@types/mocha": {
+			"version": "5.2.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@types/mocha/-/mocha-5.2.6.tgz",
+			"integrity": "sha1-uGItUFV90VXp8vY0t9aP043l6Us="
+		},
+		"@types/nock": {
+			"version": "9.3.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@types/nock/-/nock-9.3.1.tgz",
+			"integrity": "sha1-fXYaQ6EK68fsa64p2Jr8bL/6XTA=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "10.14.7",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/@types/node/-/node-10.14.7.tgz",
+			"integrity": "sha1-GFTwqaqNLNaBjWB7PQkTRsZzA2I="
+		},
+		"agent-base": {
+			"version": "4.2.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/agent-base/-/agent-base-4.2.1.tgz",
+			"integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
+		"ansi-align": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-align/-/ansi-align-2.0.0.tgz",
+			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"requires": {
+				"string-width": "^2.0.0"
+			}
+		},
+		"ansi-colors": {
+			"version": "3.2.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM="
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
+		},
+		"ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"append-transform": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+			"requires": {
+				"default-require-extensions": "^2.0.0"
+			}
+		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+		},
+		"arg": {
+			"version": "4.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/arg/-/arg-4.1.0.tgz",
+			"integrity": "sha1-WDxRgZlBngA3q7dAYsN/hRnldfA="
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"argv": {
+			"version": "0.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/argv/-/argv-0.0.2.tgz",
+			"integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas="
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
+		},
+		"async": {
+			"version": "1.5.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"boxen": {
+			"version": "1.3.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/boxen/-/boxen-1.3.0.tgz",
+			"integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
+			"requires": {
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^2.0.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^1.2.0",
+				"widest-line": "^2.0.0"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"caching-transform": {
+			"version": "3.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/caching-transform/-/caching-transform-3.0.2.tgz",
+			"integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
+			"requires": {
+				"hasha": "^3.0.0",
+				"make-dir": "^2.0.0",
+				"package-hash": "^3.0.0",
+				"write-file-atomic": "^2.4.2"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"camelcase": {
+			"version": "4.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+		},
+		"camelcase-keys": {
+			"version": "4.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+			"requires": {
+				"camelcase": "^4.1.0",
+				"map-obj": "^2.0.0",
+				"quick-lru": "^1.0.0"
+			}
+		},
+		"capture-stack-trace": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+			"integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10="
+		},
+		"chai": {
+			"version": "4.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chai/-/chai-4.2.0.tgz",
+			"integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+			"requires": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4="
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+		},
+		"ci-info": {
+			"version": "1.6.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ci-info/-/ci-info-1.6.0.tgz",
+			"integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc="
+		},
+		"clang-format": {
+			"version": "1.2.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/clang-format/-/clang-format-1.2.3.tgz",
+			"integrity": "sha1-J2NWGqdEnENzdID43zorW2bmzzc=",
+			"requires": {
+				"async": "^1.5.2",
+				"glob": "^7.0.0",
+				"resolve": "^1.1.6"
+			}
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"requires": {
+				"restore-cursor": "^2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"codecov": {
+			"version": "3.5.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/codecov/-/codecov-3.5.0.tgz",
+			"integrity": "sha1-PQdIky+ctB4a1/Ifo0bvGysb7Uc=",
+			"requires": {
+				"argv": "^0.0.2",
+				"ignore-walk": "^3.0.1",
+				"js-yaml": "^3.13.1",
+				"teeny-request": "^3.11.3",
+				"urlgrey": "^0.4.4"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"commander": {
+			"version": "2.20.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI="
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"configstore": {
+			"version": "3.1.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/configstore/-/configstore-3.1.2.tgz",
+			"integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
+			"requires": {
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			}
+		},
+		"convert-source-map": {
+			"version": "1.6.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"cp-file": {
+			"version": "6.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cp-file/-/cp-file-6.2.0.tgz",
+			"integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^2.0.0",
+				"nested-error-stacks": "^2.0.0",
+				"pify": "^4.0.1",
+				"safe-buffer": "^5.0.1"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"requires": {
+				"capture-stack-trace": "^1.0.0"
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"requires": {
+				"array-find-index": "^1.0.1"
+			}
+		},
+		"debug": {
+			"version": "3.2.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/debug/-/debug-3.2.6.tgz",
+			"integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decamelize-keys": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"requires": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+				}
+			}
+		},
+		"deep-eql": {
+			"version": "3.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+			"requires": {
+				"type-detect": "^4.0.0"
+			}
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
+		},
+		"deepmerge": {
+			"version": "2.2.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/deepmerge/-/deepmerge-2.2.1.tgz",
+			"integrity": "sha1-XT/yKgHAD2RUBaL7wX0HeKGAEXA=",
+			"optional": true
+		},
+		"default-require-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"requires": {
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+			"requires": {
+				"is-obj": "^1.0.0"
+			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"entities": {
+			"version": "1.1.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY="
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0="
+		},
+		"es6-promise": {
+			"version": "4.2.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/es6-promise/-/es6-promise-4.2.6.tgz",
+			"integrity": "sha1-toXt2CWIhjZepitX0w3ij63Nl08="
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			}
+		},
+		"external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"find-cache-dir": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+			"integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+			"requires": {
+				"commondir": "^1.0.1",
+				"make-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "^2.0.0"
+			}
+		},
+		"flat": {
+			"version": "4.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/flat/-/flat-4.1.0.tgz",
+			"integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+			"requires": {
+				"is-buffer": "~2.0.3"
+			}
+		},
+		"foreground-child": {
+			"version": "1.5.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/foreground-child/-/foreground-child-1.5.6.tgz",
+			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+			"requires": {
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "4.0.2",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cross-spawn/-/cross-spawn-4.0.2.tgz",
+					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				}
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
+		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"glob": {
+			"version": "7.1.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"requires": {
+				"ini": "^1.3.4"
+			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4="
+		},
+		"got": {
+			"version": "6.7.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/got/-/got-6.7.1.tgz",
+			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"requires": {
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
+		},
+		"gts": {
+			"version": "0.9.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/gts/-/gts-0.9.0.tgz",
+			"integrity": "sha1-spJ3qmJqvoBBGAueObuPPa7+ZIY=",
+			"requires": {
+				"chalk": "^2.4.1",
+				"clang-format": "1.2.3",
+				"diff": "^3.5.0",
+				"entities": "^1.1.1",
+				"inquirer": "^6.0.0",
+				"meow": "^5.0.0",
+				"pify": "^4.0.0",
+				"rimraf": "^2.6.2",
+				"tslint": "^5.9.1",
+				"update-notifier": "^2.5.0",
+				"write-file-atomic": "^2.3.0"
+			}
+		},
+		"handlebars": {
+			"version": "4.1.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+				}
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+		},
+		"hasha": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/hasha/-/hasha-3.0.0.tgz",
+			"integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+			"requires": {
+				"is-stream": "^1.0.1"
+			}
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
+		},
+		"hosted-git-info": {
+			"version": "2.7.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc="
+		},
+		"https-proxy-agent": {
+			"version": "2.2.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+			"integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+			"requires": {
+				"agent-base": "^4.1.0",
+				"debug": "^3.1.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"ignore-walk": {
+			"version": "3.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ignore-walk/-/ignore-walk-3.0.1.tgz",
+			"integrity": "sha1-qD5i59JyrA47VRqqgoMaGbafgvg=",
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
+		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indent-string": {
+			"version": "3.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/indent-string/-/indent-string-3.2.0.tgz",
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+		},
+		"inquirer": {
+			"version": "6.3.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/inquirer/-/inquirer-6.3.1.tgz",
+			"integrity": "sha1-ekE7XnlQgRATo9tJHGHR87d26Oc=",
+			"requires": {
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.11",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.4.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.1.0",
+				"through": "^2.3.6"
+			}
+		},
+		"invert-kv": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI="
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-buffer": {
+			"version": "2.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-buffer/-/is-buffer-2.0.3.tgz",
+			"integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU="
+		},
+		"is-ci": {
+			"version": "1.2.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-ci/-/is-ci-1.2.1.tgz",
+			"integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
+			"requires": {
+				"ci-info": "^1.5.0"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-installed-globally": {
+			"version": "0.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"requires": {
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
+			}
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"requires": {
+				"path-is-inside": "^1.0.1"
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+			"integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k="
+		},
+		"istanbul-lib-hook": {
+			"version": "2.0.7",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+			"integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
+			"requires": {
+				"append-transform": "^1.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.3.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+			"integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+			"requires": {
+				"@babel/generator": "^7.4.0",
+				"@babel/parser": "^7.4.3",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0",
+				"istanbul-lib-coverage": "^2.0.5",
+				"semver": "^6.0.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "2.0.8",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+			"integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+			"integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"rimraf": "^2.6.3",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.2.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+			"integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
+			"requires": {
+				"handlebars": "^4.1.2"
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
+		},
+		"js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json5": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+			"optional": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"optional": true
+				}
+			}
+		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"requires": {
+				"package-json": "^4.0.0"
+			}
+		},
+		"lcid": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+			"requires": {
+				"invert-kv": "^2.0.0"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
+			"requires": {
+				"chalk": "^2.0.1"
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"requires": {
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
+			}
+		},
+		"lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
+		},
+		"lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+			"requires": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+			"requires": {
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"make-error": {
+			"version": "1.3.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-error/-/make-error-1.3.5.tgz",
+			"integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg="
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
+		"map-obj": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/map-obj/-/map-obj-2.0.0.tgz",
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+		},
+		"mem": {
+			"version": "4.3.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+			"requires": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
+				}
+			}
+		},
+		"meow": {
+			"version": "5.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/meow/-/meow-5.0.0.tgz",
+			"integrity": "sha1-38c9Y6mvxxSl43F2DrXIi5EHiqQ=",
+			"requires": {
+				"camelcase-keys": "^4.0.0",
+				"decamelize-keys": "^1.0.0",
+				"loud-rejection": "^1.0.0",
+				"minimist-options": "^3.0.1",
+				"normalize-package-data": "^2.3.4",
+				"read-pkg-up": "^3.0.0",
+				"redent": "^2.0.0",
+				"trim-newlines": "^2.0.0",
+				"yargs-parser": "^10.0.0"
+			}
+		},
+		"merge-source-map": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/merge-source-map/-/merge-source-map-1.1.0.tgz",
+			"integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+			"requires": {
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+				}
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"minimist-options": {
+			"version": "3.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimist-options/-/minimist-options-3.0.2.tgz",
+			"integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
+			"requires": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "6.1.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mocha/-/mocha-6.1.4.tgz",
+			"integrity": "sha1-41+tokLVQ0p+Fj1VXHBfaHWVFkA=",
+			"requires": {
+				"ansi-colors": "3.2.3",
+				"browser-stdout": "1.3.1",
+				"debug": "3.2.6",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"find-up": "3.0.0",
+				"glob": "7.1.3",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.13.1",
+				"log-symbols": "2.2.0",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"ms": "2.1.1",
+				"node-environment-flags": "1.0.5",
+				"object.assign": "4.1.0",
+				"strip-json-comments": "2.0.1",
+				"supports-color": "6.0.0",
+				"which": "1.3.1",
+				"wide-align": "1.1.3",
+				"yargs": "13.2.2",
+				"yargs-parser": "13.0.0",
+				"yargs-unparser": "1.5.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+				},
+				"supports-color": {
+					"version": "6.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-6.0.0.tgz",
+					"integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs-parser/-/yargs-parser-13.0.0.tgz",
+					"integrity": "sha1-P8RPPnaovbHMNgLoYBCGAuXM3os=",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"ms": {
+			"version": "2.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"neo-async": {
+			"version": "2.6.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw="
+		},
+		"nested-error-stacks": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+			"integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE="
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
+		},
+		"nock": {
+			"version": "10.0.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/nock/-/nock-10.0.6.tgz",
+			"integrity": "sha1-5tkO56aLjPwqt/YSfn2Zqn0T0RE=",
+			"requires": {
+				"chai": "^4.1.2",
+				"debug": "^4.1.0",
+				"deep-equal": "^1.0.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.5",
+				"mkdirp": "^0.5.0",
+				"propagate": "^1.0.0",
+				"qs": "^6.5.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"node-environment-flags": {
+			"version": "1.0.5",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+			"integrity": "sha1-+pMCdfW/Xa4YjWGSsktMi7rD12o=",
+			"requires": {
+				"object.getownpropertydescriptors": "^2.0.3",
+				"semver": "^5.7.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"node-fetch": {
+			"version": "2.6.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/node-fetch/-/node-fetch-2.6.0.tgz",
+			"integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "^2.0.0"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nyc": {
+			"version": "14.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/nyc/-/nyc-14.1.1.tgz",
+			"integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
+			"requires": {
+				"archy": "^1.0.0",
+				"caching-transform": "^3.0.2",
+				"convert-source-map": "^1.6.0",
+				"cp-file": "^6.2.0",
+				"find-cache-dir": "^2.1.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.3",
+				"istanbul-lib-coverage": "^2.0.5",
+				"istanbul-lib-hook": "^2.0.7",
+				"istanbul-lib-instrument": "^3.3.0",
+				"istanbul-lib-report": "^2.0.8",
+				"istanbul-lib-source-maps": "^3.0.6",
+				"istanbul-reports": "^2.2.4",
+				"js-yaml": "^3.13.1",
+				"make-dir": "^2.1.0",
+				"merge-source-map": "^1.1.0",
+				"resolve-from": "^4.0.0",
+				"rimraf": "^2.6.3",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^5.2.3",
+				"uuid": "^3.3.2",
+				"yargs": "^13.2.2",
+				"yargs-parser": "^13.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				},
+				"yargs-parser": {
+					"version": "13.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs-parser/-/yargs-parser-13.1.0.tgz",
+					"integrity": "sha1-cBa23QPijhQYpRDiWL5L/1oxE48=",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4="
+		},
+		"p-limit": {
+			"version": "1.3.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+			"requires": {
+				"p-try": "^1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "^1.1.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"package-hash": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/package-hash/-/package-hash-3.0.0.tgz",
+			"integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
+			"requires": {
+				"graceful-fs": "^4.1.15",
+				"hasha": "^3.0.0",
+				"lodash.flattendeep": "^4.4.0",
+				"release-zalgo": "^1.0.0"
+			}
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"requires": {
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw="
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+			"requires": {
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"pathval": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pathval/-/pathval-1.1.0.tgz",
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+		},
+		"pify": {
+			"version": "4.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+			"requires": {
+				"find-up": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+				}
+			}
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"propagate": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/propagate/-/propagate-1.0.0.tgz",
+			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"qs": {
+			"version": "6.7.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/qs/-/qs-6.7.0.tgz",
+			"integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
+		},
+		"quick-lru": {
+			"version": "1.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/quick-lru/-/quick-lru-1.1.0.tgz",
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"requires": {
+				"find-up": "^2.0.0",
+				"read-pkg": "^3.0.0"
+			}
+		},
+		"redent": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/redent/-/redent-2.0.0.tgz",
+			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+			"requires": {
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.4.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+			"integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
+			"requires": {
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"requires": {
+				"rc": "^1.0.1"
+			}
+		},
+		"release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"requires": {
+				"es6-error": "^4.0.1"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
+		},
+		"resolve": {
+			"version": "1.11.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/resolve/-/resolve-1.11.0.tgz",
+			"integrity": "sha1-QBSHC6KWF2uGND1Qtg87UGCc4jI=",
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY="
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"requires": {
+				"is-promise": "^2.1.0"
+			}
+		},
+		"rxjs": {
+			"version": "6.5.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/rxjs/-/rxjs-6.5.2.tgz",
+			"integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+		},
+		"semver": {
+			"version": "6.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-6.1.1.tgz",
+			"integrity": "sha1-U/U9qbMLIQPNTxXqs6GOy8shDJs="
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"requires": {
+				"semver": "^5.0.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-support": {
+			"version": "0.5.12",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/source-map-support/-/source-map-support-0.5.12.tgz",
+			"integrity": "sha1-tPOxDVGFelrwE4086AA7IBYT1Zk=",
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+				}
+			}
+		},
+		"spawn-wrap": {
+			"version": "1.4.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+			"integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
+			"requires": {
+				"foreground-child": "^1.5.6",
+				"mkdirp": "^0.5.0",
+				"os-homedir": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.2",
+				"which": "^1.3.0"
+			}
+		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+			"integrity": "sha1-dezRqI3owYTvAV6vtRtbSL/RG7E="
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+			"requires": {
+				"ansi-regex": "^4.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+				}
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-indent": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"teeny-request": {
+			"version": "3.11.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/teeny-request/-/teeny-request-3.11.3.tgz",
+			"integrity": "sha1-M1xin3ZF5dZZk2LfLzIwxMvCOlU=",
+			"requires": {
+				"https-proxy-agent": "^2.2.1",
+				"node-fetch": "^2.2.0",
+				"uuid": "^3.3.2"
+			}
+		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"requires": {
+				"execa": "^0.7.0"
+			}
+		},
+		"test-exclude": {
+			"version": "5.2.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/test-exclude/-/test-exclude-5.2.3.tgz",
+			"integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+			"requires": {
+				"glob": "^7.1.3",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^2.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+				},
+				"read-pkg-up": {
+					"version": "4.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+					"integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+					"requires": {
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				}
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"trim-newlines": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/trim-newlines/-/trim-newlines-2.0.0.tgz",
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"ts-mocha": {
+			"version": "6.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ts-mocha/-/ts-mocha-6.0.0.tgz",
+			"integrity": "sha1-QLjFRi/85vXc7l/3KWVbKVjyblA=",
+			"requires": {
+				"ts-node": "7.0.1",
+				"tsconfig-paths": "^3.5.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"ts-node": {
+					"version": "7.0.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ts-node/-/ts-node-7.0.1.tgz",
+					"integrity": "sha1-lWLcLR5tJI0kvFX3c+P2FDN9m68=",
+					"requires": {
+						"arrify": "^1.0.0",
+						"buffer-from": "^1.1.0",
+						"diff": "^3.1.0",
+						"make-error": "^1.1.1",
+						"minimist": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"source-map-support": "^0.5.6",
+						"yn": "^2.0.0"
+					}
+				}
+			}
+		},
+		"ts-node": {
+			"version": "8.2.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ts-node/-/ts-node-8.2.0.tgz",
+			"integrity": "sha1-Sol1SwBWC7JM1UUm4Whfo4xF8kA=",
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.6",
+				"yn": "^3.0.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/diff/-/diff-4.0.1.tgz",
+					"integrity": "sha1-DGZ8tGfru1zqfxTxNcwtuneAqP8="
+				},
+				"yn": {
+					"version": "3.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yn/-/yn-3.1.0.tgz",
+					"integrity": "sha1-/L4ttjYQNhr8xeueCskel20EYRQ="
+				}
+			}
+		},
+		"tsconfig-paths": {
+			"version": "3.8.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/tsconfig-paths/-/tsconfig-paths-3.8.0.tgz",
+			"integrity": "sha1-TjQgLVtBlY8mnPVrAe2VuFPVn3I=",
+			"optional": true,
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"deepmerge": "^2.0.1",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"optional": true
+				}
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
+		},
+		"tslint": {
+			"version": "5.16.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/tslint/-/tslint-5.16.0.tgz",
+			"integrity": "sha1-rmH5xamNKVuaT0VTsbHoMcGYTWc=",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.13.0",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+			"requires": {
+				"tslib": "^1.8.1"
+			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
+		},
+		"typescript": {
+			"version": "3.2.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha1-xYXLlSkSJj2RW0YnJs4kS6UQ7z0="
+		},
+		"uglify-js": {
+			"version": "3.5.15",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/uglify-js/-/uglify-js-3.5.15.tgz",
+			"integrity": "sha1-/itTeP0LCeEWhkBBQ3v/iJEFziQ=",
+			"optional": true,
+			"requires": {
+				"commander": "~2.20.0",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"optional": true
+				}
+			}
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"requires": {
+				"crypto-random-string": "^1.0.0"
+			}
+		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
+		"update-notifier": {
+			"version": "2.5.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/update-notifier/-/update-notifier-2.5.0.tgz",
+			"integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
+			"requires": {
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"requires": {
+				"prepend-http": "^1.0.1"
+			}
+		},
+		"urlgrey": {
+			"version": "0.4.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/urlgrey/-/urlgrey-0.4.4.tgz",
+			"integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8="
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/which/-/which-1.3.1.tgz",
+			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
+		"widest-line": {
+			"version": "2.0.1",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/widest-line/-/widest-line-2.0.1.tgz",
+			"integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
+			"requires": {
+				"string-width": "^2.1.1"
+			}
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "2.4.3",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+			"integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "13.2.2",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs/-/yargs-13.2.2.tgz",
+			"integrity": "sha1-DBAfWArpXOp/Odkn53cOP9yX+ZM=",
+			"requires": {
+				"cliui": "^4.0.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"os-locale": "^3.1.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^3.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs-parser/-/yargs-parser-13.1.0.tgz",
+					"integrity": "sha1-cBa23QPijhQYpRDiWL5L/1oxE48=",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "10.1.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs-parser/-/yargs-parser-10.1.0.tgz",
+			"integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
+			"requires": {
+				"camelcase": "^4.1.0"
+			}
+		},
+		"yargs-unparser": {
+			"version": "1.5.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+			"integrity": "sha1-8rsqfoPLyHu5XI5XKCigbJrdbg0=",
+			"requires": {
+				"flat": "^4.1.0",
+				"lodash": "^4.17.11",
+				"yargs": "^12.0.5"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "1.0.3",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/get-caller-file/-/get-caller-file-1.0.3.tgz",
+					"integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o="
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "11.1.1",
+					"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yargs-parser/-/yargs-parser-11.1.1.tgz",
+					"integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"yn": {
+			"version": "2.0.0",
+			"resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yn/-/yn-2.0.0.tgz",
+			"integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+		}
+	}
+}

--- a/packages/opencensus-exporter-object/package.json
+++ b/packages/opencensus-exporter-object/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@opencensus/exporter-object",
+	"version": "0.0.13",
+	"description": "OpenCensus Object Exporter allows the user to collect and access traces with OpenCensus Node.js.",
+	"main": "build/src/index.js",
+	"types": "build/src/index.d.ts",
+	"repository": "census-instrumentation/opencensus-node",
+	"scripts": {
+	  "test": "nyc ts-mocha -p ./tsconfig.json test/**/*.ts",
+	  "codecov": "nyc report --reporter=json && codecov -f coverage/*.json",
+	  "clean": "rimraf build/*",
+	  "check": "gts check",
+	  "compile": "tsc -p .",
+	  "fix": "gts fix",
+	  "prepare": "npm run compile",
+	  "posttest": "npm run check"
+	},
+	"keywords": [
+	  "opencensus",
+	  "nodejs",
+	  "tracing",
+	  "profiling"
+	],
+	"author": "Google Inc.",
+	"license": "Apache-2.0",
+	"engines": {
+	  "node": ">=8"
+	},
+	"files": [
+	  "build/src/**/*.js",
+	  "build/src/**/*.d.ts",
+	  "doc",
+	  "CHANGELOG.md",
+	  "LICENSE",
+	  "README.md"
+	],
+	"nyc": {
+	  "extension": [
+	    ".ts",
+	    ".tsx"
+	  ],
+	  "exclude": [
+	    "**/*.d.ts",
+	    "build/**/**/*.js"
+	  ],
+	  "all": true
+	},
+	"publishConfig": {
+	  "access": "public"
+	},
+	"devDependencies": {
+	  "@types/mocha": "^5.2.5",
+	  "@types/nock": "^9.1.3",
+	  "@types/node": "^10.12.12",
+	  "codecov": "^3.4.0",
+	  "gts": "^0.9.0",
+	  "mocha": "^6.1.0",
+	  "nyc": "14.1.1",
+	  "ts-mocha": "^6.0.0",
+	  "ts-node": "^8.0.0",
+	  "typescript": "~3.2.0"
+	},
+	"dependencies": {
+	  "@opencensus/core": "^0.0.13"
+	}
+}

--- a/packages/opencensus-exporter-object/src/index.ts
+++ b/packages/opencensus-exporter-object/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2019 OpenCensus Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './object';

--- a/packages/opencensus-exporter-object/src/object.ts
+++ b/packages/opencensus-exporter-object/src/object.ts
@@ -19,7 +19,7 @@ import {logger, Logger} from '@opencensus/core';
 
 /** Object Exporter manager class */
 export class ObjectTraceExporter implements Exporter {
-  buffer: ExporterBuffer;
+  private buffer: ExporterBuffer;
   logger: Logger;
 
   startedSpans: Span[] = [];

--- a/packages/opencensus-exporter-object/src/object.ts
+++ b/packages/opencensus-exporter-object/src/object.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 OpenCensus Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Exporter, ExporterBuffer, ExporterConfig, Span} from '@opencensus/core';
+import {logger, Logger} from '@opencensus/core';
+
+/** Object Exporter manager class */
+export class ObjectTraceExporter implements Exporter {
+  buffer: ExporterBuffer;
+  logger: Logger;
+
+  startedSpans: Span[] = [];
+  endedSpans: Span[] = [];
+  publishedSpans: Span[] = [];
+
+  constructor(options: ExporterConfig = {}) {
+    this.buffer = new ExporterBuffer(this, options);
+    this.logger = options.logger || logger.logger();
+  }
+
+  /**
+   * Is called whenever a span is started.
+   * @param span the started span
+   */
+  onStartSpan(span: Span) {
+    this.startedSpans.push(span);
+  }
+
+  /**
+   * Is called whenever a span is ended.
+   * @param span the ended span
+   */
+  onEndSpan(span: Span) {
+    this.endedSpans.push(span);
+    this.buffer.addToBuffer(span);
+  }
+
+  /**
+   * Send the spans to memory store.
+   * @param spans The list of spans to transmit to memory.
+   */
+  publish(spans: Span[]): Promise<void> {
+    this.publishedSpans.push(...spans);
+    return Promise.resolve();
+  }
+
+  /**
+   * Reset in-memory stores.
+   */
+  reset() {
+    this.startedSpans = [];
+    this.endedSpans = [];
+    this.publishedSpans = [];
+  }
+}

--- a/packages/opencensus-exporter-object/src/object.ts
+++ b/packages/opencensus-exporter-object/src/object.ts
@@ -19,7 +19,7 @@ import {logger, Logger} from '@opencensus/core';
 
 /** Object Exporter manager class */
 export class ObjectTraceExporter implements Exporter {
-  private buffer: ExporterBuffer;
+  public buffer: ExporterBuffer;
   logger: Logger;
 
   startedSpans: Span[] = [];

--- a/packages/opencensus-exporter-object/src/object.ts
+++ b/packages/opencensus-exporter-object/src/object.ts
@@ -19,9 +19,8 @@ import {logger, Logger} from '@opencensus/core';
 
 /** Object Exporter manager class */
 export class ObjectTraceExporter implements Exporter {
-  public buffer: ExporterBuffer;
+  buffer: ExporterBuffer;
   logger: Logger;
-
   startedSpans: Span[] = [];
   endedSpans: Span[] = [];
   publishedSpans: Span[] = [];

--- a/packages/opencensus-exporter-object/test/test-object.ts
+++ b/packages/opencensus-exporter-object/test/test-object.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2019 OpenCensus Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CoreTracer, Span, SpanKind, TracerConfig} from '@opencensus/core';
+import * as assert from 'assert';
+
+import {ObjectTraceExporter} from '../src/object';
+
+/** Default config for traces tests */
+const defaultConfig: TracerConfig = {
+  samplingRate: 1
+};
+
+/** Object Exporter tests */
+describe('Object Exporter', () => {
+  /** Should called when a span started */
+  describe('onStartSpan()', () => {
+    it('Should add spans to the started spans', () => {
+      const exporter = new ObjectTraceExporter({});
+      const tracer = new CoreTracer();
+      tracer.registerSpanEventListener(exporter);
+      tracer.start(defaultConfig);
+
+      tracer.startRootSpan({name: 'root-test'}, (rootSpan: Span) => {
+        assert.strictEqual(exporter.startedSpans.length, 1);
+        rootSpan.startChildSpan({name: 'spanTest', kind: SpanKind.CLIENT});
+        assert.strictEqual(exporter.startedSpans.length, 2);
+      });
+    });
+  });
+
+  /** Should called when a span ended */
+  describe('onEndSpan()', () => {
+    it('Should add spans to the ended spans and to buffer', () => {
+      const exporter = new ObjectTraceExporter({});
+      const tracer = new CoreTracer();
+      tracer.registerSpanEventListener(exporter);
+      tracer.start(defaultConfig);
+
+      tracer.startRootSpan({name: 'root-test'}, (rootSpan: Span) => {
+        const span =
+            rootSpan.startChildSpan({name: 'spanTest', kind: SpanKind.CLIENT});
+        span.end();
+        assert.strictEqual(exporter.endedSpans.length, 1);
+        rootSpan.end();
+        assert.strictEqual(exporter.endedSpans.length, 2);
+        assert.ok(exporter.buffer.getQueue().length > 0);
+      });
+    });
+  });
+
+  /** Should add traces to the published store */
+  describe('publish()', () => {
+    it('should add spans to the published store', () => {
+      const exporter = new ObjectTraceExporter({});
+      const tracer = new CoreTracer();
+      tracer.start(defaultConfig);
+
+      return tracer.startRootSpan(
+          {name: 'root-test'}, async (rootSpan: Span) => {
+            const span = rootSpan.startChildSpan(
+                {name: 'spanTest', kind: SpanKind.CLIENT});
+            span.end();
+            rootSpan.end();
+            await exporter.publish([rootSpan, rootSpan]);
+            assert.strictEqual(exporter.publishedSpans.length, 2);
+          });
+    });
+  });
+
+  /** Should empty memory stores */
+  describe('reset()', () => {
+    it('Should add spans to the ended spans and to buffer', () => {
+      const exporter = new ObjectTraceExporter({});
+      const tracer = new CoreTracer();
+      tracer.registerSpanEventListener(exporter);
+      tracer.start(defaultConfig);
+
+      tracer.startRootSpan({name: 'root-test'}, (rootSpan: Span) => {
+        const span =
+            rootSpan.startChildSpan({name: 'spanTest', kind: SpanKind.CLIENT});
+        span.end();
+        rootSpan.end();
+        exporter.publish([rootSpan, rootSpan]);
+
+        exporter.reset();
+        assert.deepStrictEqual(exporter.startedSpans, []);
+        assert.deepStrictEqual(exporter.endedSpans, []);
+        assert.deepStrictEqual(exporter.publishedSpans, []);
+      });
+    });
+  });
+});

--- a/packages/opencensus-exporter-object/test/test-object.ts
+++ b/packages/opencensus-exporter-object/test/test-object.ts
@@ -16,7 +16,6 @@
 
 import {CoreTracer, Span, SpanKind, TracerConfig} from '@opencensus/core';
 import * as assert from 'assert';
-
 import {ObjectTraceExporter} from '../src/object';
 
 /** Default config for traces tests */

--- a/packages/opencensus-exporter-object/tsconfig.json
+++ b/packages/opencensus-exporter-object/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "pretty": true,
+    "module": "commonjs",
+    "target": "es6",
+    "strictNullChecks": true,
+    "noUnusedLocals": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
I'm considering to use an in-memory exporter approach for unit testing.
This PR adds an `object-exporter` that stores started, ended and published spans in memory and makes them accessible.