### PR TITLE
chore: skip private modules in node8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,10 @@ jobs:
           - node: 8
             # overrides for node 8
             npm-version: ^6
-            lerna-extra-args: --ignore @opencensus/exporter-stackdriver --ignore @opencensus/resource-util
+            lerna-extra-args: >-
+              --ignore @opencensus/exporter-stackdriver
+              --ignore @opencensus/resource-util
+              --no-private
     env:
       OPENCENSUS_MONGODB_TESTS: 1
       OPENCENSUS_REDIS_TESTS: 1


### PR DESCRIPTION
Skipping modules marked private in package.json. These are mostly examples which rely on stackdriver exporter, which doesn't support node8 anymore.