### PR TITLE
Use Zipkin quickstart script in download instructions

### DIFF
--- a/packages/opencensus-exporter-zipkin/README.md
+++ b/packages/opencensus-exporter-zipkin/README.md
@@ -23,7 +23,7 @@ npm install @opencensus/exporter-zipkin
 To use [Zipkin](http://zipkin.io/) as your exporter, first, download from any of the three available options on [Quickstart](https://zipkin.io/pages/quickstart.html): through Docker, on Java or manually compiling the source code. Tests were executed running Zipkin with Java, through the following commands on terminal:
 
 ```bash
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+curl -sSL https://zipkin.io/quickstart.sh | bash -s
 java -jar zipkin.jar
 ```
 


### PR DESCRIPTION
The group id of the Zipkin Server maven artifact has changed in recent versions, so the previous instructions would not download the latest version of the server. The quickstart script provided by Zipkin is the recommended way to download the Zipkin Server jar and will download the latest version.