### PR TITLE
feat(span): make tracer available on span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Feat, make `tracer` property available on spans.
 
 ## 0.0.15 - 2019-07-09
 - Update dependency codecov to 3.5 (#612)

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-root-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-root-span.ts
@@ -30,7 +30,7 @@ export class NoRecordRootSpan extends NoRecordSpan {
    */
   private parentSpanIdLocal: string;
   /** A tracer object */
-  tracer: types.TracerBase;
+  readonly tracer: types.TracerBase;
 
   /**
    * Constructs a new NoRecordRootSpanImpl instance.

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-root-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-root-span.ts
@@ -20,8 +20,6 @@ import { NoRecordSpan } from './no-record-span';
 
 /** Implementation for the Span class that does not record trace events. */
 export class NoRecordRootSpan extends NoRecordSpan {
-  /** A tracer object */
-  private tracer: types.TracerBase;
   /** Its trace ID. */
   private traceIdLocal: string;
   /** Its trace state. */
@@ -31,6 +29,8 @@ export class NoRecordRootSpan extends NoRecordSpan {
    * parent was likely started on another machine.
    */
   private parentSpanIdLocal: string;
+  /** A tracer object */
+  tracer: types.TracerBase;
 
   /**
    * Constructs a new NoRecordRootSpanImpl instance.
@@ -50,7 +50,7 @@ export class NoRecordRootSpan extends NoRecordSpan {
     parentSpanId: string,
     traceState?: types.TraceState
   ) {
-    super();
+    super(tracer);
     this.tracer = tracer;
     this.traceIdLocal = traceId;
     this.name = name;

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
@@ -31,6 +31,8 @@ export class NoRecordSpan implements types.Span {
   private endedLocal = false;
   /** The Span ID of this span */
   readonly id: string;
+  /** A tracer object */
+  tracer: types.TracerBase;
   /** An object to log information to */
   logger: Logger = noopLogger;
   /** A set of attributes, each in the format [KEY]:[VALUE] */
@@ -66,7 +68,8 @@ export class NoRecordSpan implements types.Span {
   droppedMessageEventsCount = 0;
 
   /** Constructs a new SpanBaseModel instance. */
-  constructor(parent?: NoRecordSpan) {
+  constructor(tracer: types.TracerBase, parent?: NoRecordSpan) {
+    this.tracer = tracer;
     this.id = randomSpanId();
     if (parent) {
       this.root = parent.root;
@@ -199,7 +202,7 @@ export class NoRecordSpan implements types.Span {
    * @param [options] A SpanOptions object to start a child span.
    */
   startChildSpan(options?: types.SpanOptions): types.Span {
-    const noRecordChild = new NoRecordSpan(this);
+    const noRecordChild = new NoRecordSpan(this.tracer, this);
     if (options && options.name) noRecordChild.name = options.name;
     if (options && options.kind) noRecordChild.kind = options.kind;
     noRecordChild.start();

--- a/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
+++ b/packages/opencensus-core/src/trace/model/no-record/no-record-span.ts
@@ -32,7 +32,7 @@ export class NoRecordSpan implements types.Span {
   /** The Span ID of this span */
   readonly id: string;
   /** A tracer object */
-  tracer: types.TracerBase;
+  readonly tracer: types.TracerBase;
   /** An object to log information to */
   logger: Logger = noopLogger;
   /** A set of attributes, each in the format [KEY]:[VALUE] */

--- a/packages/opencensus-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-core/src/trace/model/root-span.ts
@@ -30,7 +30,7 @@ export class RootSpan extends Span {
    */
   private parentSpanIdLocal: string;
   /** A tracer object */
-  tracer: types.TracerBase;
+  readonly tracer: types.TracerBase;
 
   /**
    * Constructs a new RootSpanImpl instance.

--- a/packages/opencensus-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-core/src/trace/model/root-span.ts
@@ -29,6 +29,8 @@ export class RootSpan extends Span {
    * parent was likely started on another machine.
    */
   private parentSpanIdLocal: string;
+  /** A tracer object */
+  tracer: types.TracerBase;
 
   /**
    * Constructs a new RootSpanImpl instance.
@@ -49,6 +51,7 @@ export class RootSpan extends Span {
     traceState?: types.TraceState
   ) {
     super(tracer);
+    this.tracer = tracer;
     this.traceIdLocal = traceId;
     this.name = name;
     this.kind = kind;

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -29,8 +29,6 @@ const STATUS_OK = {
 /** Defines a base model for spans. */
 export class Span implements types.Span {
   protected className: string;
-  /** A tracer object */
-  private tracer: types.TracerBase;
   /** The clock used to mesure the beginning and ending of a span */
   private clock!: Clock;
   /** Indicates if this span was started */
@@ -41,6 +39,8 @@ export class Span implements types.Span {
   private spansLocal: types.Span[];
   /** The Span ID of this span */
   readonly id: string;
+  /** A tracer object */
+  tracer: types.TracerBase;
   /** An object to log information to */
   logger: Logger = noopLogger;
   /** A set of attributes, each in the format [KEY]:[VALUE] */
@@ -386,7 +386,7 @@ export class Span implements types.Span {
         this.className,
         { id: this.id, name: this.name, kind: this.kind }
       );
-      return new NoRecordSpan();
+      return new NoRecordSpan(this.tracer);
     }
     if (!this.started) {
       this.logger.debug(
@@ -395,7 +395,7 @@ export class Span implements types.Span {
         this.className,
         { id: this.id, name: this.name, kind: this.kind }
       );
-      return new NoRecordSpan();
+      return new NoRecordSpan(this.tracer);
     }
 
     const child = new Span(this.tracer, this);

--- a/packages/opencensus-core/src/trace/model/span.ts
+++ b/packages/opencensus-core/src/trace/model/span.ts
@@ -40,7 +40,7 @@ export class Span implements types.Span {
   /** The Span ID of this span */
   readonly id: string;
   /** A tracer object */
-  tracer: types.TracerBase;
+  readonly tracer: types.TracerBase;
   /** An object to log information to */
   logger: Logger = noopLogger;
   /** A set of attributes, each in the format [KEY]:[VALUE] */

--- a/packages/opencensus-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-core/src/trace/model/tracer-base.ts
@@ -231,7 +231,7 @@ export class CoreTracerBase implements types.TracerBase {
       this.logger.debug(
         'no current trace found - must start a new root span first'
       );
-      return new NoRecordSpan();
+      return new NoRecordSpan(this);
     }
     const span = options.childOf.startChildSpan(options);
 

--- a/packages/opencensus-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-core/src/trace/model/tracer.ts
@@ -121,7 +121,7 @@ export class CoreTracer extends CoreTracerBase implements types.Tracer {
 
     return super.startChildSpan(
       Object.assign(
-        { childOf: this.currentRootSpan || new NoRecordSpan() },
+        { childOf: this.currentRootSpan || new NoRecordSpan(this) },
         options
       )
     );

--- a/packages/opencensus-core/src/trace/model/types.ts
+++ b/packages/opencensus-core/src/trace/model/types.ts
@@ -315,6 +315,11 @@ export interface Span {
   /** The Span ID of this span */
   readonly id: string;
 
+  /** A tracer object, exposong the tracer makes it possible to create child
+   * spans from the span instance like. span.tracer.startChildSpan()
+   */
+  tracer: TracerBase;
+
   /** If the parent span is in another process. */
   remoteParent: boolean;
 

--- a/packages/opencensus-core/test/test-no-record-span.ts
+++ b/packages/opencensus-core/test/test-no-record-span.ts
@@ -15,12 +15,14 @@
  */
 
 import * as assert from 'assert';
+import { CoreTracerBase } from '../src/trace/model/tracer-base';
 import { CanonicalCode, LinkType, MessageEventType } from '../src';
 import { NoRecordSpan } from '../src/trace/model/no-record/no-record-span';
 
 describe('NoRecordSpan()', () => {
   it('do not crash', () => {
-    const noRecordSpan = new NoRecordSpan();
+    const tracer = new CoreTracerBase();
+    const noRecordSpan = new NoRecordSpan(tracer);
     noRecordSpan.addAnnotation('MyAnnotation');
     noRecordSpan.addAnnotation('MyAnnotation', { myString: 'bar' });
     noRecordSpan.addAnnotation('MyAnnotation', {


### PR DESCRIPTION
Making tracer always available on spans would make it easier to create child spans from existing span instances when you pass your span around.

Further explanation:
https://github.com/open-telemetry/opentelemetry-specification/issues/21