### PR TITLE
fix: prevent unhandled promise rejections

### DIFF
--- a/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
+++ b/packages/opencensus-exporter-stackdriver/src/stackdriver-monitoring.ts
@@ -134,7 +134,7 @@ export class StackdriverStatsExporter implements StatsEventListener {
       }
     }
 
-    this.createTimeSeries(metricsList);
+    return this.createTimeSeries(metricsList);
   }
 
   /**


### PR DESCRIPTION
Return the Promise from `createTimeSeries` in the `export` method. This allows any thrown exceptions to be to be caught correctly in `start`'s `setInterval` callback. This allows consumers of this library to handle errors via the `onMetricUploadError` without their process being taken down by an unhandled Promise rejection.

N.B. This change does _not_ solve the problem of metrics being delivered more frequently than Stackdriver can handle. The use of `setInterval` is inappropriate. I would recommend using `setTimeout` instead - waiting for the upload to be complete before scheduling the next attempt.