### PR TITLE
Nominating @hekike as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*               @census-instrumentation/global-owners @mayurkale22 @justindsmith @draffensperger
+*               @census-instrumentation/global-owners @mayurkale22 @hekike @draffensperger


### PR DESCRIPTION
Justin Smith is no longer associated with OpenCensus project due to other assignments. Replacing him with Peter Marton (@hekike).