### PR TITLE
Fixes #566: set CurrentRootSpan whenever created span is RootSpan

### DIFF
--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -310,10 +310,8 @@ export class Span implements types.Span {
       parentSpanId: this.parentSpanId,
       traceState: this.traceState
     });
-    if (!this.parentSpanId) {
-      this.tracer.setCurrentRootSpan(this);
-    }
 
+    if (this.isRootSpan()) this.tracer.setCurrentRootSpan(this);
     this.tracer.onStartSpan(this);
   }
 

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -113,6 +113,34 @@ describe('Span', () => {
 
       assert.ok(span.started);
     });
+
+
+    it('should start a RootSpan and set CurrentRootSpan when parentSpanId is empty',
+       () => {
+         const rootSpan = new RootSpan(tracer, name, kind, traceId, '');
+         rootSpan.start();
+         assert.strictEqual(tracer.currentRootSpan, rootSpan);
+
+         const span = new Span(tracer, rootSpan);
+         span.start();
+         assert.strictEqual(tracer.currentRootSpan, rootSpan);
+
+         assert.ok(span.started);
+       });
+
+    it('should start a RootSpan and set CurrentRootSpan when parentSpanId is not empty',
+       () => {
+         const rootSpan =
+             new RootSpan(tracer, name, kind, traceId, 'd5955a12632d46a1');
+         rootSpan.start();
+         assert.strictEqual(tracer.currentRootSpan, rootSpan);
+
+         const span = new Span(tracer, rootSpan);
+         span.start();
+         assert.strictEqual(tracer.currentRootSpan, rootSpan);
+
+         assert.ok(span.started);
+       });
   });
 
   /**


### PR DESCRIPTION
After consolidation of `Span` and `RootSpan`, we set the RootSpan to CurrentRootSpan only when `parentSpanId` is null.

Which is:
```
if (!this.parentSpanId) {
  this.tracer.setCurrentRootSpan(this);
}
```
This causes an issue when `parentSpanId` is propagating on wire. In that case, although we create a new `RootSpan` it does not get set to CurrentRootSpan, therefore we create a new root span (instead of child span) for subsequent (outgoing) request.

which is:
```
// Checks if this outgoing request is part of an operation by checking
// if there is a current root span, if so, we create a child span. In
// case there is no root span, this means that the outgoing request is
// the first operation, therefore we create a root span.

if (!plugin.tracer.currentRootSpan) {
  // outgoingRequest starting a root span
  return plugin.tracer.startRootSpan(traceOptions);
} else {
  // outgoingRequest starting a child span
  const span = plugin.tracer.startChildSpan(traceOptions);
  ....
}
```
Please use https://github.com/census-instrumentation/opencensus-node/issues/566#issuecomment-497739363 example to reproduce the problem.

This PR will set CurrentRootSpan whenever created/started span is `RootSpan`.