### PR TITLE
Fix a TypeError of url.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Fix a TypeError of url.parse (#640)
 
 ## 0.0.17 - 2019-09-03
 - fix: allow override global trace params limits (#643)


### PR DESCRIPTION
This PR fixes TypeError occurring when `http2.connect` is called with `url.URL`.
It is permitted according to [official document](https://nodejs.org/api/http2.html#http2_http2_connect_authority_options_listener).

A following code reproduces the error.

Source:
```javascript
const tracing = require('@opencensus/nodejs');
const zipkin = require('@opencensus/exporter-zipkin');

const tracer = tracing.start({samplingRate: 1.0}).tracer;

const http2 = require('http2');

tracer.registerSpanEventListener(new zipkin.ZipkinTraceExporter({
    url: 'http://localhost:9411/api/v2/spans',
    serviceName: 'node.js-open-census-bug'
}));

const url = new URL('/index.html', 'https://example.com/');
const client = http2.connect(url);

const {
  HTTP2_HEADER_STATUS
} = http2.constants;
const headers = {};
const req = client.request(headers);
req.on('response', headers => {
  console.log(headers[HTTP2_HEADER_STATUS]);
  req.on('data', chunk => console.log(chunk));
  req.on('end', () => process.exit());
});

```

Result:
```
internal/validators.js:125
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received type object
    at validateString (internal/validators.js:125:11)
    at Url.parse (url.js:151:3)
    at Object.urlParse [as parse] (url.js:146:13)
    at ClientHttp2Stream.request.on (/Users/h-goto/projects/opencensus-bug-report/node_modules/@opencensus/instrumentation-http2/build/src/http2.js:107:34)
    at ClientHttp2Stream.contextWrapper (/Users/h-goto/projects/opencensus-bug-report/node_modules/@opencensus/core/build/src/internal/cls-ah.js:78:28)
    at ClientHttp2Stream.emit (events.js:202:15)
    at endReadableNT (_stream_readable.js:1132:12)
    at processTicksAndRejections (internal/process/next_tick.js:76:17)
```