### PR TITLE
chore: add initial noop github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,10 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+name: ci
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "hello world"


### PR DESCRIPTION
This is in preparation for #905, migrating to Github actions. GCP has limited CircleCI quota and automated PRs are consuming a ton of this quota. This will also speed up jobs, based on testing I've done so far.