### PR TITLE
Allow specifying apiEndpoint for stackdriver exporters

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-cloudtrace.ts
@@ -48,7 +48,7 @@ export class StackdriverTraceExporter implements Exporter {
   logger: Logger;
   failBuffer: SpanContext[] = [];
   private RESOURCE_LABELS: Promise<Record<string, AttributeValue>>;
-  private _cloudTrace: cloudtrace_v2.Cloudtrace;
+  private cloudTrace: cloudtrace_v2.Cloudtrace;
 
   constructor(options: StackdriverExporterOptions) {
     this.projectId = options.projectId;
@@ -63,7 +63,7 @@ export class StackdriverTraceExporter implements Exporter {
         scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       });
     }
-    this._cloudTrace = google.cloudtrace({
+    this.cloudTrace = google.cloudtrace({
       version: 'v2',
       rootUrl:
         'https://' + (options.apiEndpoint || 'cloudtrace.googleapis.com'),
@@ -170,20 +170,17 @@ export class StackdriverTraceExporter implements Exporter {
       // data to backend :
       // https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.
       // cloudtrace.v2#google.devtools.cloudtrace.v2.TraceService
-      this._cloudTrace.projects.traces.batchWrite(
-        spans,
-        (err: Error | null) => {
-          if (err) {
-            err.message = `batchWriteSpans error: ${err.message}`;
-            this.logger.error(err.message);
-            reject(err);
-          } else {
-            const successMsg = 'batchWriteSpans successfully';
-            this.logger.debug(successMsg);
-            resolve(successMsg);
-          }
+      this.cloudTrace.projects.traces.batchWrite(spans, (err: Error | null) => {
+        if (err) {
+          err.message = `batchWriteSpans error: ${err.message}`;
+          this.logger.error(err.message);
+          reject(err);
+        } else {
+          const successMsg = 'batchWriteSpans successfully';
+          this.logger.debug(successMsg);
+          resolve(successMsg);
         }
-      );
+      });
     });
   }
 

--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -70,7 +70,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
   > = new Map();
   private DEFAULT_RESOURCE: Promise<MonitoredResource>;
   logger: Logger;
-  private _monitoring: monitoring_v3.Monitoring;
+  private monitoring: monitoring_v3.Monitoring;
 
   constructor(options: StackdriverExporterOptions) {
     this.period =
@@ -93,7 +93,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
         scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       });
     }
-    this._monitoring = google.monitoring({
+    this.monitoring = google.monitoring({
       version: 'v3',
       rootUrl:
         'https://' + (options.apiEndpoint || 'monitoring.googleapis.com'),
@@ -200,7 +200,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
       };
 
       return new Promise((resolve, reject) => {
-        this._monitoring.projects.timeSeries.create(
+        this.monitoring.projects.timeSeries.create(
           request,
           { headers: OC_HEADER, userAgentDirectives: [OC_USER_AGENT] },
           (err: Error | null) => {
@@ -229,7 +229,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
       };
 
       return new Promise((resolve, reject) => {
-        this._monitoring.projects.metricDescriptors.create(
+        this.monitoring.projects.metricDescriptors.create(
           request,
           { headers: OC_HEADER, userAgentDirectives: [OC_USER_AGENT] },
           (err: Error | null) => {

--- a/packages/opencensus-exporter-stackdriver/src/types.ts
+++ b/packages/opencensus-exporter-stackdriver/src/types.ts
@@ -156,6 +156,11 @@ export interface StackdriverExporterOptions extends ExporterConfig {
    * instead of your application default credentials. Optional
    */
   credentials?: JWTInput;
+  /**
+   * The endpoint of the service. Defaults to cloudtrace.googleapis.com
+   * for trace, and monitoring.googleapis.com for monitoring.
+   */
+  apiEndpoint?: string;
 
   /**
    * Is called whenever the exporter fails to upload metrics to stackdriver.


### PR DESCRIPTION
This is useful if you want to use non-standard endpoints (e.g. staging or upcoming regional APIs).