### PR TITLE
chore: use github actions for CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,69 +8,13 @@ workflows:
   version: 2
   tests:
     jobs:
-      # Separate node8 from others to ignore any packages that no longer
-      # support node8
-      - unit_tests:
-          name: node8
-          filters: *release_tags
-          node_version: 8
-          npm_script_extra_args: --ignore @opencensus/exporter-stackdriver
-      - unit_tests:
-          name: node<< matrix.node_version >>
-          filters: *release_tags
-          matrix:
-            parameters:
-              node_version: [10, 11, 12]
       - publish_npm:
-          requires:
-            - node8
-            - node10
-            - node11
-            - node12
           filters:
             branches:
               ignore: /.*/
             <<: *release_tags
 
 jobs:
-  unit_tests:
-    docker:
-      - image: node:<< parameters.node_version >>
-        user: node
-        environment:
-          OPENCENSUS_MONGODB_TESTS: 1
-          OPENCENSUS_REDIS_TESTS: 1
-      - mongo_service:
-        image: mongo
-      - redis_service:
-        image: redis
-    parameters:
-      node_version:
-        description: The node version to run the tests with
-        type: integer
-      npm_script_extra_args:
-        description: Extra arguments passed to npm scripts
-        type: string
-        default: ""
-    steps:
-      - checkout
-      - run:
-          name: Install modules and dependencies.
-          command: npm install
-      - run:
-          name: Check code style and linting
-          command: npm run check -- << parameters.npm_script_extra_args >>
-      - run:
-          name: Ensure code compiles to JS.
-          command: npm run compile -- << parameters.npm_script_extra_args >>
-      - run:
-          name: Run unit tests.
-          command: npm run test -- << parameters.npm_script_extra_args >>
-      - run:
-          name: Submit coverage data to codecov.
-          command: npm run codecov -- << parameters.npm_script_extra_args >>
-          when: always
-
   publish_npm:
     docker:
       - image: node:8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,5 +6,52 @@ name: ci
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [8, 10, 12, 14, 16]
+        include:
+          # use npm 7 by default
+          - npm-version: ^7
+          - node: 8
+            # overrides for node 8
+            npm-version: ^6
+            lerna-extra-args: --ignore @opencensus/exporter-stackdriver
+    env:
+      OPENCENSUS_MONGODB_TESTS: 1
+      OPENCENSUS_REDIS_TESTS: 1
+    services:
+      mongo_service:
+        image: mongo
+        ports: ["27017:27017"]
+      redis_service:
+        image: redis
+        ports: ["6379:6379"]
+
     steps:
-      - run: echo "hello world"
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: v1-node-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            v1-node-${{ matrix.node }}-
+            v1-node-
+      - name: Upgrade to latest npm
+        run: npm install -g npm@${{ matrix.npm-version }}
+      - name: Print node/npm version
+        run: node --version && npm --version
+
+      # compile runs in prepare
+      - name: Install modules and dependencies, compile
+        run: npm install
+
+      # lint runs in posttest
+      - name: Run unit tests and lint
+        run: npm run test -- ${{ matrix.lerna-extra-args }}
+      - name: Submit coverage data to codecov.
+        run: npm run codecov -- ${{ matrix.lerna-extra-args }}
+        if: ${{ success() && matrix.node == '12' }}


### PR DESCRIPTION
Part 2 after #906 
Fixes #891

- Drops CI for Node 11 (which was not a LTS release) adds 14 and 16 which are active. Keeping Node 10 CI for now.
- Should otherwise be the same as existing CircleCI jobs
- Not migrating the CircleCI `publish_npm` job yet. This just migrates CI jobs.