### PR TITLE
fix(span): make child span clock relative to root span

### DIFF
--- a/packages/opencensus-core/src/internal/clock.ts
+++ b/packages/opencensus-core/src/internal/clock.ts
@@ -27,9 +27,11 @@ export class Clock {
   /** The duration between start and end of the clock. */
   private diff: [number, number] = [0, 0];
 
-  /** Constructs a new SamplerImpl instance. */
-  constructor() {
-    this.startTimeLocal = new Date();
+  /** Constructs a new Clock instance. */
+  constructor(startTime?: Date) {
+    // In some cases clocks need to be relative to other resources, passing a
+    // startTime makes it possible.
+    this.startTimeLocal = startTime || new Date();
     this.hrtimeLocal = process.hrtime();
   }
 
@@ -40,6 +42,14 @@ export class Clock {
     }
     this.diff = process.hrtime(this.hrtimeLocal);
     this.endedLocal = true;
+  }
+
+  /** Gets the current date from ellapsed milliseconds and start time. */
+  get currentDate(): Date {
+    const diff = process.hrtime(this.hrtimeLocal);
+    const ns = diff[0] * 1e9 + diff[1];
+    const ellapsed = ns / 1e6;
+    return new Date(this.startTime.getTime() + ellapsed);
   }
 
   /** Gets the duration of the clock. */

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -316,7 +316,12 @@ export class Span implements types.Span {
       );
       return;
     }
-    this.clock = new Clock();
+    // start child span's clock from root's current time to preserve integrity.
+    if (this.parentSpan) {
+      this.clock = new Clock(this.parentSpan.clock.currentDate);
+    } else {
+      this.clock = new Clock();
+    }
     this.startedLocal = true;
     this.logger.debug('starting %s  %o', this.className, {
       traceId: this.traceId,

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -53,8 +53,9 @@ describe('Span', () => {
       rootSpan.start();
       const dayInMs = 24 * 60 * 60 * 1000;
       const futureDate = Date.now() + dayInMs;
-      // Change rootSpan's clock to the future, so child span doesn't pick it up
-      // new Date() will be before it.
+      // Change rootSpan's clock to the future, so if child span doesn't pick
+      // root's clock and just uses new Date(), child span's time will be before
+      // root span's for sure.
       // tslint:disable-next-line
       rootSpan.clock.startTimeLocal = new Date(futureDate);
       const span = new Span(tracer, rootSpan);

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -51,17 +51,9 @@ describe('Span', () => {
     it('should use relative clock for child spans', () => {
       const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
       rootSpan.start();
-      const dayInMs = 24 * 60 * 60 * 1000;
-      const futureDate = Date.now() + dayInMs;
-      // Change rootSpan's clock to the future, so if child span doesn't pick
-      // root's clock and just uses new Date(), child span's time will be before
-      // root span's for sure.
-      // tslint:disable-next-line
-      rootSpan.clock.startTimeLocal = new Date(futureDate);
       const span = new Span(tracer, rootSpan);
       span.start();
       assert.ok(rootSpan.startTime.getTime() <= span.startTime.getTime());
-      assert.ok(futureDate <= span.startTime.getTime());
     });
   });
 

--- a/packages/opencensus-core/test/test-span.ts
+++ b/packages/opencensus-core/test/test-span.ts
@@ -47,6 +47,21 @@ describe('Span', () => {
       const span = new Span(tracer, rootSpan);
       assert.ok(span instanceof Span);
     });
+
+    it('should use relative clock for child spans', () => {
+      const rootSpan = new RootSpan(tracer, name, kind, traceId, parentSpanId);
+      rootSpan.start();
+      const dayInMs = 24 * 60 * 60 * 1000;
+      const futureDate = Date.now() + dayInMs;
+      // Change rootSpan's clock to the future, so child span doesn't pick it up
+      // new Date() will be before it.
+      // tslint:disable-next-line
+      rootSpan.clock.startTimeLocal = new Date(futureDate);
+      const span = new Span(tracer, rootSpan);
+      span.start();
+      assert.ok(rootSpan.startTime.getTime() <= span.startTime.getTime());
+      assert.ok(futureDate <= span.startTime.getTime());
+    });
   });
 
   /**


### PR DESCRIPTION
`new Date()` is vulnerable to [clock drifts](https://en.wikipedia.org/wiki/Clock_drift). This PR changes child span clocks to start relative to root span by using `process.hrtime`.  Otherwise in-process spans can have an invalid casualty.