### PR TITLE
chore: update renovate config to be less noisy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,11 @@
 {
-  "extends": [
-    "config:base",
-    "docker:disable"
-  ],
-  "pinVersions": false,
-  "rebaseStalePrs": true,
-  "schedule": [
-    "after 9am and before 3pm"
-  ],
-  "gitAuthor": null,
+  "extends": ["config:base", "docker:disable", ":pinOnlyDevDependencies"],
+  "schedule": ["after 9am and before 3pm"],
   "packageRules": [
     {
-      "extends": "packages:linters",
-      "groupName": "linters"
+      "groupName": "all non-major dependencies",
+      "updateTypes": ["patch", "minor"],
+      "groupSlug": "all-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
`renovate.json` had a bunch of old and no longer recognized config options. This upgrades it to be similar to this renovate config in Google's OTel repo https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/renovate.json