### PR TITLE
Fix nested child span support for Zipkin

### DIFF
--- a/packages/opencensus-exporter-zipkin/src/zipkin.ts
+++ b/packages/opencensus-exporter-zipkin/src/zipkin.ts
@@ -144,9 +144,9 @@ export class ZipkinTraceExporter implements Exporter {
       /** RootSpan data */
       spanList.push(this.translateSpan(span));
 
-      // Builds spans data
-      for (const child of span.spans) {
-        spanList.push(this.translateSpan(child));
+      // Traverse child spans recursively
+      if (span.spans.length > 0) {
+        Array.prototype.push.apply(spanList, this.mountSpanList(span.spans));
       }
     }
 


### PR DESCRIPTION
0.14.0 unfortunately, breaks nested child support in Zipkin.

- fix support for nested child spans
- test for published spans

Related to:
https://github.com/census-instrumentation/opencensus-node/pull/545/files#diff-427d5fa67f108e0a06e484bd47da9015R81