### PR TITLE
feat(nodejs-base): do not hook require when not necessary

### DIFF
--- a/packages/opencensus-nodejs-base/src/trace/instrumentation/plugin-loader.ts
+++ b/packages/opencensus-nodejs-base/src/trace/instrumentation/plugin-loader.ts
@@ -126,7 +126,18 @@ export class PluginLoader {
    */
   loadPlugins(pluginList: PluginNames) {
     if (this.hookState === HookState.UNINITIALIZED) {
-      hook(Object.keys(pluginList), (exports, name, basedir) => {
+      const modulesToHook = Object.keys(pluginList);
+
+      // Do not hook require when no module is provided. In this case it is
+      // not necessary. With skipping this step we lower our footprint in
+      // customer applications and require-in-the-middle won't show up in CPU
+      // frames.
+      if (modulesToHook.length === 0) {
+        this.hookState = HookState.DISABLED;
+        return;
+      }
+
+      hook(modulesToHook, (exports, name, basedir) => {
         if (this.hookState !== HookState.ENABLED) {
           return exports;
         }


### PR DESCRIPTION
`require-in-the-module` frames pollute CPU Profiles, also performance impact is not clear.
Do not enable when not necessary.

![Screen Shot 2019-07-02 at 1 56 15 PM](https://user-images.githubusercontent.com/1764512/60546057-68b06780-9cd1-11e9-9806-423d6b04cd8a.png)
