### PR TITLE
catch errors from createTimeSeries

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -108,9 +108,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
       try {
         await this.export();
       } catch (err) {
-        if (typeof this.onMetricUploadError === 'function') {
-          this.onMetricUploadError(err);
-        }
+        this.reportMetricUploadError(err);
       }
     }, this.period);
   }
@@ -134,7 +132,15 @@ export class StackdriverStatsExporter implements StatsEventListener {
       }
     }
 
-    this.createTimeSeries(metricsList);
+    this.createTimeSeries(metricsList).catch(err => {
+      this.reportMetricUploadError(err);
+    });
+  }
+
+  private reportMetricUploadError(err) {
+    if (typeof this.onMetricUploadError === 'function') {
+      this.onMetricUploadError(err);
+    }
   }
 
   /**

--- a/packages/opencensus-exporter-stackdriver/test/nocks.ts
+++ b/packages/opencensus-exporter-stackdriver/test/nocks.ts
@@ -127,17 +127,24 @@ export function batchWrite<T extends {} = {}>(
   return reply ? interceptor.reply(reply) : interceptor.reply(200);
 }
 
+export function timeSeriesNock<T extends {} = {}>(
+  project: string,
+  validator?: (body: T) => boolean
+) {
+  validator = validator || accept;
+  return nock('https://monitoring.googleapis.com').post(
+    '/v3/projects/' + project + '/timeSeries',
+    validator
+  );
+}
+
 export function timeSeries<T extends {} = {}>(
   project: string,
   validator?: (body: T) => boolean,
   reply?: () => string,
   withError?: boolean
 ) {
-  validator = validator || accept;
-  const interceptor = nock('https://monitoring.googleapis.com').post(
-    '/v3/projects/' + project + '/timeSeries',
-    validator
-  );
+  const interceptor = timeSeriesNock<T>(project, validator);
   return reply ? interceptor.reply(reply) : interceptor.reply(200);
 }
 


### PR DESCRIPTION
Avoid crashing NodeJS with an unhandledRejection
by catching errors from createTimeSeries.

`createTimeSeries` can fail with an unhandled promise rejection, which will by default cause the NodeJS process to exit.
By handling the error gracefully, the process can continue to run.

Added a corresponding test.

```
Error: 3 INVALID_ARGUMENT: One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured for the metric.: global{} timeSeries[0]: custom.googleapis.com/canary/weather/all{} at Object.callErrorFromStatus (/usr/src/app/node_modules/@grpc/grpc-js/build/src/call.js:31:19) at Object.onReceiveStatus (/usr/src/app/node_modules/@grpc/grpc-js/build/src/client.js:195:52) at Object.onReceiveStatus (/usr/src/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:365:141) at Object.onReceiveStatus (/usr/src/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:328:181) at /usr/src/app/node_modules/@grpc/grpc-js/build/src/call-stream.js:188:78 at process.processTicksAndRejections (node:internal/process/task_queues:77:11)
for call at
at ServiceClientImpl.makeUnaryRequest (/usr/src/app/node_modules/@grpc/grpc-js/build/src/client.js:163:34)
at ServiceClientImpl.<anonymous> (/usr/src/app/node_modules/@grpc/grpc-js/build/src/make-client.js:105:19)
at /usr/src/app/node_modules/@google-cloud/monitoring/build/src/v3/metric_service_client.js:218:29
at /usr/src/app/node_modules/google-gax/build/src/normalCalls/timeout.js:44:16
at OngoingCallPromise.call (/usr/src/app/node_modules/google-gax/build/src/call.js:67:27)
at NormalApiCaller.call (/usr/src/app/node_modules/google-gax/build/src/normalCalls/normalApiCaller.js:34:19)
at /usr/src/app/node_modules/google-gax/build/src/createApiCall.js:84:30
at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
code: 3,
details: 'One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured for the metric.: global{} timeSeries[0]: custom.googleapis.com/canary/weather/all{}',
metadata: Metadata {
internalRepr: Map(3) {
'grpc-server-stats-bin' => [Array],
'google.monitoring.v3.createtimeseriessummary-bin' => [Array],
'grpc-status-details-bin' => [Array]
},
options: {}
}
}
```