### PR TITLE
chore: update renovate config - take 2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,8 @@
 {
-  "extends": ["config:base", "docker:disable", ":pinOnlyDevDependencies"],
-  "schedule": ["after 9am and before 3pm"],
-  "packageRules": [
-    {
-      "groupName": "all non-major dependencies",
-      "updateTypes": ["patch", "minor"],
-      "groupSlug": "all-minor-patch"
-    }
-  ]
+  "extends": [
+    "config:js-lib",
+    "group:allNonMajor",
+    "docker:disable"
+  ],
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
Take two of #912. This time I tested it on my fork, which appears to be correctly grouping dependencies: https://github.com/aabmass/opencensus-node/pull/5

- Removed the schedule, because its not too important
- Added `dependencyDashboard` which will create an issue with overview of all dependency PRs