### PR TITLE
Add await to createTimeSeries so that onMetricUploadError can take ef…

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -129,7 +129,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
       }
     }
 
-    this.createTimeSeries(metricsList);
+    await this.createTimeSeries(metricsList);
   }
 
   /**


### PR DESCRIPTION
…fect

Currently the error thrown by createTimeSeries cannot be captured by onMetricUploadError, because the code is not run under the same context as the try catch block without "await". 

Please see the following code illustration, toggle between "delayWithError(ms);" and "await  delayWithError(ms);" to see the difference. Without await, the error is not caught and handled.

////////////////////////////////////////////////////
async function delay(ms: number): Promise<void> {
  return new Promise<void>(resolve => {
    setTimeout(resolve, ms);
  });
}

async function delayWithError(ms: number) {
   await delay(ms);
   throw("some error");
}

async function test(ms: number) {
    console.log(`start first delay, waiting for ${ms}ms...`);
    await delay(ms);
    console.log("Done first delay");
    console.log(`start second delay with error, waiting for ${ms}ms...`);
    // await delayWithError(ms);
    delayWithError(ms);
}

async function main() {
  const ms = 1000;
  try{
      await test(ms);
  }catch(err){
      console.log("caugh error:" + err);
  }
}

main();
/////////////////////////////////////////////////////